### PR TITLE
fix: Update CI to use JDK 21 for Android build

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -93,10 +93,10 @@ jobs:
       - name: Sync Capacitor
         run: npx cap sync android
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle


### PR DESCRIPTION
Updated `.github/workflows/build-mobile.yml` to use JDK 21 instead of 17. This fixes the CI build failure `invalid source release: 21`.

---
*PR created automatically by Jules for task [9017124881333067769](https://jules.google.com/task/9017124881333067769) started by @HereLiesAz*

## Summary by Sourcery

CI:
- Switch the Android build job in the GitHub Actions workflow to use JDK 21 (Temurin) rather than JDK 17.