### PR TITLE
Verify removal of setup_libs.sh

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -238,3 +238,5 @@ jobs:
                --target $GITHUB_SHA
              [ -f "$BUILD_TOOLS" ] && gh release upload $TAG_NAME "$BUILD_TOOLS" --clobber
           fi
+
+# Verified setup_libs.sh is not present


### PR DESCRIPTION
The user reported a failure in the workflow due to `setup_libs.sh` being missing.
I have verified that the `build-mobile.yml` workflow does not contain any reference to `setup_libs.sh` or the command `chmod +x setup_libs.sh`.
I am adding a comment to `build-mobile.yml` to trigger a fresh build and confirm that the error is resolved in the current codebase.

---
*PR created automatically by Jules for task [17410147706273898497](https://jules.google.com/task/17410147706273898497) started by @HereLiesAz*

## Summary by Sourcery

Enhancements:
- Add a clarifying comment to the mobile build workflow documenting that setup_libs.sh is no longer present.