### PR TITLE
Remove setup_libs step from build-mobile workflow

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Dependencies
-        run: chmod +x setup_libs.sh && ./setup_libs.sh
-
       - name: Inject Google Services
         env:
           GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}


### PR DESCRIPTION
Removed the 'Setup Dependencies' step from `.github/workflows/build-mobile.yml` as the referenced `setup_libs.sh` script is missing from the codebase. This ensures the workflow does not attempt to execute a non-existent script.

---
*PR created automatically by Jules for task [13682884647054869827](https://jules.google.com/task/13682884647054869827) started by @HereLiesAz*

## Summary by Sourcery

Build:
- Update the mobile build GitHub Actions workflow by removing the step that runs the non-existent setup_libs.sh script.