### PR TITLE
fix: Correct setTimeout return type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,8 +107,7 @@ function App() {
   const [quantityPicker, setQuantityPicker] = useState<{ open: boolean, currentQty: number, context: string }>({ open: false, currentQty: 1, context: '' });
 
   const [navStack, setNavStack] = useState<ButtonConfig[]>([]);
-  // FIX 1: Use proper return type for browser environment
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timerRef = useRef<number | null>(null);
   const isDraggingRef = useRef(false);
   const [showOffClockDialog, setShowOffClockDialog] = useState(false);
   const [showNotificationSettings, setShowNotificationSettings] = useState(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["vite/client", "vitest/globals", "node"],
+    "types": ["vite/client", "vitest/globals"],
     "esModuleInterop": true
   },
   "include": ["src"],


### PR DESCRIPTION
Removes "node" from the tsconfig.json types array to prevent NodeJS.Timeout from conflicting with the browser's number type for setTimeout.

Also, updates the type of the timerRef in App.tsx to be a number.

Note: I was unable to run the tests due to persistent network issues in the sandbox environment. I've tried both npm and yarn, and both failed to install the dependencies.

## Summary by Sourcery

Align timer reference typing with a browser-only environment by removing Node type definitions and updating the timer ref type.

Bug Fixes:
- Prevent setTimeout return type conflicts by removing Node typings from the TypeScript configuration.
- Ensure the timer reference in the main app component uses a browser-compatible numeric type.