### PR TITLE
Fix merged-but-broken main: stitch #244/#245/#246 together correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,18 +94,6 @@ import {
   arrayMove
 } from '@dnd-kit/sortable';
 
-// Generate a 128-bit hex suffix for ntfy topic IDs. ntfy.sh is an
-// unauthenticated pub-sub: anyone who knows the topic can subscribe to
-// it. Topics used to be `barbacker-${uid}`, which meant a leaked UID
-// (visible in every Request and Notice document a user authors) let
-// anyone subscribe to that user's push stream. Random suffixes break
-// that link without changing how the topic is used downstream.
-function generateRandomTopicSuffix(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
-}
-
 // Helper component for listing joined bars.
 const BarListItem = ({ name, onClick }: { name: string, onClick: () => void }) => {
     return (
@@ -152,11 +140,7 @@ function App() {
   // Store the ntfy topic ID for iOS notifications (per-bar snapshot
   // of the global topic, kept in sync via the bar listener).
   const [ntfyTopic, setNtfyTopic] = useState<string | null>(null);
-  // Store the account-level ntfy topic. Source of truth for the
-  // subscribe link on the bar-select screen and what gets written into
-  // each per-bar user profile.
-  const [globalNtfyTopic, setGlobalNtfyTopic] = useState<string | null>(null);
-  
+
   // --- Data State ---
   // Store the list of active requests.
   const [requests, setRequests] = useState<Request[]>([]);
@@ -339,110 +323,12 @@ function App() {
     }
   });
 
-  // Admin / god-mode gate. Currently client-side only — see hook doc.
+  // Admin / god-mode gate.
   const isGodMode = useGodMode(user);
-    // Subscribe to foreground messages with a callback we can detach on
-    // unmount. The previous one-shot Promise API only fired for the
-    // first message of the session.
-    const unsubscribeMessages = onForegroundMessage((payload: any) => {
-      if (navigator.vibrate) navigator.vibrate([500, 200, 500]);
 
-      // The Notification constructor throws under denied permission and
-      // is undefined in some embedded webviews / JSDOM, so guard both.
-      if (
-        payload?.notification
-        && typeof Notification !== 'undefined'
-        && Notification.permission === 'granted'
-      ) {
-        try {
-          new Notification(payload.notification.title, {
-            body: payload.notification.body,
-            icon: '/icon-192x192.png',
-          });
-        } catch (e) {
-          console.warn('Notification display failed', e);
-        }
-      }
-
-      if (!audioRef.current) audioRef.current = new Audio('/alert.wav');
-      const audio = audioRef.current;
-      let plays = 0;
-      audio.onended = () => {
-        plays++;
-        if (plays < 8) {
-          audio.currentTime = 0;
-          audio.play().catch(() => {});
-        }
-      };
-      audio.play().catch(() => {});
-    });
-
-    return () => unsubscribeMessages();
-  }, []);
-
-  // --- 1.5. User Data & Joined Bars ---
-  useEffect(() => {
-    if (!user) return;
-    const userRef = doc(db, 'users', user.uid);
-    const unsub = onSnapshot(userRef, (d) => {
-        const data = d.exists() ? d.data() : {};
-        setMyBars(data.joinedBars || []);
-
-        // Global ntfy topic. Generated once per account with a high
-        // entropy random suffix so the topic is not derivable from a
-        // leaked UID — ntfy.sh is unauthenticated, so anyone who knows
-        // the topic can subscribe. Pre-existing users keep whatever
-        // topic they already have stored.
-        if (data.ntfyTopic) {
-            setGlobalNtfyTopic(data.ntfyTopic);
-        } else if (user) {
-            const newTopic = `barbacker-${generateRandomTopicSuffix()}`;
-            setGlobalNtfyTopic(newTopic);
-            setDoc(userRef, { ntfyTopic: newTopic }, { merge: true })
-              .catch(e => console.warn('Failed to persist ntfy topic', e));
-        }
-    });
-    return () => unsub();
-  }, [user]);
-
-  // --- 1.6. Fetch Bar Names Efficiently ---
-  useEffect(() => {
-    const fetchBarNames = async () => {
-        if (myBars.length === 0) {
-            setBarDetails({});
-            return;
-        }
-
-        // Use chunks to respect Firestore 'in' query limit of 30.
-        const chunks = [];
-        for (let i = 0; i < myBars.length; i += 30) {
-            chunks.push(myBars.slice(i, i + 30));
-        }
-
-        const newDetails: Record<string, string> = {};
-
-        await Promise.all(chunks.map(async (chunk) => {
-            try {
-                const q = query(collection(db, 'bars'), where(documentId(), 'in', chunk));
-                const snapshot = await getDocs(q);
-                snapshot.forEach(d => {
-                    newDetails[d.id] = (d.data() as Bar).name;
-                });
-            } catch (e) {
-                console.error("Error fetching bar names", e);
-            }
-        }));
-
-        // Batch update state once, ensuring all bars have a display name.
-        const finalDetails: Record<string, string> = {};
-        myBars.forEach(bid => {
-            finalDetails[bid] = newDetails[bid] || 'Unknown Bar';
-        });
-        setBarDetails(finalDetails);
-    };
-
-  // Joined bars + their display names — driven by users/{uid}.joinedBars.
-  const { myBars, barDetails } = useMyBars(user);
+  // Joined bars + their display names + the account-level ntfy topic
+  // — all driven by the global users/{uid} document.
+  const { myBars, barDetails, globalNtfyTopic } = useMyBars(user);
 
   // --- 2. Bar Logic (Listeners) ---
   useEffect(() => {
@@ -572,50 +458,6 @@ function App() {
 
   // Auto-submit an "(Ask Me)" request if a sub-menu sits open for 60s.
   useInactivityAutoSubmit(navStack, (label) => submitRequest(label), () => setNavStack([]));
-  // --- Admin / god-mode gate ---
-  // Reads the `admin` custom claim off the user's ID token. Claims are
-  // signed by Firebase so they cannot be spoofed from the client, and
-  // Firestore rules can check the same claim via request.auth.token.admin.
-  // Set the claim with `node scripts/set-admin-claim.js --email ...`.
-  useEffect(() => {
-    let cancelled = false;
-    if (!user) {
-      setIsGodMode(false);
-      return;
-    }
-    user.getIdTokenResult()
-      .then(result => {
-        if (cancelled) return;
-        setIsGodMode(result.claims.admin === true);
-      })
-      .catch(err => {
-        console.warn('Failed to read admin claim', err);
-        if (!cancelled) setIsGodMode(false);
-      });
-    return () => { cancelled = true; };
-  }, [user]);
-
-  // --- Timer ---
-  // Inactivity timer to close menus after 60 seconds.
-  useEffect(() => {
-    // Clear existing timer.
-    if (timerRef.current) window.clearTimeout(timerRef.current);
-
-    // If a menu is open (navStack > 0)...
-    if (navStack.length > 0) {
-      // Set a timeout.
-      timerRef.current = window.setTimeout(() => {
-        // Construct label from the path (e.g. "SERVICE ITEMS: PINT").
-        const trail = navStack.map(b => b.label).join(': ');
-        // Auto-submit as an "Ask Me" request.
-        submitRequest(`${trail} (Ask Me)`);
-        // Reset stack.
-        setNavStack([]);
-      }, 60000);
-    }
-    // Cleanup.
-    return () => { if (timerRef.current) window.clearTimeout(timerRef.current); };
-  }, [navStack]);
 
   // --- Actions ---
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import {
   onAuthStateChanged,
   signInWithPopup,

--- a/src/hooks/useGodMode.ts
+++ b/src/hooks/useGodMode.ts
@@ -1,24 +1,31 @@
 import { useEffect, useState } from 'react';
 import type { User } from 'firebase/auth';
-import { adminManager } from '../services/subscription';
 
 // Resolves whether the current user has elevated ("god mode")
-// privileges. NOTE: this currently routes through `adminManager`,
-// which checks `user.email` against VITE_GOD_MODE_EMAIL — a
-// client-side gate that ships the admin address in the bundle. The
-// rules in firestore.rules do NOT enforce this, so anything gated by
-// the returned value should be treated as UI affordance only. A
-// follow-up should replace this with a Firebase Auth custom claim
-// read via getIdTokenResult().
+// privileges by reading the `admin` custom claim off their ID token.
+// Claims are signed by Firebase so they cannot be spoofed from the
+// client, and the same claim is checked in firestore.rules
+// (request.auth.token.admin). Set the claim with
+// `node scripts/set-admin-claim.js --email ...`.
 export function useGodMode(user: User | null) {
   const [isGodMode, setIsGodMode] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     if (!user) {
       setIsGodMode(false);
       return;
     }
-    setIsGodMode(adminManager.checkSubscription(user.email));
+    user.getIdTokenResult()
+      .then(result => {
+        if (cancelled) return;
+        setIsGodMode(result.claims.admin === true);
+      })
+      .catch(err => {
+        console.warn('Failed to read admin claim', err);
+        if (!cancelled) setIsGodMode(false);
+      });
+    return () => { cancelled = true; };
   }, [user]);
 
   return isGodMode;

--- a/src/hooks/useMyBars.ts
+++ b/src/hooks/useMyBars.ts
@@ -7,30 +7,49 @@ import {
   getDocs,
   onSnapshot,
   query,
+  setDoc,
   where,
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { Bar } from '../types';
 
-// Resolves the current user's list of joined bars (subscribed via the
-// global users/{uid}.joinedBars array) and their display names.
-// Returns:
-//   - myBars: the live array of bar IDs the user has joined
-//   - barDetails: a map of barId -> bar name, lazily populated via
-//     chunked `in` queries (30-id limit per query)
-// "Unknown Bar" is used as a fallback for any bar id that fails to
-// resolve, so the UI always shows something for every entry in myBars.
+// Generate a 128-bit hex suffix for ntfy topic IDs. ntfy.sh is an
+// unauthenticated pub-sub — anyone who knows the topic can subscribe,
+// so we use a high-entropy random value instead of deriving from the
+// Firebase UID (which leaks into every Request/Notice document).
+function generateRandomTopicSuffix(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Subscribes to the global users/{uid} document and exposes:
+//   - myBars: live array of bar IDs the user has joined
+//   - barDetails: map of barId -> bar name, lazily populated via
+//     chunked `in` queries (Firestore's 30-id limit). Fallback
+//     "Unknown Bar" so the UI always has something to render.
+//   - globalNtfyTopic: account-level ntfy topic. Generated once per
+//     account and persisted back to users/{uid}.ntfyTopic if missing;
+//     pre-existing accounts keep whatever topic they have stored.
 export function useMyBars(user: User | null) {
   const [myBars, setMyBars] = useState<string[]>([]);
   const [barDetails, setBarDetails] = useState<Record<string, string>>({});
+  const [globalNtfyTopic, setGlobalNtfyTopic] = useState<string | null>(null);
 
   useEffect(() => {
     if (!user) return;
-    const unsub = onSnapshot(doc(db, 'users', user.uid), (d) => {
-      if (d.exists() && d.data().joinedBars) {
-        setMyBars(d.data().joinedBars);
+    const userRef = doc(db, 'users', user.uid);
+    const unsub = onSnapshot(userRef, (d) => {
+      const data = d.exists() ? d.data() : {};
+      setMyBars(data.joinedBars || []);
+
+      if (data.ntfyTopic) {
+        setGlobalNtfyTopic(data.ntfyTopic);
       } else {
-        setMyBars([]);
+        const newTopic = `barbacker-${generateRandomTopicSuffix()}`;
+        setGlobalNtfyTopic(newTopic);
+        setDoc(userRef, { ntfyTopic: newTopic }, { merge: true })
+          .catch(e => console.warn('Failed to persist ntfy topic', e));
       }
     });
     return () => unsub();
@@ -71,5 +90,5 @@ export function useMyBars(user: User | null) {
     fetchBarNames();
   }, [myBars]);
 
-  return { myBars, barDetails };
+  return { myBars, barDetails, globalNtfyTopic };
 }


### PR DESCRIPTION
## Summary

`main` is currently red — the merge of #246 was performed despite a failing `build-and-release` check, and it left three classes of merge artifact:

1. **`src/hooks/useGodMode.ts`** imports `adminManager` from `src/services/subscription.ts`, which #244 deleted. The bundle can't resolve it.
2. **`src/App.tsx`** kept *both* sides of three conflicts side-by-side:
   - The pre-extraction inline `1.5/1.6` users-doc + bar-names effects AND the `useMyBars()` hook call. The inline effect references `setMyBars` / `setBarDetails` / `setGlobalNtfyTopic` — none of which exist as local setters anymore.
   - An orphaned `onForegroundMessage(...)` block plus its cleanup `return`, sitting outside any `useEffect`, after the `usePushNotifications()` hook call.
   - An inline admin-claim `useEffect` AND an inline 60-s inactivity timer with `timerRef`, alongside the `useGodMode()` and `useInactivityAutoSubmit()` hook calls.
3. **`src/hooks/useAuth.ts`** has an unused `useCallback` import.

`tsc --noEmit` reports cascading syntax errors at `App.tsx:381` and `:1761` because of the dangling `}, [myBars]);` and orphaned blocks.

## Fix

- Rewrite `useGodMode.ts` to read `result.claims.admin` via `user.getIdTokenResult()` — matches the pre-#246 main behavior, drops the dead import.
- Delete the three duplicated inline blocks from `App.tsx`; let the hooks own the behavior.
- Fold the ntfy-topic generation (`generateRandomTopicSuffix` + the "keep existing topic if set" rule from #245) into `useMyBars`, which now returns `{ myBars, barDetails, globalNtfyTopic }`.
- Drop the unused `useCallback` import in `useAuth.ts`.

No behavior change from the intended post-#246 state — just stitching the three already-merged PRs together correctly.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --run` → 48/48 pass.
- [x] `npm run build` → vite build succeeds; PWA generated.
- [ ] Manual smoke once deployed: sign in, switch bars, verify the bar list renders, verify the iOS subscribe link uses a random topic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNSVEPNDEKGquk5vwFzr9Z)_

## Summary by Sourcery

Stitch together previously merged changes to restore a green main branch by delegating auth- and bar-related side effects to their hooks and fixing broken admin and notification wiring.

Bug Fixes:
- Fix useGodMode to read the Firebase admin custom claim directly from the user token instead of a removed subscription service.
- Remove duplicated and orphaned effect blocks in App.tsx to resolve TypeScript syntax errors and rely on the corresponding hooks for behavior.
- Wire App.tsx to consume global ntfy topics from useMyBars so the notification topic logic lives in one place and the bundle builds correctly.
- Drop an unused import from useAuth to clean up a merge artifact.

Enhancements:
- Extend useMyBars to manage and persist the account-level ntfy topic alongside joined bars and bar details, centralizing user notification state.