### PR TITLE
Fix Android build by adding Capacitor sync step

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -78,6 +78,20 @@ jobs:
             echo "Warning: KEYSTORE_PRIVATE secret is missing. Skipping custom keystore generation."
           fi
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Web App
+        run: npm run build
+
+      - name: Sync Capacitor
+        run: npx cap sync android
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The Android build was failing in CI because `cordova.variables.gradle` was missing. This file is generated by `npx cap sync`. Updated `.github/workflows/build-mobile.yml` to include steps for setting up Node.js, installing dependencies, building the web app, and running `npx cap sync android` before the Gradle build step.

---
*PR created automatically by Jules for task [11845350956128746941](https://jules.google.com/task/11845350956128746941) started by @HereLiesAz*

## Summary by Sourcery

CI:
- Add Node.js setup, dependency installation, web build, and Capacitor Android sync steps to the Android CI workflow to ensure required artifacts are generated before building.