### PR TITLE
Use explicit window timers and number type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,6 @@ import '@material/web/menu/menu-item.js';
 // Import Types and Constants.
 import { Bar, ButtonConfig, Request, Notice, BarUser } from './types';
 import { DEFAULT_BUTTONS, ROLE_NOTIFICATION_DEFAULTS, DEFAULT_BEERS, NTFY_DISPATCH_CONCURRENCY } from './constants';
-import { pMap } from './utils/async';
 // Import Custom Hooks.
 import { useNag } from './hooks/useNag';
 // Import UI Components.
@@ -186,7 +185,6 @@ function App() {
   // Stack to navigate through nested button menus.
   const [navStack, setNavStack] = useState<ButtonConfig[]>([]);
 
-  // FIX 1: Use proper return type for browser environment
   // Ref for the inactivity timer. The type is `number | null` to be compatible with the return value of `window.setTimeout` in browsers.
   const timerRef = useRef<number | null>(null);
   // Ref to track dragging state to prevent accidental clicks.
@@ -830,13 +828,13 @@ function App() {
 
   // Periodic flush of usage stats.
   useEffect(() => {
-    const interval = setInterval(flushUsage, 10000); // 10 seconds
+    const interval = window.setInterval(flushUsage, 10000); // 10 seconds
     // Also flush on page unload (refresh/close).
     const onUnload = () => flushUsage();
     window.addEventListener('beforeunload', onUnload);
 
     return () => {
-        clearInterval(interval);
+        window.clearInterval(interval);
         window.removeEventListener('beforeunload', onUnload);
         flushUsage(); // Flush on unmount
     };
@@ -1058,7 +1056,8 @@ function App() {
                     'Priority': 'high',
                     'Tags': 'bell,bar_chart'
                 }
-            }).catch(err => console.error('Failed to send ntfy', err)),
+            }).catch(err => console.error('Failed to send ntfy', err));
+        },
         NTFY_DISPATCH_CONCURRENCY
     );
   };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,5 +107,3 @@ export const ROLE_NOTIFICATION_DEFAULTS: Record<string, string[]> = {
   'Security': ['security', 'manager', 'break']
 };
 
-// Define the concurrency limit for ntfy.sh notification dispatch.
-export const NTFY_DISPATCH_CONCURRENCY = 5;


### PR DESCRIPTION
Explicitly used window.setTimeout, window.setInterval, and window.clearInterval in App.tsx to ensure the return type is 'number', matching the useRef<number | null> definition. This avoids type mismatches with Node.js environment types. Also cleaned up duplicate imports and syntax errors discovered during verification.

---
*PR created automatically by Jules for task [1632458027348950659](https://jules.google.com/task/1632458027348950659) started by @HereLiesAz*