### PR TITLE
Merge PR #154: Enable Firestore Persistence

### DIFF
--- a/.github/workflows/jules-branch-handler.yml
+++ b/.github/workflows/jules-branch-handler.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: google-labs-code/jules-invoke@v1
+      - uses: google-labs-code/jules-action@v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/jules-issue-handler.yml
+++ b/.github/workflows/jules-issue-handler.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: google-labs-code/jules-invoke@v1
+      - uses: google-labs-code/jules-action@v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.24'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,5 +13,5 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
-    kotlinVersion = '1.9.24'
+    kotlinVersion = '2.1.0'
 }

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,7 +1,11 @@
 // Import the 'initializeApp' function from the Firebase SDK to initialize the Firebase app instance.
 import { initializeApp } from "firebase/app";
-// Import 'getFirestore' to access the Cloud Firestore database service.
-import { getFirestore } from "firebase/firestore";
+// Import Firestore functions including persistence configuration.
+import {
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager
+} from "firebase/firestore";
 // Import authentication-related functions from the Firebase Auth SDK.
 // 'getAuth' retrieves the authentication service.
 // 'GoogleAuthProvider' is used for Google Sign-In.
@@ -37,8 +41,12 @@ const firebaseConfig = {
 // Initialize the Firebase application with the configuration.
 const app = initializeApp(firebaseConfig);
 
-// Initialize and export the Cloud Firestore service instance.
-export const db = getFirestore(app);
+// Initialize and export the Cloud Firestore service instance with offline persistence enabled.
+export const db = initializeFirestore(app, {
+  localCache: persistentLocalCache({
+    tabManager: persistentMultipleTabManager()
+  })
+});
 
 // Initialize and export the Firebase Authentication service instance.
 export const auth = getAuth(app);

--- a/src/test/FirebasePersistence.test.ts
+++ b/src/test/FirebasePersistence.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Spies
+const initializeFirestoreSpy = vi.fn(() => ({ type: 'firestore-instance' }));
+const persistentLocalCacheSpy = vi.fn(() => ({ type: 'cache-config' }));
+const persistentMultipleTabManagerSpy = vi.fn(() => ({ type: 'tab-manager' }));
+const getFirestoreSpy = vi.fn(() => ({ type: 'firestore-default' }));
+
+// Mock firebase/firestore
+vi.mock('firebase/firestore', () => ({
+  getFirestore: getFirestoreSpy,
+  initializeFirestore: initializeFirestoreSpy,
+  persistentLocalCache: persistentLocalCacheSpy,
+  persistentMultipleTabManager: persistentMultipleTabManagerSpy,
+  // Mock other potential exports if needed, but for initialization this is key
+  collection: vi.fn(),
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+}));
+
+// Mock firebase/app
+vi.mock('firebase/app', () => ({
+  initializeApp: vi.fn(),
+}));
+
+// Mock firebase/auth
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({})),
+  GoogleAuthProvider: class {
+    setCustomParameters = vi.fn()
+  },
+  OAuthProvider: class {},
+}));
+
+// Mock firebase/messaging
+vi.mock('firebase/messaging', () => ({
+  getMessaging: vi.fn(() => ({})),
+  getToken: vi.fn(),
+  onMessage: vi.fn(),
+}));
+
+describe('Firebase Persistence', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should initialize Firestore with offline persistence', async () => {
+    // Import the module dynamically to trigger initialization
+    await import('../firebase');
+
+    // We expect initializeFirestore to be called, NOT getFirestore alone
+    // (or if getFirestore is called, initializeFirestore MUST be called to set persistence)
+
+    // Check if initializeFirestore was called
+    if (initializeFirestoreSpy.mock.calls.length === 0) {
+        // If not called, fail with descriptive message
+        // This is what we expect before the fix
+        throw new Error('initializeFirestore was not called. Persistence is likely not enabled.');
+    }
+
+    expect(initializeFirestoreSpy).toHaveBeenCalled();
+
+    // Verify arguments for persistence
+    const args = initializeFirestoreSpy.mock.calls[0];
+    const settings = args[1];
+
+    expect(settings).toBeDefined();
+    expect(settings.localCache).toBeDefined();
+
+    // Verify persistentLocalCache was called
+    expect(persistentLocalCacheSpy).toHaveBeenCalled();
+
+    // Verify persistentMultipleTabManager was called (optional but good for multi-tab support)
+    expect(persistentMultipleTabManagerSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Merging PR #154 changes: Enabled Firestore offline persistence, upgraded Android Kotlin version to 2.1.0, and fixed CI workflow references.

- src/firebase.ts: Enabled offline persistence.
- src/test/FirebasePersistence.test.ts: Added verification test.
- android/build.gradle, android/variables.gradle: Upgraded Kotlin to 2.1.0.
- .github/workflows/*.yml: Fixed action references.

---
*PR created automatically by Jules for task [10935560559578555905](https://jules.google.com/task/10935560559578555905) started by @HereLiesAz*