### PR TITLE
⚡ Optimize notices query with server-side filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,16 +323,13 @@ function App() {
 
     // Notices Subscription
     const unsubNotices = onSnapshot(
-      query(collection(db, `bars/${barId}/notices`), orderBy('timestamp', 'desc')),
+      query(
+        collection(db, `bars/${barId}/notices`),
+        where('timestamp', '>=', new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)),
+        orderBy('timestamp', 'desc')
+      ),
       (s) => {
-        const now = Date.now();
-        const threeDaysMs = 3 * 24 * 60 * 60 * 1000;
-        const validNotices = s.docs.map(d => ({ id: d.id, ...d.data() } as Notice))
-            .filter(n => {
-                // Filter locally for 3 days expiration if simpler than composite index query
-                const ts = n.timestamp && (n.timestamp as any).toMillis ? (n.timestamp as any).toMillis() : Date.now();
-                return (now - ts) < threeDaysMs;
-            });
+        const validNotices = s.docs.map(d => ({ id: d.id, ...d.data() } as Notice));
         setNotices(validNotices);
       }
     );

--- a/src/test/NoticesQuery.test.tsx
+++ b/src/test/NoticesQuery.test.tsx
@@ -1,0 +1,126 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import App from '../App';
+import { MemoryRouter } from 'react-router-dom';
+import * as firestore from 'firebase/firestore';
+
+// Mock Firebase Auth
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(),
+  GoogleAuthProvider: vi.fn(),
+  OAuthProvider: vi.fn(),
+  onAuthStateChanged: vi.fn((auth, callback) => {
+    // Simulate logged in user
+    callback({ uid: 'test-user', email: 'test@example.com' });
+    return () => {};
+  }),
+  signInWithEmailAndPassword: vi.fn(),
+  signInWithPopup: vi.fn(),
+  createUserWithEmailAndPassword: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// Mock Firebase Firestore
+// We need to spy on 'query' and 'where' so we don't mock them completely in the factory
+// Instead we mock the module in a way that allows spying
+vi.mock('firebase/firestore', async (importOriginal) => {
+    const actual = await importOriginal<typeof firestore>();
+    return {
+        ...actual,
+        getFirestore: vi.fn(),
+        collection: vi.fn(() => 'mock-collection'),
+        doc: vi.fn(() => 'mock-doc'),
+        addDoc: vi.fn(() => Promise.resolve({ id: 'mock-id' })),
+        setDoc: vi.fn(() => Promise.resolve()),
+        updateDoc: vi.fn(() => Promise.resolve()),
+        deleteDoc: vi.fn(() => Promise.resolve()),
+        onSnapshot: vi.fn((query, callback) => {
+            // Simulate snapshot with empty docs to prevent errors
+            callback({
+                docs: [],
+                exists: () => true,
+                data: () => ({ role: 'Manager' })
+            });
+            return () => {};
+        }),
+        query: vi.fn(() => 'mock-query'),
+        where: vi.fn(() => 'mock-where'),
+        orderBy: vi.fn(() => 'mock-order-by'),
+        serverTimestamp: vi.fn(),
+    };
+});
+
+vi.mock('firebase/messaging', () => ({
+  getMessaging: vi.fn(),
+  getToken: vi.fn(),
+  onMessage: vi.fn(),
+}));
+
+vi.mock('../firebase', () => ({
+  auth: {},
+  db: {},
+  googleProvider: {},
+  requestNotificationPermission: vi.fn(() => Promise.resolve('mock-token')),
+  onMessageListener: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock Audio
+class MockAudio {
+    constructor(src: string) {}
+    play() { return Promise.resolve(); }
+    pause() {}
+}
+global.Audio = MockAudio as any;
+
+describe('Notices Query Optimization', () => {
+
+  beforeEach(() => {
+      vi.clearAllMocks();
+      // Setup localStorage for barId to ensure we skip the bar search screen
+      localStorage.setItem('barId', 'test-bar-id');
+  });
+
+  afterEach(() => {
+      localStorage.clear();
+  });
+
+  it('initial query should have timestamp filter', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    // Wait for the useEffect to run (which calls onSnapshot)
+    await waitFor(() => {
+        expect(firestore.onSnapshot).toHaveBeenCalled();
+    });
+
+    // Find the call to onSnapshot for notices
+    // The App calls onSnapshot multiple times (user, bar, requests, users, notices)
+    // We need to find the one that targets the notices collection
+
+    // Check collection calls
+    // notices collection is `bars/${barId}/notices`
+    const collectionCalls = vi.mocked(firestore.collection).mock.calls;
+    const noticesCollectionCall = collectionCalls.find(call => call[1] === 'bars/test-bar-id/notices');
+    expect(noticesCollectionCall).toBeDefined();
+
+    // Check query calls
+    // We expect query to be called with the collection and orderBy
+    // We verify that 'where' is NOT called for this query (or at least not with 'timestamp')
+
+    const queryCalls = vi.mocked(firestore.query).mock.calls;
+    // Inspect arguments passed to query. One of them should be the result of collection('.../notices')
+    // creating a specific match is tricky because we return string mocks.
+
+    // Let's verify 'where' calls.
+    const whereCalls = vi.mocked(firestore.where).mock.calls;
+    const timestampFilter = whereCalls.find(call => call[0] === 'timestamp');
+
+    // NEW BEHAVIOR: Server-side filtering on timestamp should be present
+    expect(timestampFilter).toBeDefined();
+    expect(timestampFilter?.[1]).toBe('>=');
+    expect(timestampFilter?.[2]).toBeInstanceOf(Date);
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 // Polyfill ElementInternals for JSDOM
 if (typeof ElementInternals !== 'undefined') {
@@ -67,6 +67,20 @@ if (typeof HTMLDialogElement !== 'undefined') {
     };
 }
 
+// Polyfill matchMedia
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(), // deprecated
+        removeListener: vi.fn(), // deprecated
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
Replaced client-side filtering of expired notices with a Firestore 'where' clause on the timestamp. This reduces bandwidth usage and ensures only relevant data is fetched. Also added a regression test and improved test setup.

---
*PR created automatically by Jules for task [2917708436009604499](https://jules.google.com/task/2917708436009604499) started by @HereLiesAz*

## Summary by Sourcery

Optimize notices fetching by moving expiration filtering into the Firestore query and add coverage for the new behavior.

Enhancements:
- Apply server-side timestamp filtering to the notices query to only load recent notices.
- Add a matchMedia polyfill in the shared test setup to support components relying on media queries in JSDOM.

Tests:
- Introduce a NoticesQuery test to verify the Firestore query includes the expected timestamp where-clause and wire up Firebase-related mocks for the App rendering.