### PR TITLE
rules-tests CI: bump Node 20 → 22 to match the other workflows

### DIFF
--- a/.github/workflows/rules-tests.yml
+++ b/.github/workflows/rules-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
deploy.yml just moved 18 → 22 and build-mobile.yml is already on 22; align the rules-tests runner so all three workflows use the same Node major. Vite 7 (a devDep this workflow installs via npm ci) declares engines.node = ^20.19.0 || >=22.12.0 — Node 20 minor versions can drift below 20.19 on cached setup-node toolchains, producing the same engine warning we just hit on deploy. 22 sidesteps that entirely.

Local: npm run test:rules → 20/20 pass against the emulator.