### PR TITLE
Implement Restock Beer flow with dynamic inventory

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface Bar {
   status: 'verified' | 'temporary';
   type?: 'bar' | 'restaurant';
   beerInventory?: Record<string, string[]>;
+  wells?: string[];
 }
 
 export interface Request {


### PR DESCRIPTION
Added 'RESTOCK BEER' button with dynamic navigation for Brands and Types. Implemented 'beerInventory' in Firestore with search/create dialogs for adding new brands and types. Added quantity picker with custom 'Other' option.
Refactored to use atomic Firestore updates for concurrency.