### PR TITLE
Integrate #255 phase-1-hardening on top of audit-pass main

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "barbacker-6c683"
+  }
+}

--- a/docs/plans/2026-05-21-feature-set-purr-design.md
+++ b/docs/plans/2026-05-21-feature-set-purr-design.md
@@ -1,0 +1,274 @@
+# Feature Set Hardening + Build-Out — Design
+
+**Date:** 2026-05-21
+**Scope:** Staff-side feature set only. Customer-facing ordering PWA deferred to a separate brainstorm.
+
+## Background
+
+An audit found that of eleven advertised features, most are unimplemented stubs, broken, or have security holes:
+
+- Role/admin management exists as strings but has no UI for promote/demote/kick.
+- Signup restriction is a `console.log` stub.
+- The "Approvals" badge in the dashboard opens the wrong dialog; the pending-approval flow is unreachable because `confirmRole` hard-codes `status: 'active'`.
+- 86'd list is functionally correct on the client but Firestore rules let any authenticated user read private entries.
+- Notices are 3-day rolling, not persistent, with no role gate in rules.
+- POS integration is ten mock adapters, none wired into the app.
+- Calendar is `console.log("Calendar Synced")`.
+- Custom theming is the one feature that works.
+
+This design fixes the staff side in four sequential phases.
+
+## Phase 1 — Hardening: rules, roles, signup, 86'd, user management
+
+### Role model
+
+Three roles per bar. Stored on `bars/{barId}/users/{uid}.role`. Mirrored into Firebase Auth custom claims via Cloud Function on role change so Firestore rules can read role without a recursive document fetch.
+
+- **Staff** — post requests, post non-pinned chat, view public 86'd, set own prefs.
+- **Manager** — full operational admin. Approve/reject users, manage 86'd (public + private if premium), pin notices, configure POS, configure calendar, edit theme, manage subscription/billing. Can change roles of Staff and other Managers. Cannot touch Owners.
+- **Owner** — same powers as Manager, plus immunity from role changes by anyone but themselves. The Owner title is primarily a recognition badge; multiple Owners per bar are allowed and co-equal. An Owner can self-relinquish via "Step down as Owner."
+
+Bars with no Owner are a first-class supported state. Managers run them. Many bars will never have a claimed Owner.
+
+### Permission matrix
+
+| Actor → Target  | Staff | Manager | Owner |
+|-----------------|:-----:|:-------:|:-----:|
+| Manager         |   ✅  |    ✅   |   ❌  |
+| Owner           |   ✅  |    ✅   |   ❌  |
+
+### Signup gating
+
+New field `bars/{barId}.joinPolicy: 'open' | 'approval'` (default `'open'` to preserve current behavior). When `'approval'`, `confirmRole` writes `status: 'pending'` instead of `'active'`. The existing pending-approval screen at `App.tsx:1385` finally becomes reachable.
+
+### Invites
+
+`bars/{barId}/invites/{inviteId}` with `{email, role, createdBy, createdAt, consumed}`. On sign-in, the app checks for a matching un-consumed invite by email; if found, auto-creates an `active` user record at the invited role and marks the invite consumed. Cloud Function trigger sends email via existing mail provider; if none configured, surface a copy-able deep-link the inviter can share manually.
+
+### Ownership claim flow
+
+Hybrid waterfall, optional (bars don't need an Owner to function). All steps execute in a Cloud Function:
+
+1. **OSM phone/email code** — if the bar's OSM record has a contact, send a 6-digit code there; claimant enters it; auto-approved.
+2. **Domain-match auto-approval** — if OSM has a website and claimant's email domain matches, auto-approved.
+3. **Manager-approval fallback** — claim posts to a queue any existing Manager can approve from the Users dialog.
+4. **Dispute-window auto-approval** — if the bar has fewer than 3 active users or zero Managers, claim is posted to the bar's chat with a 7-day no-dispute window. Auto-approved if uncontested.
+5. **Manual review escalation** — only if all four above fail AND claimant explicitly escalates. UI explicitly steers them back to fixing OSM data first: "We can't auto-verify you. Update your bar's contact info on OpenStreetMap and try again, or submit a manual review request that may take weeks." Manual queue is intentionally low-traffic.
+
+Each claim runs independently; multiple successful claims produce multiple co-equal Owners.
+
+### User-management UI
+
+New `UsersDialog` component (mirrors `BarManager` shape). Three tabs: **Active**, **Pending**, **Invites**. Each row exposes role dropdown + actions appropriate to caller's role. The yellow "N Approvals" badge in the dashboard footer at `App.tsx:1820` rewires from `setShowBarManager` to `setShowUsersDialog`.
+
+### 86'd hardening
+
+Rules-side enforcement of visibility — current client-side filter is insufficient:
+
+- `read` — allowed if `resource.data.visibility == 'public'` OR caller's role custom claim is in `['Manager','Owner']`.
+- `create` — Manager+ only. `visibility: 'private'` additionally requires the bar's subscription claim to be `premium`.
+- `delete` — Manager+ only.
+
+### Firestore rules rewrite
+
+Replace the wide-open rules at `firestore.rules:18-48`:
+
+- `bars/{barId}` — read by any member; write only by Manager+ for operational fields; Owner-level for `joinPolicy` etc. Wait — no, in this model Manager has full operational powers including those fields. Owner gates only role-change-of-Manager. Restate: `bars/{barId}` writable by Manager+ for everything; the Owner gate lives on the `users` sub-collection role field.
+- `users/{uid}` sub-collection — self can write `lastSeen`, `notificationPreferences`, `displayName`, `status: 'off_clock'`. Cannot write `role`, cannot promote self to `status: 'active'`. Role/status changes only by Manager+ (with Owner-immunity rule for target role == Owner).
+- `notices` — to be removed in Phase 2 (replaced by chat).
+- `requests`, `tokens` — keep current behavior, scope writes to caller's UID where appropriate.
+
+### Bar deletion
+
+Out of scope until requested. If an Owner exists, only an Owner can delete; otherwise it's a support request.
+
+## Phase 2 — Real chat with pinned notices
+
+### Surface
+
+Full-screen sheet/dialog opened from a chat icon in the top toolbar. **Active-requests footer at `App.tsx:1814` is sacrosanct and remains untouched.** Unread badge on the icon when sheet is closed.
+
+### Pinned-message glance bar
+
+Pinned messages continue to render in the existing marquee bar at `App.tsx:1632`. The marquee just changes its source from the `notices` collection to `chat.where(pinned == true)`. That preserves the "persistent notice visible from the main dashboard" property without consuming any dashboard real estate.
+
+### Data model
+
+Single collection `bars/{barId}/chat/{messageId}` with:
+
+```
+{
+  text: string,
+  authorId: string,
+  authorName: string,        // snapshot at write
+  authorRole: string,        // snapshot at write
+  timestamp: serverTimestamp,
+  pinned: boolean,
+  pinnedBy?: string,
+  pinnedAt?: timestamp
+}
+```
+
+Pagination via `limit(50)` + cursor for scrollback.
+
+### Migration
+
+One-shot Cloud Function copies existing `bars/{barId}/notices` docs into `chat` with `pinned: true`, preserves snapshot `authorName`, then `notices` listener and collection are dropped.
+
+### Permissions
+
+- `read` — any authenticated bar member.
+- `create` — Staff+ for `pinned: false`; Manager+ for `pinned: true`. Server validates `authorId == auth.uid` and `authorName/authorRole` match caller's bar user doc.
+- `update` — only `pinned`, `pinnedBy`, `pinnedAt` fields, by Manager+. Text is immutable (no edit in v1).
+- `delete` — author can delete own; Manager+ can delete any.
+
+### Notifications
+
+Pinning fires an FCM push to all bar members. Regular chat messages do not push. Per-user "notify on every chat" preference deferred to follow-up.
+
+### UI behavior
+
+- Author name + role badge (Owner gets a visible badge), timestamp on each message.
+- Pin/unpin button for Manager+ on hover or long-press.
+- Delete: own messages always; any message for Manager+.
+- Auto-scroll-to-bottom unless user has scrolled up.
+
+### Out of scope (Phase 2)
+
+Typing indicators, reactions, threading, attachments, DMs, message edit, search.
+
+## Phase 3 — POS: Square + Toast (real), eight others stay stubbed
+
+### Adapter inventory
+
+Square and Toast get real OAuth + API implementations. The eight existing stubs (`Clover`, `Lightspeed`, `SpotOn`, `TouchBistro`, `Revel`, `Lavu`, `Talech`, `Aloha`) stay as scaffolding files conforming to the interface — useful for future implementations. UI honesty is enforced at the provider-picker level instead of deleting code.
+
+### Tightened POSClient interface
+
+Current shape at `types.ts:160` returns `Promise<any[]>` everywhere. Replace with concrete shapes — the intersection of what Square and Toast actually return now, to prevent abstraction leaks later:
+
+```
+interface POSClient {
+  connect(creds): Promise<{ connected: boolean; merchantId: string; error?: string }>
+  disconnect(): Promise<void>
+  syncMenu(): Promise<MenuItem[]>           // { id, name, price, category?, modifiers?[] }
+  getOrders(opts?: { since?: Date }): Promise<Order[]>
+  getSales(start, end): Promise<SalesSummary>
+}
+```
+
+### Provider-picker honesty
+
+`POS_PROVIDER_STATUS` constant lists each adapter as `'available'` or `'coming_soon'`. The picker enables only `'available'` entries; the rest render with a disabled state and "Coming soon — not yet available" label. Flipping a stub to a real implementation is a one-line constant change.
+
+### OAuth flow
+
+1. Manager opens POS Settings dialog (gated by `isPremium && role ∈ {Manager, Owner}`).
+2. Picks provider → app redirects to provider's OAuth consent URL with our `clientId` + bar-scoped `state`.
+3. Provider redirects to Cloud Function callback `/oauth/{provider}/callback` with `code`.
+4. Function exchanges `code` for tokens, **encrypts with KMS**, writes to `bars/{barId}/posConnection/{provider}`. Tokens never leave the server.
+5. Scheduled Function rotates refresh tokens hourly for anything within 24h of expiry.
+
+### Server-only API calls
+
+All POS API calls happen in Cloud Functions. Three callable Functions: `posSyncMenu(barId)`, `posGetOrders(barId, since?)`, `posGetSales(barId, start, end)`. Each verifies caller's role from custom claims before doing anything. Browser never sees tokens.
+
+### What Phase 3 ships
+
+- POS Settings dialog (connect/disconnect, list status of each provider).
+- Menu sync as a smoke test: synced menu lands in `bars/{barId}/menu/{itemId}`, shown in POS Settings as "✓ Connected — synced 47 items."
+- Tiny "POS Insights" panel inside bar settings: last 7 days gross, today's count.
+
+### Out of scope (Phase 3)
+
+Webhooks (poll on demand instead), modifiers/variants beyond name+price, multi-location bars, refunds, voids, tip allocation, loyalty, real reporting dashboards, customer-facing menu consumption (Phase 5+).
+
+### Provider config
+
+- Square: `SQUARE_CLIENT_ID`, `SQUARE_CLIENT_SECRET` in Cloud Function env. Sandbox URL for dev.
+- Toast: same pattern. Toast partner-app approval is slow — start that application early.
+
+## Phase 4 — Calendar: two-way Google + iCal in/out
+
+### Honest scope
+
+"Two-way iCal" doesn't exist; iCal is a one-way file format. Phase 4 ships: **two-way Google Calendar** + **outbound iCal feed** (other apps subscribe) + **inbound iCal subscription** (we poll a URL the manager pastes). That covers Apple Calendar, Outlook, etc. without writing N adapters.
+
+### Data model
+
+`bars/{barId}/events/{eventId}`:
+
+```
+{
+  title, start, end, description?,
+  type,                    // 'shift' | 'booking' | 'event' | ...
+  assignedTo?: [uid],      // for shifts
+  externalId?: string,
+  externalProvider?: string,  // 'google' | 'ical:<url-hash>' | future: 'asana', 'clickup', etc.
+  lastSyncedAt?: timestamp,
+  deletedAt?: timestamp
+}
+```
+
+This shape is the future extension point: Asana, ClickUp, Trello and similar tools plug in as new `externalProvider` values with their own adapters and OAuth — no schema changes needed.
+
+### Google two-way sync
+
+- OAuth connect in Calendar Settings (KMS-encrypted server-side tokens, same pattern as POS).
+- Manager picks **one** Google calendar to mirror — not "all calendars," too many ways to send the wrong invite.
+- **Outbound:** Firestore trigger on `events` create/update/delete mirrors to Google via `externalId`. New events get Google ID written back.
+- **Inbound:** subscribe to Google Calendar `watch` push notifications on connect (refresh weekly). On ping, fetch incremental changes via `events.list` + `syncToken`. Upsert.
+- **Conflict resolution:** last-write-wins on `updatedAt`. Both-sides-changed logs to `bars/{barId}/syncConflicts/{id}` and surfaces a Calendar Settings banner. No auto-merge — bars want predictability.
+- **Delete semantics:** delete in our app → delete in Google. Delete in Google → soft-delete here (sets `deletedAt`, recoverable for 30 days). Asymmetric on purpose.
+
+### Outbound iCal feed
+
+Cloud Function endpoint `/ical/{barId}/{token}.ics` serves a `.ics` of current events. `{token}` is a random opaque secret stored on the bar; Manager+ can rotate or revoke. Anyone with the URL gets read-only access — that's the iCal model.
+
+### Inbound iCal subscription
+
+Manager pastes an external `.ics` URL into Calendar Settings. Scheduled Function polls every 15 min, parses with `node-ical`, upserts events with `externalProvider: 'ical:<url-hash>'`. These events are read-only in our app (can't edit something you don't own). Removing the subscription removes all its events.
+
+### UI surfaces
+
+- **Calendar Settings dialog** — connect Google, manage iCal subscriptions, copy/rotate outbound feed URL, view conflicts.
+- **Calendar view** — month/week/agenda, color-coded by `type`. Manager+ create/edit (non-external-owned); Staff read; Staff view own shifts.
+- **Shift auto-clock-in** — if a user has an active `type: 'shift'` event with their UID in `assignedTo` when they sign in, status auto-promotes to `active`. Connects to the existing `confirmRole` flow at `App.tsx:1019`.
+
+### Notifications
+
+15-min-before reminders for upcoming shifts via existing FCM/ntfy plumbing. Per-user opt-out preference.
+
+### Permissions
+
+- Read — any member.
+- Create/edit/delete — Manager+. Externally-owned events are read-only.
+- Outbound feed token — Manager+ can rotate/revoke.
+
+### Out of scope (Phase 4)
+
+Recurring events with per-instance exceptions (v1 supports simple `RRULE-MONTHLY/WEEKLY/DAILY` with no overrides), invitee management, video-call links, multiple Google calendars per bar.
+
+## Cross-cutting infrastructure
+
+These get built in Phase 1 because everything else depends on them:
+
+- **Cloud Functions environment** — currently the app is largely client-only. POS OAuth, Google Calendar sync, role-claim-stamping, invite emails, ownership-claim waterfall, iCal poller, etc. all need server-side execution. Standing up the Functions project, env-var management, and KMS key for token encryption is Phase 1 infrastructure work.
+- **Firebase Auth custom claims** — role stamping so rules can read role without recursive fetches. Cloud Function on `users` doc role change updates claims.
+- **Honest free-tier vs premium gating** — current `isPremium` derivation at `App.tsx:642` is fine; it just needs to be enforced in rules too (subscription tier on custom claims).
+
+## Testing strategy
+
+- **Firestore rules tests** — required for Phase 1. Every rule path (Staff-as-actor on Manager target, Manager-as-actor on Owner target, etc.) gets a unit test using `@firebase/rules-unit-testing`. Owner-immunity is the kind of thing that breaks silently in code review without these tests.
+- **Cloud Function tests** — emulator-based integration tests for OAuth callback handling, claim waterfall step transitions, sync engines.
+- **Component tests** — extend the existing Vitest setup for `UsersDialog`, `ChatPanel`, `POSSettings`, `CalendarSettings`.
+- **Manual end-to-end** — for each phase, walk through the golden path in a real browser before declaring done. UI behavior is not verified by type-checking.
+
+## Build sequence
+
+1. Phase 1 (hardening) — rules, roles, signup, 86'd, user mgmt. **Ships before anything else** because everything else depends on the role model and Cloud Functions infrastructure it introduces.
+2. Phase 2 (chat) — replaces the broken notices marquee.
+3. Phase 3 (POS, Square + Toast).
+4. Phase 4 (Google + iCal calendar).
+
+Customer-facing ordering PWA (CMS, billing, tips, reports, pager-status) is its own brainstorm after Phase 4 lands.

--- a/docs/plans/2026-05-21-phase-1-hardening.md
+++ b/docs/plans/2026-05-21-phase-1-hardening.md
@@ -1,0 +1,1283 @@
+# Phase 1 — Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Land the role model, signup gating, user-management UI, hardened Firestore rules, custom-claims stamping, 86'd rules enforcement, and the full optional ownership-claim waterfall — the foundation every later phase depends on.
+
+**Architecture:** Roles (`Staff` / `Manager` / `Owner`) live in `bars/{barId}/users/{uid}.role` and are mirrored to Firebase Auth custom claims by a Cloud Function so Firestore rules can read them without recursive document reads. Multiple Owners per bar allowed; Owners are immune to role changes by anyone but themselves. A new `joinPolicy` field on each bar toggles open join vs. pending-approval. A new `UsersDialog` component replaces the misrouted "N Approvals" badge target. Ownership is optional and acquired through a five-step waterfall implemented as Cloud Functions: OSM-contact code → email-domain match → existing-Manager approval → 7-day dispute window → manual escalation.
+
+**Tech Stack:** Existing — React 19, TypeScript, Vite, Vitest, Firebase Web SDK, Material Web Components, Tailwind. New for this phase — Firebase Cloud Functions (Node 20, TypeScript), `@firebase/rules-unit-testing`, `firebase-admin`, `firebase-functions`. External services for the claim waterfall: SendGrid (email) and Twilio Verify (SMS) — both configured via Cloud Function env vars with graceful no-op fallbacks when not configured.
+
+**Reference design:** See `docs/plans/2026-05-21-feature-set-purr-design.md` for context and rationale.
+
+---
+
+## Section A — Infrastructure bootstrap
+
+### Task A1: Initialize Firebase project files (firebase.json + .firebaserc)
+
+**Files:**
+- Create: `firebase.json`
+- Create: `.firebaserc`
+
+**Step 1: Create `firebase.json`**
+
+```json
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "runtime": "nodejs20",
+      "ignore": ["node_modules", ".git", "*.local", "**/__tests__/**"]
+    }
+  ],
+  "emulators": {
+    "auth": { "port": 9099 },
+    "functions": { "port": 5001 },
+    "firestore": { "port": 8080 },
+    "ui": { "enabled": true, "port": 4000 },
+    "singleProjectMode": true
+  }
+}
+```
+
+**Step 2: Create `.firebaserc` — use the project ID already present in `.env`**
+
+```json
+{
+  "projects": {
+    "default": "<paste VITE_FIREBASE_PROJECT_ID value here>"
+  }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add firebase.json .firebaserc
+git commit -m "chore: initialize firebase project files"
+```
+
+### Task A2: Scaffold the `functions/` package
+
+**Files:**
+- Create: `functions/package.json`
+- Create: `functions/tsconfig.json`
+- Create: `functions/.gitignore`
+- Create: `functions/src/index.ts`
+
+**Step 1: Create `functions/package.json`**
+
+```json
+{
+  "name": "barbacker-functions",
+  "private": true,
+  "main": "lib/index.js",
+  "engines": { "node": "20" },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "deploy": "firebase deploy --only functions",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^4.0.16",
+    "@types/node": "^20.10.0"
+  }
+}
+```
+
+**Step 2: Create `functions/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+**Step 3: Create `functions/.gitignore`**
+
+```
+node_modules/
+lib/
+*.local
+```
+
+**Step 4: Create `functions/src/index.ts` (placeholder)**
+
+```typescript
+import * as admin from "firebase-admin";
+
+admin.initializeApp();
+
+export const ping = () => "ok";
+```
+
+**Step 5: Install + build**
+
+Run: `cd functions && npm install && npm run build`
+Expected: builds without errors, produces `functions/lib/index.js`.
+
+**Step 6: Commit**
+
+```bash
+git add functions/
+git commit -m "chore: scaffold cloud functions package"
+```
+
+### Task A3: Add rules-testing dev dependency to root
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+
+**Step 1: Install**
+
+Run: `npm install --save-dev @firebase/rules-unit-testing@^4.0.0`
+Expected: installs cleanly; `package.json` updated.
+
+**Step 2: Add npm scripts**
+
+Modify `package.json` `scripts`:
+
+```json
+"test:rules": "vitest run src/test/rules",
+"emulators": "firebase emulators:start --only firestore,auth,functions"
+```
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @firebase/rules-unit-testing + emulator scripts"
+```
+
+---
+
+## Section B — Type updates
+
+### Task B1: Extend `Bar`, `BarUser`, and add new types
+
+**Files:**
+- Modify: `src/types.ts`
+
+**Step 1: Add fields to `Bar`** (`src/types.ts:18`)
+
+Add after `subscription?:`:
+
+```typescript
+// Join policy for new users. 'open' = auto-active. 'approval' = pending until Manager approves.
+joinPolicy?: 'open' | 'approval';
+```
+
+**Step 2: Update `BarUser`** (`src/types.ts:110`)
+
+Replace the `status` line with:
+
+```typescript
+status?: 'active' | 'off_clock' | 'pending' | 'rejected';
+```
+
+**Step 3: Add new type definitions** at end of file:
+
+```typescript
+// Define an invite for a specific email to join a bar at a specific role.
+export interface BarInvite {
+  id: string;
+  email: string;            // normalized lowercase
+  role: 'Staff' | 'Manager' | 'Owner';
+  createdBy: string;        // uid
+  createdByName: string;
+  createdAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+  consumed: boolean;
+  consumedBy?: string;      // uid of the user who used it
+  consumedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}
+
+// Define an ownership-claim request and its waterfall state.
+export interface OwnershipClaim {
+  id: string;
+  barId: string;
+  claimantId: string;       // uid
+  claimantEmail: string;
+  claimantName: string;
+  // Method that succeeded, if any.
+  approvedVia?: 'osm_code' | 'domain_match' | 'manager_approval' | 'dispute_window' | 'manual';
+  status: 'pending_code' | 'pending_manager' | 'pending_dispute' | 'pending_manual' | 'approved' | 'rejected' | 'expired';
+  // OSM step.
+  codeSentTo?: string;      // masked phone or email
+  codeChannel?: 'email' | 'sms';
+  codeHash?: string;        // bcrypt of the code; never store plaintext
+  codeExpiresAt?: import('firebase/firestore').Timestamp;
+  codeAttempts?: number;
+  // Dispute step.
+  disputeOpensAt?: import('firebase/firestore').Timestamp;
+  disputeClosesAt?: import('firebase/firestore').Timestamp;
+  disputedBy?: string[];    // uids
+  createdAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+  updatedAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(types): add joinPolicy, BarInvite, OwnershipClaim"
+```
+
+---
+
+## Section C — Custom-claims stamping function
+
+### Task C1: TDD — onUserRoleChange Cloud Function
+
+**Files:**
+- Create: `functions/src/onUserRoleChange.ts`
+- Create: `functions/src/__tests__/onUserRoleChange.test.ts`
+- Modify: `functions/src/index.ts`
+
+**Step 1: Write the failing test**
+
+`functions/src/__tests__/onUserRoleChange.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const setCustomUserClaims = vi.fn().mockResolvedValue(undefined);
+vi.mock("firebase-admin", () => ({
+  initializeApp: vi.fn(),
+  auth: () => ({ setCustomUserClaims })
+}));
+
+import { computeClaimsForUser } from "../onUserRoleChange";
+
+describe("computeClaimsForUser", () => {
+  beforeEach(() => setCustomUserClaims.mockClear());
+
+  it("aggregates roles across multiple bars", () => {
+    const userDocs = [
+      { barId: "bar_A", role: "Manager" },
+      { barId: "bar_B", role: "Owner" },
+      { barId: "bar_C", role: "Staff" }
+    ];
+    expect(computeClaimsForUser(userDocs)).toEqual({
+      bars: { bar_A: "Manager", bar_B: "Owner", bar_C: "Staff" }
+    });
+  });
+
+  it("returns empty object when user has no bars", () => {
+    expect(computeClaimsForUser([])).toEqual({ bars: {} });
+  });
+});
+```
+
+**Step 2: Run — expect FAIL** ("Cannot find module '../onUserRoleChange'")
+
+Run: `cd functions && npx vitest run src/__tests__/onUserRoleChange.test.ts`
+
+**Step 3: Implement** `functions/src/onUserRoleChange.ts`:
+
+```typescript
+import * as admin from "firebase-admin";
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+
+type UserRoleDoc = { barId: string; role: string };
+
+export function computeClaimsForUser(docs: UserRoleDoc[]): { bars: Record<string, string> } {
+  const bars: Record<string, string> = {};
+  for (const d of docs) bars[d.barId] = d.role;
+  return { bars };
+}
+
+export const onUserRoleChange = onDocumentWritten(
+  "bars/{barId}/users/{userId}",
+  async (event) => {
+    const userId = event.params.userId;
+    const db = admin.firestore();
+
+    // Aggregate this user's role across every bar.
+    const snap = await db.collectionGroup("users")
+      .where(admin.firestore.FieldPath.documentId(), "==", userId)
+      .get();
+    // collectionGroup query against doc id won't work — replace with a fan-out below.
+    const docs: UserRoleDoc[] = [];
+    snap.forEach((d) => {
+      const parent = d.ref.parent.parent;
+      if (parent && d.data().role) docs.push({ barId: parent.id, role: d.data().role });
+    });
+
+    const claims = computeClaimsForUser(docs);
+    await admin.auth().setCustomUserClaims(userId, claims);
+  }
+);
+```
+
+**Note on the collectionGroup query:** the `documentId()` filter on a collectionGroup query is not actually supported. Replace the implementation with a fan-out using the `joinedBars` array stored on `users/{uid}` (already maintained by `confirmRole` in `App.tsx:1026`):
+
+```typescript
+const userDoc = await db.collection("users").doc(userId).get();
+const joinedBars: string[] = userDoc.data()?.joinedBars ?? [];
+const docs: UserRoleDoc[] = [];
+await Promise.all(joinedBars.map(async (barId) => {
+  const u = await db.doc(`bars/${barId}/users/${userId}`).get();
+  if (u.exists && u.data()?.role) docs.push({ barId, role: u.data()!.role });
+}));
+```
+
+**Step 4: Wire into `functions/src/index.ts`**
+
+```typescript
+import * as admin from "firebase-admin";
+admin.initializeApp();
+
+export { onUserRoleChange } from "./onUserRoleChange";
+```
+
+**Step 5: Run — expect PASS**
+
+Run: `cd functions && npx vitest run src/__tests__/onUserRoleChange.test.ts`
+
+**Step 6: Commit**
+
+```bash
+git add functions/src/onUserRoleChange.ts functions/src/__tests__/onUserRoleChange.test.ts functions/src/index.ts
+git commit -m "feat(functions): stamp role claims on user role change"
+```
+
+---
+
+## Section D — Firestore rules rewrite (TDD)
+
+### Task D1: Rules test harness
+
+**Files:**
+- Create: `src/test/rules/helpers.ts`
+- Create: `src/test/rules/sanity.test.ts`
+
+**Step 1: Create helper** `src/test/rules/helpers.ts`:
+
+```typescript
+import {
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export async function getTestEnv(): Promise<RulesTestEnvironment> {
+  return initializeTestEnvironment({
+    projectId: "barbacker-test",
+    firestore: {
+      rules: fs.readFileSync(path.resolve(__dirname, "../../../firestore.rules"), "utf8"),
+      host: "127.0.0.1",
+      port: 8080,
+    },
+  });
+}
+
+export function authedAs(env: RulesTestEnvironment, uid: string, claims: object = {}) {
+  return env.authenticatedContext(uid, claims).firestore();
+}
+```
+
+**Step 2: Sanity test** `src/test/rules/sanity.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+describe("rules sanity", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+  beforeAll(async () => { env = await getTestEnv(); });
+  afterAll(async () => { await env.cleanup(); });
+
+  it("unauthenticated user cannot read /users/anyone", async () => {
+    const db = env.unauthenticatedContext().firestore();
+    await assertFails(setDoc(doc(db, "users/anyone"), { foo: "bar" }));
+  });
+});
+```
+
+**Step 3: Run with emulators**
+
+Run (in one terminal): `firebase emulators:start --only firestore`
+Run (in another): `npm run test:rules`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/test/rules/
+git commit -m "test(rules): add rules-testing harness + sanity check"
+```
+
+### Task D2: TDD — bar read/write rules
+
+**Files:**
+- Create: `src/test/rules/bar.test.ts`
+- Modify: `firestore.rules`
+
+**Step 1: Write failing tests** `src/test/rules/bar.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc, updateDoc, getDoc } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+describe("bar rules", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+
+  beforeAll(async () => { env = await getTestEnv(); });
+  beforeEach(async () => {
+    await env.clearFirestore();
+    // Seed: bar_A with manager_alice (Manager), staff_bob (Staff).
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, "bars/bar_A"), { name: "Bar A", joinPolicy: "open" });
+      await setDoc(doc(db, "bars/bar_A/users/manager_alice"), { role: "Manager", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Staff", status: "active" });
+    });
+  });
+  afterAll(async () => { await env.cleanup(); });
+
+  it("Manager can read the bar doc", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("Staff can read the bar doc", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("non-member cannot read the bar doc", async () => {
+    const db = authedAs(env, "outsider_carol", { bars: {} });
+    await assertFails(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("Manager can update operational fields", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
+  });
+
+  it("Staff cannot update bar doc", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
+  });
+});
+```
+
+**Step 2: Run — expect failures** (current rules allow everything authenticated).
+
+Run: `npm run test:rules -- bar.test`
+
+**Step 3: Rewrite `firestore.rules`** (full file replacement):
+
+```
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAuthed() { return request.auth != null; }
+
+    function roleIn(barId) {
+      return isAuthed() && request.auth.token.bars[barId];
+    }
+
+    function isManagerPlus(barId) {
+      return roleIn(barId) in ['Manager', 'Owner'];
+    }
+
+    function isOwner(barId) {
+      return roleIn(barId) == 'Owner';
+    }
+
+    // Global /users/{userId}
+    match /users/{userId} {
+      allow read, write: if isAuthed() && request.auth.uid == userId;
+    }
+
+    match /bars/{barId} {
+      allow read: if roleIn(barId) != null;
+      allow create: if isAuthed();
+      allow update: if isManagerPlus(barId);
+      allow delete: if isOwner(barId);
+
+      match /users/{userId} {
+        // Self-write limited to safe operational fields.
+        allow write: if isAuthed() && request.auth.uid == userId &&
+          request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(['displayName', 'lastSeen', 'notificationPreferences', 'ntfyTopic', 'email']) ||
+          // Self can set own status to off_clock only.
+          (isAuthed() && request.auth.uid == userId &&
+           request.resource.data.status == 'off_clock' &&
+           resource.data.status != null);
+
+        // Managers can promote pending → active, set role for non-Owners, kick non-Owners.
+        allow update: if isManagerPlus(barId) &&
+          resource.data.role != 'Owner';
+
+        // Owners can do anything to any user (including other Owners only via self-relinquish).
+        allow update: if isOwner(barId) &&
+          (resource.data.role != 'Owner' || request.auth.uid == userId);
+
+        allow read: if roleIn(barId) != null;
+        // New user creating own pending/active record at join time.
+        allow create: if isAuthed() && request.auth.uid == userId;
+        allow delete: if isManagerPlus(barId) && resource.data.role != 'Owner';
+      }
+
+      match /tokens/{userId} {
+        allow read, write: if isAuthed() && request.auth.uid == userId;
+      }
+
+      match /eightySixed/{entryId} {
+        allow read: if (resource.data.visibility == 'public' && roleIn(barId) != null) ||
+                       isManagerPlus(barId);
+        allow create: if isManagerPlus(barId) &&
+          (request.resource.data.visibility == 'public' ||
+           (request.resource.data.visibility == 'private' &&
+            request.auth.token.bars[barId] != null));
+        allow delete: if isManagerPlus(barId);
+        allow update: if false;
+      }
+
+      match /notices/{noticeId} {
+        // Kept wide for Phase 1 — replaced in Phase 2 by chat.
+        allow read, write: if roleIn(barId) != null;
+      }
+
+      match /invites/{inviteId} {
+        allow read: if isManagerPlus(barId) ||
+                       (isAuthed() && resource.data.email == request.auth.token.email);
+        allow create: if isManagerPlus(barId);
+        allow update: if isAuthed() && resource.data.email == request.auth.token.email &&
+                        request.resource.data.diff(resource.data).affectedKeys()
+                          .hasOnly(['consumed', 'consumedBy', 'consumedAt']);
+        allow delete: if isManagerPlus(barId);
+      }
+
+      match /ownershipClaims/{claimId} {
+        allow read: if isManagerPlus(barId) ||
+                       (isAuthed() && resource.data.claimantId == request.auth.uid);
+        // Writes go through Cloud Functions only.
+        allow write: if false;
+      }
+    }
+
+    match /requests/{requestId} {
+      allow read: if isAuthed() && roleIn(resource.data.barId) != null;
+      allow create: if isAuthed() && roleIn(request.resource.data.barId) != null &&
+                      request.resource.data.requesterId == request.auth.uid;
+      allow update, delete: if isAuthed() && (
+        resource.data.requesterId == request.auth.uid ||
+        isManagerPlus(resource.data.barId)
+      );
+    }
+  }
+}
+```
+
+**Step 4: Run — expect PASS**
+
+Run: `npm run test:rules -- bar.test`
+
+**Step 5: Commit**
+
+```bash
+git add firestore.rules src/test/rules/bar.test.ts
+git commit -m "feat(rules): role-gated bar reads/writes"
+```
+
+### Task D3: TDD — user-subcollection role-change rules (Owner immunity)
+
+**Files:**
+- Create: `src/test/rules/userRoles.test.ts`
+
+**Step 1: Write failing tests**
+
+Critical paths to cover:
+- Staff cannot change any role.
+- Manager can promote Staff → Manager.
+- Manager can demote Manager → Staff.
+- Manager cannot touch an Owner's record.
+- Owner can promote Manager → Owner.
+- Owner can demote Manager → Staff.
+- Owner cannot demote another Owner (only self can).
+- Self can self-relinquish Owner → Manager.
+- Self can change own `lastSeen` without role.
+
+Write each as a separate `it()` block following the pattern in D2. Use `withSecurityRulesDisabled` to seed each scenario.
+
+**Step 2: Run — expect FAIL on any incorrectly-permitted writes**
+
+If a test fails because the rule allows something it shouldn't, refine `firestore.rules` and re-run.
+
+**Step 3: Iterate on rules until all tests pass**
+
+The rule for owner-immunity is subtle. Validate by hand that the existing rule from D2 handles every case; add additional sub-cases if not. The pattern:
+
+```
+// Anyone Manager+ can write to non-Owner records.
+// Owners can write to any record but cannot demote other Owners.
+// Self can always relinquish.
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/test/rules/userRoles.test.ts firestore.rules
+git commit -m "test(rules): owner immunity matrix"
+```
+
+### Task D4: TDD — 86'd visibility rules
+
+**Files:**
+- Create: `src/test/rules/eightySixed.test.ts`
+
+**Step 1: Write failing tests**
+
+Cover:
+- Staff can read public entries.
+- Staff cannot read private entries.
+- Manager can read both.
+- Staff cannot create any entry.
+- Manager can create public entries.
+- Manager can create private entries only if bar subscription claim is `premium`.
+- Manager can delete entries.
+
+For premium gating in the test, set `request.auth.token.subscription_bar_A = 'premium'` (see Section H for how the claims function will set this; for now, just stub the claim in the test).
+
+**Step 2: Adjust the `match /eightySixed/{entryId}` rule** to check `request.auth.token.subscription[barId] == 'premium'` for private-create.
+
+```
+match /eightySixed/{entryId} {
+  allow read: if (resource.data.visibility == 'public' && roleIn(barId) != null) ||
+                 isManagerPlus(barId);
+  allow create: if isManagerPlus(barId) &&
+    (request.resource.data.visibility == 'public' ||
+     (request.resource.data.visibility == 'private' &&
+      request.auth.token.subscription[barId] == 'premium'));
+  allow delete: if isManagerPlus(barId);
+  allow update: if false;
+}
+```
+
+**Step 3: Run — expect PASS**
+
+**Step 4: Commit**
+
+```bash
+git add src/test/rules/eightySixed.test.ts firestore.rules
+git commit -m "feat(rules): 86'd visibility + premium gate"
+```
+
+---
+
+## Section E — `joinPolicy` + `confirmRole` honors it
+
+### Task E1: TDD — `confirmRole` writes `pending` when joinPolicy is `approval`
+
+**Files:**
+- Modify: `src/App.tsx:1019` (`confirmRole`)
+- Create: `src/test/JoinPolicy.test.tsx`
+
+**Step 1: Write failing test** that mounts the app with a bar of `joinPolicy: 'approval'`, simulates role selection, and asserts the resulting `bars/{barId}/users/{uid}` doc has `status: 'pending'`. Use the existing test pattern in `src/test/App.test.tsx` for setup.
+
+**Step 2: Run — expect FAIL** (current code hard-codes `'active'`).
+
+**Step 3: Modify `confirmRole`** at `src/App.tsx:1019`:
+
+Replace `const status = 'active';` with:
+
+```typescript
+// Read joinPolicy from the bar doc we already have in state.
+const status: BarUser["status"] =
+  bar?.joinPolicy === "approval" ? "pending" : "active";
+```
+
+Ensure `bar` is in scope; if not, fall back to a one-shot `getDoc` of the bar before deciding status.
+
+**Step 4: Run — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git add src/App.tsx src/test/JoinPolicy.test.tsx
+git commit -m "feat: honor joinPolicy on user confirmRole"
+```
+
+### Task E2: Manager toggle for `joinPolicy` in BarManager
+
+**Files:**
+- Modify: `src/components/BarManager.tsx`
+- Create: `src/components/BarManager.joinPolicy.test.tsx`
+
+**Step 1: Write failing test** that mounts `BarManager` with a Manager user and asserts a toggle is present and toggles `joinPolicy`.
+
+**Step 2: Add prop** `currentJoinPolicy` and `onJoinPolicyChange` to `BarManagerProps`; render a `md-switch` near the top of the dialog when `userRole === 'Owner' || userRole === 'Manager'` (pass `userRole` as a new prop).
+
+**Step 3: Wire from `App.tsx`** at the BarManager invocation:
+
+```typescript
+<BarManager
+  ...
+  currentJoinPolicy={bar?.joinPolicy ?? 'open'}
+  onJoinPolicyChange={async (next) => { await updateDoc(doc(db, 'bars', barId!), { joinPolicy: next }); }}
+  userRole={userRole}
+/>
+```
+
+**Step 4: Run — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git add src/components/BarManager.tsx src/components/BarManager.joinPolicy.test.tsx src/App.tsx
+git commit -m "feat(ui): join policy toggle in bar manager"
+```
+
+---
+
+## Section F — `UsersDialog` (replaces broken "N Approvals" target)
+
+### Task F1: Create `UsersDialog` skeleton with three tabs
+
+**Files:**
+- Create: `src/components/UsersDialog.tsx`
+- Create: `src/components/UsersDialog.test.tsx`
+
+**Step 1: Write a failing test** that mounts the dialog, asserts three tabs exist (`Active`, `Pending`, `Invites`), and asserts switching tabs renders the correct content.
+
+**Step 2: Implement the skeleton.** Use `BarManager.tsx` as a structural reference. Tabs implemented as three buttons styling `data-active`, content area below switches by local state. Props:
+
+```typescript
+interface UsersDialogProps {
+  open: boolean;
+  onClose: () => void;
+  barId: string;
+  users: BarUser[];
+  invites: BarInvite[];
+  currentUserRole: 'Owner' | 'Manager' | 'Staff';
+  currentUserId: string;
+  onApprove: (uid: string) => Promise<void>;
+  onReject: (uid: string) => Promise<void>;
+  onChangeRole: (uid: string, role: 'Owner' | 'Manager' | 'Staff') => Promise<void>;
+  onKick: (uid: string) => Promise<void>;
+  onSendInvite: (email: string, role: 'Staff' | 'Manager' | 'Owner') => Promise<void>;
+  onRevokeInvite: (inviteId: string) => Promise<void>;
+}
+```
+
+**Step 3: Run — expect PASS**
+
+**Step 4: Commit**
+
+```bash
+git add src/components/UsersDialog.tsx src/components/UsersDialog.test.tsx
+git commit -m "feat(ui): UsersDialog skeleton with tabs"
+```
+
+### Task F2: Active tab — list users with role dropdown + kick
+
+**Files:**
+- Modify: `src/components/UsersDialog.tsx`
+- Modify: `src/components/UsersDialog.test.tsx`
+
+**Step 1: Write tests** asserting:
+- Each active user renders with name + role.
+- Owners render with a `verified` icon badge.
+- Owner row's role dropdown and kick button are disabled for non-Owner viewers.
+- Self row's "Step down" button appears for Owners viewing themselves.
+- Clicking kick prompts confirmation, then calls `onKick(uid)`.
+
+**Step 2: Implement.** Use `md-select`/native `<select>` for the role dropdown; gate options based on viewer's role + target's role.
+
+**Step 3: Run — expect PASS**
+
+**Step 4: Commit**
+
+```bash
+git add src/components/UsersDialog.tsx src/components/UsersDialog.test.tsx
+git commit -m "feat(ui): active users tab"
+```
+
+### Task F3: Pending tab — approve / reject
+
+**Files:**
+- Modify: `src/components/UsersDialog.tsx`
+- Modify: `src/components/UsersDialog.test.tsx`
+
+**Step 1: Write tests** asserting:
+- Pending users (`status === 'pending'`) render in this tab with name + role they requested.
+- "Approve" button calls `onApprove(uid)`; "Reject" calls `onReject(uid)`.
+- Visible only to Manager+.
+
+**Step 2: Implement.**
+
+**Step 3: Run — expect PASS**
+
+**Step 4: Commit**
+
+```bash
+git add src/components/UsersDialog.tsx src/components/UsersDialog.test.tsx
+git commit -m "feat(ui): pending users tab"
+```
+
+### Task F4: Invites tab — list + send invite
+
+**Files:**
+- Modify: `src/components/UsersDialog.tsx`
+- Modify: `src/components/UsersDialog.test.tsx`
+
+**Step 1: Write tests** asserting:
+- Existing un-consumed invites render with email + role + creator + "Revoke."
+- "Send invite" form (email field + role dropdown + Send button) calls `onSendInvite(email, role)`.
+- Lowercase normalization on email before submit.
+- Owner-role invites only selectable if current user is Owner.
+
+**Step 2: Implement.**
+
+**Step 3: Run — expect PASS**
+
+**Step 4: Commit**
+
+```bash
+git add src/components/UsersDialog.tsx src/components/UsersDialog.test.tsx
+git commit -m "feat(ui): invites tab"
+```
+
+### Task F5: Wire UsersDialog into App; rewire "N Approvals" badge
+
+**Files:**
+- Modify: `src/App.tsx`
+
+**Step 1: Add state** `const [showUsersDialog, setShowUsersDialog] = useState(false);`
+
+**Step 2: Add Firestore listener** for `bars/{barId}/invites` (mirrors the existing listener pattern around `App.tsx:582`):
+
+```typescript
+const unsubInvites = onSnapshot(
+  query(collection(db, `bars/${barId}/invites`), where('consumed', '==', false)),
+  (s) => setInvites(s.docs.map(d => ({ id: d.id, ...d.data() } as BarInvite)))
+);
+// add to cleanup return
+```
+
+**Step 3: Implement handler functions** (`approveUser`, `rejectUser`, `changeUserRole`, `kickUser`, `sendInvite`, `revokeInvite`) that wrap `updateDoc`/`deleteDoc` calls. `sendInvite` calls a callable Cloud Function (`createInvite`) defined later in Section G.
+
+**Step 4: Render `UsersDialog`** in the dialogs block around `App.tsx:1400`:
+
+```typescript
+<UsersDialog
+  open={showUsersDialog}
+  onClose={() => setShowUsersDialog(false)}
+  barId={barId!}
+  users={allUsers}
+  invites={invites}
+  currentUserRole={userRole as any}
+  currentUserId={user!.uid}
+  onApprove={approveUser}
+  onReject={rejectUser}
+  onChangeRole={changeUserRole}
+  onKick={kickUser}
+  onSendInvite={sendInvite}
+  onRevokeInvite={revokeInvite}
+/>
+```
+
+**Step 5: Rewire the "N Approvals" badge** at `App.tsx:1820`. Change `onClick={() => setShowBarManager(true)}` to `onClick={() => setShowUsersDialog(true)}`.
+
+**Step 6: Add a Users menu item** in the top-bar menu near `App.tsx:1591` for Manager+ to open `UsersDialog` directly.
+
+**Step 7: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: wire UsersDialog; rewire Approvals badge"
+```
+
+---
+
+## Section G — Invites: callable Cloud Function + auto-consume
+
+### Task G1: TDD — `createInvite` callable Cloud Function
+
+**Files:**
+- Create: `functions/src/createInvite.ts`
+- Create: `functions/src/__tests__/createInvite.test.ts`
+- Modify: `functions/src/index.ts`
+
+**Step 1: Write failing test** asserting:
+- Caller without Manager+ claim on the target bar gets `permission-denied`.
+- Owner-role invite from a Manager caller gets `permission-denied`.
+- Valid call writes a doc to `bars/{barId}/invites` with `email` normalized lowercase, `consumed: false`, the caller's name/uid, and a server timestamp.
+
+**Step 2: Implement** `functions/src/createInvite.ts`:
+
+```typescript
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import * as admin from "firebase-admin";
+
+export const createInvite = onCall<{ barId: string; email: string; role: "Staff" | "Manager" | "Owner" }>(
+  async (req) => {
+    const auth = req.auth;
+    if (!auth) throw new HttpsError("unauthenticated", "Sign in required.");
+    const { barId, email, role } = req.data;
+    if (!barId || !email || !role) throw new HttpsError("invalid-argument", "Missing fields.");
+    const callerRole = auth.token.bars?.[barId];
+    if (callerRole !== "Manager" && callerRole !== "Owner") {
+      throw new HttpsError("permission-denied", "Manager+ required.");
+    }
+    if (role === "Owner" && callerRole !== "Owner") {
+      throw new HttpsError("permission-denied", "Only Owners can invite Owners.");
+    }
+    const db = admin.firestore();
+    const userDoc = await db.doc(`bars/${barId}/users/${auth.uid}`).get();
+    const createdByName = userDoc.data()?.displayName ?? "Unknown";
+    await db.collection(`bars/${barId}/invites`).add({
+      email: email.trim().toLowerCase(),
+      role,
+      createdBy: auth.uid,
+      createdByName,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      consumed: false,
+    });
+    return { ok: true };
+  }
+);
+```
+
+**Step 3: Export from `index.ts`**, run tests, expect PASS.
+
+**Step 4: Commit**
+
+```bash
+git add functions/src/createInvite.ts functions/src/__tests__/createInvite.test.ts functions/src/index.ts
+git commit -m "feat(functions): createInvite callable"
+```
+
+### Task G2: Auto-consume invites on sign-in
+
+**Files:**
+- Modify: `src/App.tsx` — auth sign-in effect
+
+**Step 1: Find** the existing `onAuthStateChanged` block (search for `onAuthStateChanged` in `App.tsx`).
+
+**Step 2: After sign-in**, query `collectionGroup('invites')` filtered by `email == user.email && consumed == false`. For each match, in a transaction:
+
+- Mark invite `consumed: true`, `consumedBy: user.uid`, `consumedAt: serverTimestamp()`.
+- Create `bars/{barId}/users/{user.uid}` with `role` from the invite and `status: 'active'`.
+
+Add an index for the collectionGroup query: append to `firestore.indexes.json`:
+
+```json
+{
+  "collectionGroup": "invites",
+  "queryScope": "COLLECTION_GROUP",
+  "fields": [
+    { "fieldPath": "email", "order": "ASCENDING" },
+    { "fieldPath": "consumed", "order": "ASCENDING" }
+  ]
+}
+```
+
+**Step 3: Manual test in emulator** — invite an email, sign in as that user, verify auto-join.
+
+**Step 4: Commit**
+
+```bash
+git add src/App.tsx firestore.indexes.json
+git commit -m "feat: auto-consume invites on sign-in"
+```
+
+### Task G3: Email delivery via SendGrid (with deep-link fallback)
+
+**Files:**
+- Create: `functions/src/sendInviteEmail.ts`
+- Modify: `functions/src/createInvite.ts`
+
+**Step 1: Add `@sendgrid/mail` to `functions/package.json` dependencies**, install.
+
+**Step 2: Implement `sendInviteEmail.ts`:**
+
+```typescript
+import * as sgMail from "@sendgrid/mail";
+
+export async function sendInviteEmail(args: { to: string; barName: string; role: string; inviteUrl: string }): Promise<{ sent: boolean; reason?: string }> {
+  const key = process.env.SENDGRID_API_KEY;
+  if (!key) return { sent: false, reason: "no_api_key" };
+  sgMail.setApiKey(key);
+  await sgMail.send({
+    to: args.to,
+    from: process.env.INVITE_FROM_EMAIL ?? "no-reply@barbacker.app",
+    subject: `You're invited to ${args.barName}`,
+    text: `Join ${args.barName} as a ${args.role}: ${args.inviteUrl}`,
+  });
+  return { sent: true };
+}
+```
+
+**Step 3: Call it from `createInvite`** after the doc write; return `{ ok: true, emailSent }` so the UI can show a "copy link manually" prompt when SendGrid isn't configured.
+
+**Step 4: Commit**
+
+```bash
+git add functions/src/sendInviteEmail.ts functions/src/createInvite.ts functions/package.json functions/package-lock.json
+git commit -m "feat(functions): send invite emails via SendGrid"
+```
+
+---
+
+## Section H — Subscription claim stamping
+
+### Task H1: Subscription field reflected in custom claims
+
+**Files:**
+- Modify: `functions/src/onUserRoleChange.ts` (rename or supplement) OR
+- Create: `functions/src/onBarSubscriptionChange.ts`
+
+**Step 1: Create `onBarSubscriptionChange`**, triggered on `bars/{barId}` document writes when `subscription` field changes. For every user in `bars/{barId}/users`, refresh their claims to include `subscription[barId]`.
+
+**Step 2: Update `computeClaimsForUser`** to take `subscriptions: Record<string, string>` and emit `{ bars, subscription }`.
+
+**Step 3: Write tests covering: subscription change cascades to all bar members.**
+
+**Step 4: Commit**
+
+```bash
+git add functions/src/onBarSubscriptionChange.ts functions/src/__tests__/onBarSubscriptionChange.test.ts functions/src/index.ts
+git commit -m "feat(functions): stamp subscription claims on bar change"
+```
+
+---
+
+## Section I — Ownership claim waterfall
+
+### Task I1: `OwnershipClaim` Firestore data model + UI entrypoint
+
+**Files:**
+- Modify: `src/components/UsersDialog.tsx` — add "Claim Owner" button visible to non-Owners.
+- Modify: `src/App.tsx` — open new `ClaimOwnerDialog` when clicked.
+- Create: `src/components/ClaimOwnerDialog.tsx`
+
+**Step 1: Implement `ClaimOwnerDialog`** with stepper UI:
+
+1. Confirmation: "You're requesting Owner of {barName}. We'll try to verify automatically before involving a human."
+2. Outcome screen based on Cloud Function response.
+
+**Step 2: Wire** to a callable `initiateOwnershipClaim` Function (created next task).
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ClaimOwnerDialog.tsx src/components/UsersDialog.tsx src/App.tsx
+git commit -m "feat(ui): ownership claim entrypoint"
+```
+
+### Task I2: `initiateOwnershipClaim` Cloud Function — domain match + OSM lookup
+
+**Files:**
+- Create: `functions/src/initiateOwnershipClaim.ts`
+- Create: `functions/src/osmLookup.ts`
+- Create: `functions/src/__tests__/initiateOwnershipClaim.test.ts`
+
+**Step 1: Implement `osmLookup.ts`** — given a bar's `osmId`, fetch `https://nominatim.openstreetmap.org/lookup?osm_ids=...&format=json&addressdetails=1&extratags=1`. Extract `phone`, `email`, `website` from `extratags`.
+
+**Step 2: Implement `initiateOwnershipClaim`:**
+
+Algorithm:
+1. Validate caller is signed in and is a member of the bar.
+2. Fetch bar doc + OSM extras.
+3. **Domain match**: if `extratags.website` host equals the caller's email domain, immediately create an approved claim and a role-change to Owner. Return `{ outcome: 'approved', via: 'domain_match' }`.
+4. **OSM code**: if `extratags.email` exists, generate a 6-digit code, bcrypt it, write a `pending_code` claim with `codeChannel: 'email'`, `codeExpiresAt: now+15min`, send the email via SendGrid. Return `{ outcome: 'code_sent', via: 'osm_code', channel: 'email', masked: maskEmail(extratags.email) }`.
+5. **SMS fallback**: else if `extratags.phone` exists and `TWILIO_*` env vars are set, call Twilio Verify API. Same `pending_code` doc, `codeChannel: 'sms'`. Return `{ outcome: 'code_sent', via: 'osm_code', channel: 'sms', masked: maskPhone(extratags.phone) }`.
+6. **Manager-approval fallback**: else if the bar has at least one Manager+, write a `pending_manager` claim and notify Managers via FCM. Return `{ outcome: 'pending_manager' }`.
+7. **Dispute-window fallback**: else if `bars/{barId}/users` has fewer than 3 active users OR zero Managers, write a `pending_dispute` claim with `disputeClosesAt: now+7d` and post a pinned notice to the bar. Return `{ outcome: 'pending_dispute' }`.
+8. **Manual escalation**: else write a `pending_manual` claim. Return `{ outcome: 'pending_manual' }`.
+
+**Step 3: Write tests** for each branch using mocked OSM and SendGrid/Twilio clients.
+
+**Step 4: Commit**
+
+```bash
+git add functions/src/initiateOwnershipClaim.ts functions/src/osmLookup.ts functions/src/__tests__/initiateOwnershipClaim.test.ts functions/src/index.ts
+git commit -m "feat(functions): initiate ownership claim waterfall"
+```
+
+### Task I3: `verifyOwnershipCode` Cloud Function
+
+**Files:**
+- Create: `functions/src/verifyOwnershipCode.ts`
+- Create: `functions/src/__tests__/verifyOwnershipCode.test.ts`
+
+**Step 1: Implement.** Inputs: `{ claimId, code }`. Behavior:
+
+- Load claim. Check status `pending_code`, `codeExpiresAt > now`, `codeAttempts < 5`.
+- bcrypt-compare the code; on fail, increment `codeAttempts`.
+- On success: mark claim `approved`, `approvedVia: 'osm_code'`, then promote the claimant to Owner by writing `bars/{barId}/users/{claimantId}.role = 'Owner'` (server-side bypasses rules via admin SDK).
+
+**Step 2: Tests** for happy path, expired, max attempts, wrong code.
+
+**Step 3: Commit**
+
+```bash
+git add functions/src/verifyOwnershipCode.ts functions/src/__tests__/verifyOwnershipCode.test.ts functions/src/index.ts
+git commit -m "feat(functions): verify ownership code"
+```
+
+### Task I4: `approveOwnershipClaim` (Manager approval path)
+
+**Files:**
+- Create: `functions/src/approveOwnershipClaim.ts`
+- Create: `functions/src/__tests__/approveOwnershipClaim.test.ts`
+- Modify: `src/components/UsersDialog.tsx` — render pending Manager-approval claims in Pending tab.
+
+**Step 1: Implement** the callable: only callable by Manager+ on the target bar. Sets claim `approved` with `approvedVia: 'manager_approval'`, promotes claimant to Owner.
+
+**Step 2: Pending tab** renders both pending users AND pending Manager-route claims; "Approve" on a claim calls this function.
+
+**Step 3: Tests + commit**
+
+```bash
+git add functions/src/approveOwnershipClaim.ts functions/src/__tests__/approveOwnershipClaim.test.ts src/components/UsersDialog.tsx functions/src/index.ts
+git commit -m "feat(functions): manager-approved ownership claims"
+```
+
+### Task I5: Scheduled `closeExpiredClaims` Cloud Function
+
+**Files:**
+- Create: `functions/src/closeExpiredClaims.ts`
+- Create: `functions/src/__tests__/closeExpiredClaims.test.ts`
+
+**Step 1: Implement** scheduled Function (daily): query all `pending_dispute` claims where `disputeClosesAt < now`. If `disputedBy` is empty, approve with `approvedVia: 'dispute_window'`; else mark `rejected`.
+
+Also: expire `pending_code` claims that passed `codeExpiresAt`.
+
+**Step 2: Tests + commit**
+
+```bash
+git add functions/src/closeExpiredClaims.ts functions/src/__tests__/closeExpiredClaims.test.ts functions/src/index.ts
+git commit -m "feat(functions): scheduled claim resolver"
+```
+
+### Task I6: Dispute UI + endpoint
+
+**Files:**
+- Create: `functions/src/disputeOwnershipClaim.ts`
+- Modify: `src/App.tsx` — render an in-app banner when a claim is in `pending_dispute` for the user's bar.
+
+**Step 1: Implement** the callable: any bar member can dispute a `pending_dispute` claim. Adds their uid to `disputedBy`, immediately marks the claim `rejected`.
+
+**Step 2: Banner UI** in the marquee bar at `App.tsx:1632` (the existing notice marquee — still wired for Phase 1; replaced in Phase 2 but Phase 1 ships first). Banner copy: "{claimantName} is requesting Owner of this bar. Tap to dispute if you don't recognize them."
+
+**Step 3: Tests + commit**
+
+```bash
+git add functions/src/disputeOwnershipClaim.ts src/App.tsx functions/src/index.ts
+git commit -m "feat: ownership claim dispute UI + endpoint"
+```
+
+### Task I7: Manual-escalation backstop
+
+**Files:**
+- Modify: `src/components/ClaimOwnerDialog.tsx` — render the "submit a manual review request" copy + button when the initiate call returns `pending_manual`.
+- Modify: `functions/src/initiateOwnershipClaim.ts` — when `pending_manual`, send an email to `ADMIN_REVIEW_EMAIL` env var via SendGrid summarizing the claim.
+
+**Step 1: Implement, test, commit**
+
+```bash
+git add src/components/ClaimOwnerDialog.tsx functions/src/initiateOwnershipClaim.ts
+git commit -m "feat: manual claim escalation backstop"
+```
+
+### Task I8: Owner-self-relinquish
+
+**Files:**
+- Modify: `src/components/UsersDialog.tsx` — Owner viewing own row sees a "Step down as Owner" button.
+- Modify: `src/App.tsx` — handler writes `role: 'Manager'` on own user doc (rules allow self-write here).
+
+**Step 1: Confirm + commit**
+
+```bash
+git add src/components/UsersDialog.tsx src/App.tsx
+git commit -m "feat: owner self-relinquish"
+```
+
+---
+
+## Section J — Verification
+
+### Task J1: Full emulator end-to-end smoke
+
+**Step 1: Start emulators.**
+
+Run: `firebase emulators:start`
+
+**Step 2: Walk through the golden paths** in a browser:
+
+- Owner-less bar: Manager toggles `joinPolicy → approval`. Second user joins → pending. Manager approves → active.
+- Manager invites third user by email; third user signs in with that email → auto-active.
+- Manager-promoted to Manager kicks another Manager → succeeds.
+- Owner claim via OSM email code (test bar must have `osmId` with email contact); confirm code → claimant becomes Owner.
+- Manager attempts to demote Owner → rules reject.
+- Owner steps down → rules allow.
+- 86'd: Staff creates entry → rejected. Manager creates public entry → succeeds. Manager creates private entry (free bar) → rejected. Set bar subscription to premium → manager creates private entry → succeeds. Staff queries private entries → empty.
+
+**Step 3: Document any defects** in a follow-up `docs/plans/2026-05-21-phase-1-defects.md` and re-run failing tests.
+
+### Task J2: Deploy to a Firebase project
+
+**Step 1: Confirm `.firebaserc` has the right project ID.**
+
+**Step 2: Deploy rules + functions**
+
+Run: `firebase deploy --only firestore:rules,firestore:indexes,functions`
+
+**Step 3: Smoke-test the deployed app** (same golden paths as J1).
+
+**Step 4: Commit any post-deploy fixes; final tag.**
+
+```bash
+git tag -a phase-1-hardening -m "Phase 1: hardening complete"
+git push --tags
+```
+
+---
+
+## Notes for the executor
+
+- **TDD strictly** for Cloud Functions and rules — they're the highest-risk surface and the most expensive to debug after the fact.
+- **Don't skip the rules tests in D2/D3/D4.** Owner immunity in particular has 9+ permutations that are very easy to break with a one-character edit.
+- **Use the Firestore emulator** for all rule and Function tests. Do not test against the live project.
+- **SendGrid + Twilio are optional.** Both have free dev tiers; if you don't configure them, the related branches return `outcome: 'pending_manual'` immediately. That's acceptable for early dev.
+- **Don't write the manual-review back-office UI yet.** The Firebase console + a Firestore query is enough for the rare cases that hit it.
+- **The Phase 2 chat work assumes** rules already enforce `roleIn(barId)`, so don't postpone Section D.
+- **Reference design:** `docs/plans/2026-05-21-feature-set-purr-design.md`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -88,7 +88,12 @@ service cloud.firestore {
         allow update: if isOwner(barId) &&
           (resource.data.role != 'Owner' || request.auth.uid == userId);
 
-        allow delete: if isManagerPlus(barId) && resource.data.role != 'Owner';
+        // Self-delete (Leave Bar) is always allowed; Manager+ can
+        // delete any non-Owner.
+        allow delete: if isAuthed() && (
+          request.auth.uid == userId
+          || (isManagerPlus(barId) && resource.data.role != 'Owner')
+        );
       }
 
       // FCM tokens — strictly self.
@@ -123,9 +128,17 @@ service cloud.firestore {
       match /eightySixed/{entryId} {
         allow read: if (resource.data.visibility == 'public' && hasRole(barId))
                        || isManagerPlus(barId);
+        // Private entries are gated by the bar's premium
+        // subscription so non-paying bars can't store private
+        // moderator-only notes about patrons. The UI also hides the
+        // "private" toggle when isPremium is false, but the rules
+        // are the authority. Admins (isAdmin) bypass via isManagerPlus.
         allow create: if isManagerPlus(barId)
           && (request.resource.data.visibility == 'public'
-              || (request.resource.data.visibility == 'private' && hasRole(barId)));
+              || (request.resource.data.visibility == 'private'
+                  && (isAdmin()
+                      || get(/databases/$(database)/documents/bars/$(barId))
+                         .data.get('subscription', 'free') == 'premium')));
         allow update: if false;
         allow delete: if isManagerPlus(barId);
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,92 +3,164 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    function isAuthenticated() {
-      return request.auth != null;
-    }
+    function isAuthed() { return request.auth != null; }
 
-    // Admin claim. Set via `scripts/set-admin-claim.js`. Admins bypass
-    // membership checks for moderation and cross-bar operations.
+    // Admin claim. Set via `scripts/set-admin-claim.js`. Admins
+    // bypass per-bar role checks for moderation.
     function isAdmin() {
-      return isAuthenticated() && request.auth.token.admin == true;
+      return isAuthed() && request.auth.token.admin == true;
     }
 
-    // A user is a "member" of a bar if they have a profile document in
-    // that bar's users subcollection. Membership is established by the
-    // join flow in App.tsx (confirmRole writes to bars/{barId}/users/{uid}).
-    // Admins are treated as members of every bar.
-    function isMember(barId) {
-      return isAdmin() || (isAuthenticated()
-        && exists(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid)));
+    // Per-bar role claim. Stamped on the user's ID token by the
+    // onUserRoleChange Cloud Function. Returns the user's role
+    // ('Staff' | 'Manager' | 'Owner') for the given bar, or '' if
+    // they have none. The `bars` map is keyed by barId.
+    function roleIn(barId) {
+      return isAuthed() && 'bars' in request.auth.token
+        ? request.auth.token.bars.get(barId, '')
+        : '';
     }
 
-    // Global per-user document — self only. Holds joinedBars and other
-    // account-level data.
+    function hasRole(barId) { return isAdmin() || roleIn(barId) != ''; }
+    function isManagerPlus(barId) {
+      return isAdmin() || roleIn(barId) in ['Manager', 'Owner'];
+    }
+    function isOwner(barId) {
+      return isAdmin() || roleIn(barId) == 'Owner';
+    }
+
+    // Global /users/{userId} — self-only.
     match /users/{userId} {
-      allow read, write: if isAuthenticated() && request.auth.uid == userId;
+      allow read, write: if isAuthed() && request.auth.uid == userId;
     }
 
     // Bar documents.
     match /bars/{barId} {
       // Bars are discoverable by any signed-in user (search + join).
-      allow read: if isAuthenticated();
-      // Anyone signed in can claim a new bar (creates a verified or
-      // temporary bar via BarSearch).
-      allow create: if isAuthenticated();
-      // Only members can mutate the bar's settings (name, buttons,
-      // inventory, hiddenButtonIds, etc.).
-      allow update, delete: if isMember(barId);
+      allow read: if isAuthed();
+      // Anyone signed in can claim a new bar.
+      allow create: if isAuthed();
+      // Routine updates by Manager+.
+      allow update: if isManagerPlus(barId);
+      // Only Owners can delete.
+      allow delete: if isOwner(barId);
 
-      // Per-user profile within a bar — only the owning user can write
-      // their own doc.
+      // Per-bar user profile. Self-write is limited to operational
+      // fields so an attacker who controls a user's session can't
+      // self-promote by writing `role: 'Owner'`. Promotions go
+      // through the Manager update branch below, and the role claim
+      // is then stamped by the onUserRoleChange Cloud Function so
+      // these rules see it on the next request.
       match /users/{userId} {
-        allow read: if isAuthenticated()
-          && (request.auth.uid == userId || resource.data.status in ['active', 'pending']);
-        allow write: if isAuthenticated() && request.auth.uid == userId;
+        allow read: if hasRole(barId);
+
+        // Self-create on join. Role must be 'Staff' — higher roles
+        // only come from Manager/Owner promotion (post-join) or a
+        // Cloud Function (invite consumption). Status may be
+        // 'active' (open policy) or 'pending' (approval policy).
+        allow create: if isAuthed() && request.auth.uid == userId &&
+          request.resource.data.role == 'Staff' &&
+          (request.resource.data.status == 'active' ||
+           request.resource.data.status == 'pending');
+
+        // Self-write limited to safe operational fields. `status`
+        // may only be set to 'off_clock' (clocking out). The
+        // lastNoticeAt cooldown stamp is included so saveNotice's
+        // batched write succeeds.
+        allow write: if isAuthed() && request.auth.uid == userId &&
+          request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(['displayName', 'lastSeen', 'notificationPreferences',
+                      'ntfyTopic', 'email', 'status', 'lastNoticeAt']) &&
+          (!('status' in request.resource.data.diff(resource.data).affectedKeys()) ||
+           request.resource.data.status == 'off_clock');
+
+        // Managers can flip pending → active, set role for
+        // non-Owners, or kick non-Owners. They cannot promote to
+        // Owner, can't change their own role, can't touch existing
+        // Owners.
+        allow update: if isManagerPlus(barId) &&
+          resource.data.role != 'Owner' &&
+          request.resource.data.role != 'Owner' &&
+          request.auth.uid != userId;
+
+        // Owners can do anything to non-Owners and to themselves
+        // (self-relinquish only).
+        allow update: if isOwner(barId) &&
+          (resource.data.role != 'Owner' || request.auth.uid == userId);
+
+        allow delete: if isManagerPlus(barId) && resource.data.role != 'Owner';
       }
 
-      // FCM tokens — strictly self. Reads are server-side via the
-      // notification dispatcher (admin SDK bypasses rules); clients
-      // should never need to read another user's token.
+      // FCM tokens — strictly self.
       match /tokens/{userId} {
-        allow read, write: if isAuthenticated() && request.auth.uid == userId;
+        allow read, write: if isAuthed() && request.auth.uid == userId;
       }
 
-      // Notices (bulletin board) — readable by bar members; create
-      // must set authorId to the writer; any member may delete
-      // (matches the current marquee UX). Posts are rate-limited via
-      // the lastNoticeAt field on the writer's per-bar user doc:
-      // saveNotice writes a batch that creates the notice AND bumps
-      // lastNoticeAt = serverTimestamp(), so the rule below blocks
-      // bursts faster than once every 5s. Admins bypass via
-      // isMember/isAdmin and the default-when-missing read.
+      // Notices (bulletin board). Members read/write. Posts are
+      // rate-limited via lastNoticeAt on the writer's per-bar user
+      // doc — saveNotice writes a batch that creates the notice
+      // AND bumps lastNoticeAt = serverTimestamp(), so this rule
+      // blocks bursts faster than once every 5 seconds. Admins
+      // bypass via isAdmin.
       match /notices/{noticeId} {
-        allow read: if isMember(barId);
-        allow create: if isMember(barId)
+        allow read: if hasRole(barId);
+        allow create: if hasRole(barId)
           && request.resource.data.authorId == request.auth.uid
           && (
             isAdmin()
-            || request.time > get(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid)).data.get('lastNoticeAt', timestamp.value(0))
-              + duration.value(5, 's')
+            || request.time > get(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid))
+                                .data.get('lastNoticeAt', timestamp.value(0))
+                              + duration.value(5, 's')
           );
-        allow update: if isMember(barId)
+        allow update: if hasRole(barId)
           && resource.data.authorId == request.auth.uid;
-        allow delete: if isMember(barId);
+        allow delete: if hasRole(barId);
+      }
+
+      // 86'd list. Public entries readable by anyone with a role;
+      // private entries (gated by premium subscription) readable
+      // only by Manager+. Only Manager+ can create/delete.
+      match /eightySixed/{entryId} {
+        allow read: if (resource.data.visibility == 'public' && hasRole(barId))
+                       || isManagerPlus(barId);
+        allow create: if isManagerPlus(barId)
+          && (request.resource.data.visibility == 'public'
+              || (request.resource.data.visibility == 'private' && hasRole(barId)));
+        allow update: if false;
+        allow delete: if isManagerPlus(barId);
+      }
+
+      // Invites. Manager+ can read all; invitee can read their own.
+      // Consumption (flipping `consumed`) is the only update the
+      // invitee can do client-side.
+      match /invites/{inviteId} {
+        allow read: if isManagerPlus(barId) ||
+                       (isAuthed() && resource.data.email == request.auth.token.email);
+        allow create: if isManagerPlus(barId);
+        allow update: if isAuthed() && resource.data.email == request.auth.token.email &&
+                        request.resource.data.diff(resource.data).affectedKeys()
+                          .hasOnly(['consumed', 'consumedBy', 'consumedAt']);
+        allow delete: if isManagerPlus(barId);
+      }
+
+      // Ownership claims — writes flow through Cloud Functions only.
+      match /ownershipClaims/{claimId} {
+        allow read: if isManagerPlus(barId) ||
+                       (isAuthed() && resource.data.claimantId == request.auth.uid);
+        allow write: if false;
       }
     }
 
     // Requests — top-level collection, scoped by barId field.
     match /requests/{requestId} {
-      allow read: if isAuthenticated() && isMember(resource.data.barId);
-      allow create: if isAuthenticated()
-        && request.resource.data.requesterId == request.auth.uid
-        && isMember(request.resource.data.barId);
-      // Any member can claim/update a request in their bar.
-      allow update: if isAuthenticated() && isMember(resource.data.barId);
-      // Requester can cancel; any member can also clean up.
-      allow delete: if isAuthenticated() && (
+      allow read: if isAuthed() && hasRole(resource.data.barId);
+      allow create: if isAuthed()
+        && hasRole(request.resource.data.barId)
+        && request.resource.data.requesterId == request.auth.uid;
+      allow update: if isAuthed() && hasRole(resource.data.barId);
+      allow delete: if isAuthed() && (
         resource.data.requesterId == request.auth.uid
-        || isMember(resource.data.barId)
+        || isManagerPlus(resource.data.barId)
       );
     }
   }

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+lib/
+*.local

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,0 +1,4037 @@
+{
+  "name": "barbacker-functions",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "barbacker-functions",
+      "dependencies": {
+        "firebase-admin": "^12.0.0",
+        "firebase-functions": "^6.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "typescript": "^5.4.0",
+        "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": "20"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
+      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
+      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.10.0"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@types/node": "^22.0.1",
+        "farmhash-modern": "^1.1.0",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.3.1",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.7.0",
+        "@google-cloud/storage": "^7.7.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/firebase-functions": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
+      "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.5",
+        "@types/express": "^4.17.21",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "protobufjs": "^7.2.2"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
+      },
+      "engines": {
+        "node": ">=14.10.0"
+      },
+      "peerDependencies": {
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "barbacker-functions",
+  "private": true,
+  "main": "lib/index.js",
+  "engines": { "node": "20" },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "deploy": "firebase deploy --only functions",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^6.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^4.0.16",
+    "@types/node": "^20.10.0"
+  }
+}

--- a/functions/src/__tests__/onUserRoleChange.test.ts
+++ b/functions/src/__tests__/onUserRoleChange.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const setCustomUserClaims = vi.fn().mockResolvedValue(undefined);
+vi.mock("firebase-admin", () => ({
+  initializeApp: vi.fn(),
+  auth: () => ({ setCustomUserClaims })
+}));
+
+import { computeClaimsForUser } from "../onUserRoleChange";
+
+describe("computeClaimsForUser", () => {
+  beforeEach(() => setCustomUserClaims.mockClear());
+
+  it("aggregates roles across multiple bars", () => {
+    const userDocs = [
+      { barId: "bar_A", role: "Manager" },
+      { barId: "bar_B", role: "Owner" },
+      { barId: "bar_C", role: "Staff" }
+    ];
+    expect(computeClaimsForUser(userDocs)).toEqual({
+      bars: { bar_A: "Manager", bar_B: "Owner", bar_C: "Staff" }
+    });
+  });
+
+  it("returns empty object when user has no bars", () => {
+    expect(computeClaimsForUser([])).toEqual({ bars: {} });
+  });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,5 @@
+import * as admin from "firebase-admin";
+
+admin.initializeApp();
+
+export { onUserRoleChange } from "./onUserRoleChange";

--- a/functions/src/onUserRoleChange.ts
+++ b/functions/src/onUserRoleChange.ts
@@ -1,0 +1,53 @@
+import * as admin from "firebase-admin";
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+
+type UserRoleDoc = { barId: string; role: string };
+
+export function computeClaimsForUser(docs: UserRoleDoc[]): { bars: Record<string, string> } {
+  const bars: Record<string, string> = {};
+  for (const d of docs) bars[d.barId] = d.role;
+  return { bars };
+}
+
+/**
+ * Stamps the user's `bars` claim from their role docs on every write to a role
+ * doc under `bars/{barId}/users/{userId}`.
+ *
+ * Contract:
+ *   - This function OWNS the `bars` claim namespace. Other claim keys
+ *     (e.g. `subscription` set by Task H1) are preserved via merge.
+ *   - Deletion of a role doc effectively revokes the bar's claim (the bar
+ *     drops out of the aggregated map).
+ *   - The triggering `barId` is always included in the enumeration so that
+ *     races against `users/{uid}.joinedBars` writes do not produce stale claims.
+ */
+export const onUserRoleChange = onDocumentWritten(
+  "bars/{barId}/users/{userId}",
+  async (event) => {
+    const userId = event.params.userId;
+    const triggeringBarId = event.params.barId;
+    const db = admin.firestore();
+    const userDoc = await db.collection("users").doc(userId).get();
+    const joinedBars: string[] = (userDoc.data()?.joinedBars as string[]) ?? [];
+    const barIds = Array.from(new Set([triggeringBarId, ...joinedBars]));
+    const docs: UserRoleDoc[] = [];
+    await Promise.all(barIds.map(async (barId) => {
+      const u = await db.doc(`bars/${barId}/users/${userId}`).get();
+      const role = u.data()?.role;
+      if (u.exists && typeof role === "string") {
+        docs.push({ barId, role });
+      }
+    }));
+    const { bars } = computeClaimsForUser(docs);
+    let existingClaims: Record<string, unknown> = {};
+    try {
+      const userRecord = await admin.auth().getUser(userId);
+      existingClaims = userRecord.customClaims ?? {};
+    } catch (err: any) {
+      // If the auth user doesn't exist yet, treat existing claims as empty.
+      if (err?.code !== "auth/user-not-found") throw err;
+    }
+    const merged = { ...existingClaims, bars };
+    await admin.auth().setCustomUserClaims(userId, merged);
+  }
+);

--- a/functions/src/onUserRoleChange.ts
+++ b/functions/src/onUserRoleChange.ts
@@ -40,14 +40,23 @@ export const onUserRoleChange = onDocumentWritten(
     }));
     const { bars } = computeClaimsForUser(docs);
     let existingClaims: Record<string, unknown> = {};
+    let userExists = true;
     try {
       const userRecord = await admin.auth().getUser(userId);
       existingClaims = userRecord.customClaims ?? {};
     } catch (err: any) {
-      // If the auth user doesn't exist yet, treat existing claims as empty.
-      if (err?.code !== "auth/user-not-found") throw err;
+      if (err?.code === "auth/user-not-found") {
+        // User deleted from Auth (or race during user creation).
+        // Skip the claim write entirely — setCustomUserClaims would
+        // also throw auth/user-not-found and crash the trigger.
+        userExists = false;
+      } else {
+        throw err;
+      }
     }
-    const merged = { ...existingClaims, bars };
-    await admin.auth().setCustomUserClaims(userId, merged);
+    if (userExists) {
+      const merged = { ...existingClaims, bars };
+      await admin.auth().setCustomUserClaims(userId, merged);
+    }
   }
 );

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   serverTimestamp,
   setDoc,
   getDoc,
+  addDoc,
   deleteDoc,
   arrayUnion,
   arrayRemove,
@@ -65,15 +66,18 @@ import '@material/web/menu/menu.js';
 import '@material/web/menu/menu-item.js';
 
 // Import Types and Constants.
-import { Bar, ButtonConfig, Request, Notice, BarUser } from './types';
+import { Bar, BarTheme, ButtonConfig, Request, Notice, BarUser, EightySixEntry } from './types';
 import { DEFAULT_BUTTONS, ROLE_NOTIFICATION_DEFAULTS, DEFAULT_BEERS } from './constants';
 // Import Custom Hooks.
 import { useNag } from './hooks/useNag';
+import { useBarTheme } from './hooks/useBarTheme';
 // Import UI Components.
 import BarSearch from './components/BarSearch';
 import RoleSelector from './components/RoleSelector';
 import NotificationSettings from './components/NotificationSettings';
 import BarManager from './components/BarManager';
+import EightySixDialog from './components/EightySixDialog';
+import ThemeEditor from './components/ThemeEditor';
 import InputDialog from './components/InputDialog';
 import { WhoIsOnDialog } from './components/WhoIsOnDialog';
 import { SortableButton } from './components/SortableButton';
@@ -300,8 +304,26 @@ function App() {
     }
   });
 
-  // Admin / god-mode gate.
+  // Admin / god-mode gate (custom claim on the user's ID token).
   const isGodMode = useGodMode(user);
+
+  // Bar-level subscription tier + custom theme. Both populated from
+  // the bar listener below.
+  const [barSubscription, setBarSubscription] = useState<'free' | 'premium'>('free');
+  const [barTheme, setBarTheme] = useState<BarTheme | undefined>(undefined);
+
+  // Premium gating. Admins (god mode) always count as premium for
+  // moderation purposes; otherwise the bar must be on the premium
+  // tier.
+  const isPremium = isGodMode || barSubscription === 'premium';
+
+  // Apply the custom bar theme to the document root when premium.
+  useBarTheme(barTheme, isPremium);
+
+  // 86'd list state and dialog visibility.
+  const [eightySixEntries, setEightySixEntries] = useState<EightySixEntry[]>([]);
+  const [showEightySixDialog, setShowEightySixDialog] = useState(false);
+  const [showThemeEditor, setShowThemeEditor] = useState(false);
 
   // Joined bars + their display names + the account-level ntfy topic
   // — all driven by the global users/{uid} document.
@@ -374,6 +396,8 @@ function App() {
         if (data.hiddenButtonIds) setHiddenButtonIds(data.hiddenButtonIds);
         if (data.buttonUsage) setButtonUsage(data.buttonUsage);
         if (data.customOrders) setCustomOrders(data.customOrders);
+        setBarSubscription(data.subscription || 'free');
+        setBarTheme(data.theme);
       }
     });
 
@@ -432,6 +456,24 @@ function App() {
 
     return () => { unsubReq(); unsubNotices(); };
   }, [user, barId, windowEpoch]);
+
+  // 86'd list listener. Public entries are visible to anyone with a
+  // role; private entries (gated by premium subscription) are only
+  // visible to Owner/Manager. Switching the query shape based on the
+  // caller's permission is what keeps a tighter rule on the read
+  // side and avoids the client even attempting a private read it
+  // can't decode.
+  useEffect(() => {
+    if (!barId) return;
+    const canSeePrivate = isPremium && (userRole === 'Owner' || userRole === 'Manager');
+    const q = canSeePrivate
+      ? query(collection(db, `bars/${barId}/eightySixed`), orderBy('timestamp', 'desc'), limit(200))
+      : query(collection(db, `bars/${barId}/eightySixed`), where('visibility', '==', 'public'), orderBy('timestamp', 'desc'), limit(200));
+    const unsub = onSnapshot(q, (s) => {
+      setEightySixEntries(s.docs.map(d => ({ id: d.id, ...d.data() } as EightySixEntry)));
+    });
+    return () => unsub();
+  }, [barId, isPremium, userRole]);
 
   // Mirror globalNtfyTopic into the per-bar user doc whenever the
   // account-level topic changes. The per-bar user snapshot above also
@@ -564,13 +606,41 @@ function App() {
     setHiddenButtonIds(prev => [...prev, btnId]);
   };
 
-  // Unhide a button (God Mode only).
+  // Unhide a button (premium only).
   const unhideButton = async (btnId: string) => {
     if (!user || !barId) return;
     await updateDoc(doc(db, 'bars', barId), {
         hiddenButtonIds: arrayRemove(btnId)
     });
     setHiddenButtonIds(prev => prev.filter(id => id !== btnId));
+  };
+
+  // Add a person to the 86'd list. Visibility decides whether all
+  // staff with a role can see the entry ('public') or only Manager+
+  // ('private', gated by the premium subscription).
+  const addEightySixEntry = async (patronName: string, reason?: string, visibility: 'public' | 'private' = 'public') => {
+    if (!user || !barId || !patronName.trim()) return;
+    await addDoc(collection(db, `bars/${barId}/eightySixed`), {
+      patronName: patronName.trim(),
+      submittedBy: user.uid,
+      submitterName: displayName,
+      visibility,
+      ...(reason ? { reason } : {}),
+      timestamp: serverTimestamp(),
+    });
+  };
+
+  // Remove an entry from the 86'd list (Manager+ only via rules).
+  const deleteEightySixEntry = async (entryId: string) => {
+    if (!user || !barId) return;
+    await deleteDoc(doc(db, `bars/${barId}/eightySixed`, entryId));
+  };
+
+  // Save the bar's custom theme. Gated to Manager+ via rules; the UI
+  // hides the entry point unless isPremium.
+  const saveBarTheme = async (theme: BarTheme) => {
+    if (!barId) return;
+    await updateDoc(doc(db, 'bars', barId), { theme });
   };
 
   // Notice-board write actions + dialog form state.
@@ -1041,9 +1111,30 @@ function App() {
         allButtons={sortedAllButtons}
         hiddenButtonIds={hiddenButtonIds}
         onHideButton={hideButton}
-        godMode={isGodMode}
+        isPremium={isPremium}
         onUnhideButton={unhideButton}
       />
+
+      <EightySixDialog
+        open={showEightySixDialog}
+        onClose={() => setShowEightySixDialog(false)}
+        entries={eightySixEntries}
+        onAdd={addEightySixEntry}
+        onDelete={deleteEightySixEntry}
+        isPremium={isPremium}
+        userRole={userRole}
+        currentUserId={user?.uid}
+      />
+
+      {isPremium && (
+        <ThemeEditor
+          open={showThemeEditor}
+          onClose={() => setShowThemeEditor(false)}
+          currentTheme={barTheme}
+          onSave={saveBarTheme}
+          barId={barId!}
+        />
+      )}
 
       <WhoIsOnDialog
         open={showWhoIsOn}
@@ -1156,11 +1247,21 @@ function App() {
         {/* Right Side Actions */}
         <div className="flex items-center gap-6 mr-4 flex-wrap justify-end">
            {/* Bar Name (Hidden on small screens) */}
-           <span className="font-bold text-xl text-white tracking-wide hidden sm:block">{barName}</span>
+           <span className="font-bold text-xl text-white tracking-wide hidden sm:flex items-center gap-2">
+             {barTheme?.logoUrl && isPremium && (
+               <img src={barTheme.logoUrl} alt={barName} className="h-8 w-8 rounded-full object-cover" />
+             )}
+             {barName}
+           </span>
 
            {/* Bar Manager Button (Visible on small screens) */}
            <md-text-button onClick={() => setShowBarManager(true)} className="sm:hidden">
-             <span className="font-bold text-lg text-white tracking-wide">{barName}</span>
+             <span className="font-bold text-lg text-white tracking-wide flex items-center gap-2">
+               {barTheme?.logoUrl && isPremium && (
+                 <img src={barTheme.logoUrl} alt={barName} className="h-6 w-6 rounded-full object-cover" />
+               )}
+               {barName}
+             </span>
            </md-text-button>
 
            <div className="flex gap-4 items-center">
@@ -1201,6 +1302,12 @@ function App() {
                             <md-icon slot="start">store</md-icon>
                             <div slot="headline">Manage Bar</div>
                         </md-menu-item>
+                        {isPremium && (userRole === 'Owner' || userRole === 'Manager') && (
+                          <md-menu-item onClick={() => setShowThemeEditor(true)}>
+                              <md-icon slot="start">palette</md-icon>
+                              <div slot="headline">Customize Theme</div>
+                          </md-menu-item>
+                        )}
                         <md-menu-item onClick={handleShare}>
                             <md-icon slot="start">share</md-icon>
                             <div slot="headline">Share</div>
@@ -1208,6 +1315,10 @@ function App() {
                         <md-menu-item onClick={() => setShowWhoIsOn(true)}>
                             <md-icon slot="start">group</md-icon>
                             <div slot="headline">Who's On</div>
+                        </md-menu-item>
+                        <md-menu-item onClick={() => setShowEightySixDialog(true)}>
+                            <md-icon slot="start">block</md-icon>
+                            <div slot="headline">86'd List</div>
                         </md-menu-item>
                         <md-menu-item onClick={() => { setIsAddingNotice(true); setNoticeError(null); }}>
                             <md-icon slot="start">campaign</md-icon>

--- a/src/components/BarManager.test.tsx
+++ b/src/components/BarManager.test.tsx
@@ -70,7 +70,7 @@ describe('BarManager', () => {
     expect(screen.getByText('Hidden Button B')).toBeDefined();
   });
 
-  it('renders restorable buttons when in God Mode', () => {
+  it('renders restorable buttons when premium', () => {
     const onHide = vi.fn();
     const onClose = vi.fn();
     const onUnhide = vi.fn();
@@ -83,13 +83,13 @@ describe('BarManager', () => {
         allButtons={buttons}
         hiddenButtonIds={['2']}
         onHideButton={onHide}
-        godMode={true}
+        isPremium={true}
         onUnhideButton={onUnhide}
       />
     );
 
     // Should show the hidden button in the "Restorable" section
-    expect(screen.getByText('Restorable Buttons (God Mode)')).toBeDefined();
+    expect(screen.getByText('Restorable Buttons (Premium)')).toBeDefined();
     expect(screen.getByText('Hidden Button B')).toBeDefined();
   });
 });

--- a/src/components/BarManager.tsx
+++ b/src/components/BarManager.tsx
@@ -28,15 +28,15 @@ interface BarManagerProps {
   hiddenButtonIds: string[];
   // Callback function to hide a button.
   onHideButton: (id: string) => void;
-  // Boolean indicating if God Mode (paid features) is enabled.
-  godMode?: boolean;
+  // Boolean indicating if the bar has premium features enabled.
+  isPremium?: boolean;
   // Callback function to unhide/restore a button.
   onUnhideButton?: (id: string) => void;
 }
 
 // The BarManager component provides an interface for managers to configure which buttons are visible on the dashboard.
 // Currently, it only supports "hiding" (soft deleting) buttons.
-const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHideButton, godMode, onUnhideButton }: BarManagerProps) => {
+const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHideButton, isPremium, onUnhideButton }: BarManagerProps) => {
   // State to track the ID of the button currently selected for deletion confirmation.
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
@@ -49,7 +49,7 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
     return allButtons.filter(b => !hiddenButtonSet.has(b.id));
   }, [allButtons, hiddenButtonSet]);
 
-  // Compute the list of hidden buttons (for God Mode restoration).
+  // Compute the list of hidden buttons (for premium restoration).
   const hiddenButtons = useMemo(() => {
     return allButtons.filter(b => hiddenButtonSet.has(b.id));
   }, [allButtons, hiddenButtonSet]);
@@ -104,10 +104,10 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
                 </md-list>
            </div>
 
-           {/* Hidden Buttons (God Mode Only) */}
-           {godMode && hiddenButtons.length > 0 && (
+           {/* Hidden Buttons (Premium Only) */}
+           {isPremium && hiddenButtons.length > 0 && (
                <div className="mt-4 border border-red-800 rounded overflow-y-auto max-h-[30vh]">
-                   <div className="bg-red-900/20 p-2 text-xs font-bold text-red-400 uppercase">Restorable Buttons (God Mode)</div>
+                   <div className="bg-red-900/20 p-2 text-xs font-bold text-red-400 uppercase">Restorable Buttons (Premium)</div>
                    <md-list>
                        {hiddenButtons.map(btn => (
                            <md-list-item key={btn.id}>

--- a/src/components/EightySixDialog.test.tsx
+++ b/src/components/EightySixDialog.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import EightySixDialog from './EightySixDialog';
+import type { EightySixEntry } from '../types';
+
+const mockEntries: EightySixEntry[] = [
+  {
+    id: '1',
+    patronName: 'John Doe',
+    submittedBy: 'user1',
+    submitterName: 'Manager Mike',
+    visibility: 'public',
+    timestamp: { toDate: () => new Date('2026-01-15'), seconds: 0 } as any,
+  },
+  {
+    id: '2',
+    patronName: 'Jane Smith',
+    submittedBy: 'user2',
+    submitterName: 'Manager Mike',
+    reason: 'Aggressive behavior',
+    visibility: 'private',
+    timestamp: { toDate: () => new Date('2026-01-16'), seconds: 0 } as any,
+  },
+];
+
+describe('EightySixDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    entries: mockEntries,
+    onAdd: vi.fn().mockResolvedValue(undefined),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    isPremium: false,
+    userRole: 'Bartender' as string | null,
+    currentUserId: 'user3',
+  };
+
+  it('renders public entries for all users', () => {
+    render(<EightySixDialog {...defaultProps} entries={[mockEntries[0]]} />);
+    expect(screen.getByText('John Doe')).toBeDefined();
+    expect(screen.getByText(/Manager Mike/)).toBeDefined();
+  });
+
+  it('shows upsell banner for free-tier users', () => {
+    render(<EightySixDialog {...defaultProps} />);
+    expect(screen.getByText(/Upgrade to Premium/)).toBeDefined();
+  });
+
+  it('hides upsell banner for premium users', () => {
+    render(<EightySixDialog {...defaultProps} isPremium={true} userRole="Owner" />);
+    expect(screen.queryByText(/Upgrade to Premium/)).toBeNull();
+  });
+
+  it('shows add button only for Owner/Manager', () => {
+    const { rerender } = render(<EightySixDialog {...defaultProps} userRole="Bartender" />);
+    expect(screen.queryByText('Add Person')).toBeNull();
+
+    rerender(<EightySixDialog {...defaultProps} userRole="Owner" />);
+    expect(screen.getByText('Add Person')).toBeDefined();
+
+    rerender(<EightySixDialog {...defaultProps} userRole="Manager" />);
+    expect(screen.getByText('Add Person')).toBeDefined();
+  });
+
+  it('shows private entry details for premium Owner/Manager', () => {
+    render(<EightySixDialog {...defaultProps} isPremium={true} userRole="Owner" />);
+    expect(screen.getByText('Jane Smith')).toBeDefined();
+    expect(screen.getByText('Aggressive behavior')).toBeDefined();
+  });
+
+  it('shows empty state when no entries', () => {
+    render(<EightySixDialog {...defaultProps} entries={[]} />);
+    expect(screen.getByText(/No one on the 86'd list/)).toBeDefined();
+  });
+
+  it('shows add form when Add Person is clicked', () => {
+    render(<EightySixDialog {...defaultProps} userRole="Owner" />);
+    fireEvent.click(screen.getByText('Add Person'));
+    expect(screen.getByText('Add')).toBeDefined();
+  });
+
+  it('shows private toggle only for premium Owner/Manager in add form', () => {
+    render(<EightySixDialog {...defaultProps} userRole="Owner" isPremium={true} />);
+    fireEvent.click(screen.getByText('Add Person'));
+    expect(screen.getByText(/Private entry/)).toBeDefined();
+  });
+
+  it('hides private toggle for non-premium users in add form', () => {
+    render(<EightySixDialog {...defaultProps} userRole="Owner" isPremium={false} />);
+    fireEvent.click(screen.getByText('Add Person'));
+    expect(screen.queryByText(/Private entry/)).toBeNull();
+  });
+});

--- a/src/components/EightySixDialog.tsx
+++ b/src/components/EightySixDialog.tsx
@@ -46,6 +46,9 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
       setReason('');
       setIsPrivate(false);
       setShowAddForm(false);
+    } catch (err) {
+      console.error('Failed to add 86d entry:', err);
+      alert('Failed to add entry. Please try again.');
     } finally {
       setSubmitting(false);
     }
@@ -53,14 +56,28 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
 
   const handleDelete = async () => {
     if (!confirmDeleteId) return;
-    await onDelete(confirmDeleteId);
-    setConfirmDeleteId(null);
+    try {
+      await onDelete(confirmDeleteId);
+    } catch (err) {
+      console.error('Failed to delete 86d entry:', err);
+      alert('Failed to delete entry. Please try again.');
+    } finally {
+      setConfirmDeleteId(null);
+    }
   };
 
-  const formatDate = (ts: any) => {
-    if (!ts) return '';
-    const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
-    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  // Robust against Firestore FieldValue (which has neither toDate
+  // nor a numeric seconds) seen during optimistic local writes.
+  const formatDate = (ts: { toDate?: () => Date; seconds?: number } | unknown) => {
+    if (!ts || typeof ts !== 'object') return '';
+    const t = ts as { toDate?: () => Date; seconds?: number };
+    if (typeof t.toDate === 'function') {
+      return t.toDate().toLocaleDateString([], { month: 'short', day: 'numeric' });
+    }
+    if (typeof t.seconds === 'number') {
+      return new Date(t.seconds * 1000).toLocaleDateString([], { month: 'short', day: 'numeric' });
+    }
+    return '';
   };
 
   return (

--- a/src/components/EightySixDialog.tsx
+++ b/src/components/EightySixDialog.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+
+import '@material/web/dialog/dialog.js';
+import '@material/web/button/text-button.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/button/filled-tonal-button.js';
+import '@material/web/icon/icon.js';
+import '@material/web/iconbutton/icon-button.js';
+import '@material/web/list/list.js';
+import '@material/web/list/list-item.js';
+import '@material/web/textfield/filled-text-field.js';
+import '@material/web/switch/switch.js';
+
+import type { EightySixEntry } from '../types';
+
+interface EightySixDialogProps {
+  open: boolean;
+  onClose: () => void;
+  entries: EightySixEntry[];
+  onAdd: (patronName: string, reason?: string, visibility?: 'public' | 'private') => Promise<void>;
+  onDelete: (entryId: string) => Promise<void>;
+  isPremium: boolean;
+  userRole: string | null;
+  currentUserId?: string;
+}
+
+const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, userRole }: EightySixDialogProps) => {
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [patronName, setPatronName] = useState('');
+  const [reason, setReason] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const isManager = userRole === 'Owner' || userRole === 'Manager';
+  const canAdd = isManager;
+  const canDelete = isManager;
+
+  const handleSubmit = async () => {
+    if (!patronName.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      const visibility = isPrivate ? 'private' : 'public';
+      await onAdd(patronName.trim(), isPrivate && reason.trim() ? reason.trim() : undefined, visibility);
+      setPatronName('');
+      setReason('');
+      setIsPrivate(false);
+      setShowAddForm(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDeleteId) return;
+    await onDelete(confirmDeleteId);
+    setConfirmDeleteId(null);
+  };
+
+  const formatDate = (ts: any) => {
+    if (!ts) return '';
+    const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  };
+
+  return (
+    <>
+      <md-dialog open={open || undefined} onClose={onClose} style={{ maxHeight: '85vh' }}>
+        <div slot="headline" className="flex items-center gap-2">
+          <md-icon>block</md-icon>
+          86'd List
+          <span className="text-sm text-gray-400 ml-1">({entries.length})</span>
+        </div>
+
+        <div slot="content" className="flex flex-col gap-3 min-w-[300px]">
+          {/* Upsell banner for free-tier users */}
+          {!isPremium && (
+            <div className="bg-yellow-900/20 border border-yellow-800 rounded p-2 text-xs text-yellow-400">
+              Upgrade to Premium to add private notes and reasons.
+            </div>
+          )}
+
+          {/* Add button for managers */}
+          {canAdd && !showAddForm && (
+            <md-filled-tonal-button onClick={() => setShowAddForm(true)} style={{ width: '100%' }}>
+              <md-icon slot="icon">person_add</md-icon>
+              Add Person
+            </md-filled-tonal-button>
+          )}
+
+          {/* Add form */}
+          {canAdd && showAddForm && (
+            <div className="border border-gray-700 rounded p-3 flex flex-col gap-3">
+              <md-filled-text-field
+                label="Patron Name"
+                value={patronName}
+                onInput={(e: any) => setPatronName(e.target.value)}
+                style={{ width: '100%' }}
+              />
+
+              {/* Private entry options - premium only */}
+              {isPremium && (
+                <>
+                  <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                    <md-switch
+                      selected={isPrivate || undefined}
+                      onInput={(e: any) => setIsPrivate(e.target.selected)}
+                    />
+                    Private entry (hidden from non-managers)
+                  </label>
+
+                  {isPrivate && (
+                    <md-filled-text-field
+                      label="Reason (private)"
+                      value={reason}
+                      onInput={(e: any) => setReason(e.target.value)}
+                      type="textarea"
+                      rows={2}
+                      style={{ width: '100%' }}
+                    />
+                  )}
+                </>
+              )}
+
+              <div className="flex gap-2 justify-end">
+                <md-text-button onClick={() => { setShowAddForm(false); setPatronName(''); setReason(''); setIsPrivate(false); }}>
+                  Cancel
+                </md-text-button>
+                <md-filled-button onClick={handleSubmit} disabled={!patronName.trim() || submitting || undefined}>
+                  {submitting ? 'Adding...' : 'Add'}
+                </md-filled-button>
+              </div>
+            </div>
+          )}
+
+          {/* Entry list */}
+          <div className="border border-gray-800 rounded overflow-y-auto max-h-[50vh]">
+            {entries.length === 0 ? (
+              <div className="p-4 text-center text-gray-500">No one on the 86'd list.</div>
+            ) : (
+              <md-list>
+                {entries.map(entry => (
+                  <md-list-item key={entry.id}>
+                    <div slot="headline" className="flex items-center gap-2">
+                      {entry.visibility === 'private' && <md-icon style={{ fontSize: '16px' }}>lock</md-icon>}
+                      <span className="font-medium">{entry.patronName}</span>
+                    </div>
+                    <div slot="supporting-text">
+                      <span>Submitted by {entry.submitterName}</span>
+                      <span className="mx-1">&middot;</span>
+                      <span>{formatDate(entry.timestamp)}</span>
+                      {entry.visibility === 'private' && entry.reason && (
+                        <div className="text-yellow-400/80 mt-1 text-xs italic">{entry.reason}</div>
+                      )}
+                    </div>
+                    {canDelete && (
+                      <md-icon-button slot="end" onClick={() => setConfirmDeleteId(entry.id)}>
+                        <md-icon>close</md-icon>
+                      </md-icon-button>
+                    )}
+                  </md-list-item>
+                ))}
+              </md-list>
+            )}
+          </div>
+        </div>
+
+        <div slot="actions">
+          <md-text-button onClick={onClose}>Close</md-text-button>
+        </div>
+      </md-dialog>
+
+      {/* Delete confirmation dialog */}
+      <md-dialog open={!!confirmDeleteId || undefined} onClose={() => setConfirmDeleteId(null)}>
+        <div slot="headline">Remove from 86'd List?</div>
+        <div slot="content">
+          Are you sure you want to remove this person from the 86'd list?
+        </div>
+        <div slot="actions">
+          <md-text-button onClick={() => setConfirmDeleteId(null)}>Cancel</md-text-button>
+          <md-filled-button onClick={handleDelete} className="btn-alert">Remove</md-filled-button>
+        </div>
+      </md-dialog>
+    </>
+  );
+};
+
+export default EightySixDialog;

--- a/src/components/ThemeEditor.test.tsx
+++ b/src/components/ThemeEditor.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ThemeEditor from './ThemeEditor';
+import type { BarTheme } from '../types';
+
+// Mock Firebase Storage
+vi.mock('../firebase', () => ({
+  storage: {},
+}));
+vi.mock('firebase/storage', () => ({
+  ref: vi.fn(),
+  uploadBytes: vi.fn().mockResolvedValue({}),
+  getDownloadURL: vi.fn().mockResolvedValue('https://example.com/logo.png'),
+}));
+
+describe('ThemeEditor', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    currentTheme: undefined as BarTheme | undefined,
+    onSave: vi.fn().mockResolvedValue(undefined),
+    barId: 'test-bar-id',
+  };
+
+  it('renders with default values when no theme is set', () => {
+    render(<ThemeEditor {...defaultProps} />);
+    expect(screen.getByText('Customize Theme')).toBeDefined();
+    expect(screen.getByText('Primary Color')).toBeDefined();
+    expect(screen.getByText('Accent Color')).toBeDefined();
+    expect(screen.getByText('Font')).toBeDefined();
+    expect(screen.getByText('Logo')).toBeDefined();
+  });
+
+  it('renders the live preview section', () => {
+    render(<ThemeEditor {...defaultProps} />);
+    expect(screen.getByText('Preview')).toBeDefined();
+    expect(screen.getByText('Your Bar Name')).toBeDefined();
+    expect(screen.getByText('Sample Button')).toBeDefined();
+  });
+
+  it('renders with current theme values', () => {
+    const theme: BarTheme = {
+      primaryColor: '#FF5722',
+      accentColor: '#03A9F4',
+      logoUrl: 'https://example.com/logo.png',
+      fontFamily: 'Inter, sans-serif',
+    };
+    render(<ThemeEditor {...defaultProps} currentTheme={theme} />);
+    // Logo preview should be visible
+    const logoImg = screen.getByAltText('Logo');
+    expect(logoImg).toBeDefined();
+  });
+
+  it('shows save and reset buttons', () => {
+    render(<ThemeEditor {...defaultProps} />);
+    expect(screen.getByText('Save')).toBeDefined();
+    expect(screen.getByText('Reset')).toBeDefined();
+    expect(screen.getByText('Cancel')).toBeDefined();
+  });
+
+  it('shows remove button when logo URL exists', () => {
+    const theme: BarTheme = {
+      primaryColor: '#FFFFFF',
+      accentColor: '#1E1E1E',
+      logoUrl: 'https://example.com/logo.png',
+    };
+    render(<ThemeEditor {...defaultProps} currentTheme={theme} />);
+    expect(screen.getByText('Remove')).toBeDefined();
+  });
+});

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -55,6 +55,9 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
     if (!file) return;
     if (file.size > 2 * 1024 * 1024) {
       alert('Logo must be under 2MB.');
+      // Clear the input so a same-file retry after fixing the size
+      // still fires onChange.
+      e.target.value = '';
       return;
     }
     setUploading(true);
@@ -69,6 +72,9 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
       alert('Failed to upload logo.');
     } finally {
       setUploading(false);
+      // Reset the file input so re-uploading the same file after a
+      // delete or a failed upload re-fires onChange.
+      e.target.value = '';
     }
   };
 
@@ -82,6 +88,9 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
         ...(logoUrl ? { logoUrl } : {}),
       });
       onClose();
+    } catch (err) {
+      console.error('Failed to save theme:', err);
+      alert('Failed to save theme. Please try again.');
     } finally {
       setSaving(false);
     }
@@ -91,14 +100,15 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
     if (!confirm('Reset theme to default? This removes all custom branding.')) return;
     setSaving(true);
     try {
-      // Save an empty-ish theme to clear it. The updateDoc in App.tsx will overwrite.
-      // Actually we need to delete the theme field. For now, save defaults.
       await onSave({ primaryColor: '#FFFFFF', accentColor: '#1E1E1E' });
       setPrimaryColor('#FFFFFF');
       setAccentColor('#1E1E1E');
       setFontFamily('system-ui, sans-serif');
       setLogoUrl(undefined);
       onClose();
+    } catch (err) {
+      console.error('Failed to reset theme:', err);
+      alert('Failed to reset theme. Please try again.');
     } finally {
       setSaving(false);
     }

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect } from 'react';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { storage } from '../firebase';
+
+import '@material/web/dialog/dialog.js';
+import '@material/web/button/text-button.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/icon/icon.js';
+import '@material/web/progress/circular-progress.js';
+
+import type { BarTheme } from '../types';
+import { getContrastColor } from '../utils/color';
+
+const FONT_OPTIONS = [
+  { label: 'System Default', value: 'system-ui, sans-serif' },
+  { label: 'Roboto', value: 'Roboto, sans-serif' },
+  { label: 'Inter', value: 'Inter, sans-serif' },
+  { label: 'Playfair Display', value: '"Playfair Display", serif' },
+];
+
+interface ThemeEditorProps {
+  open: boolean;
+  onClose: () => void;
+  currentTheme: BarTheme | undefined;
+  onSave: (theme: BarTheme) => Promise<void>;
+  barId: string;
+}
+
+const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditorProps) => {
+  const [primaryColor, setPrimaryColor] = useState('#FFFFFF');
+  const [accentColor, setAccentColor] = useState('#1E1E1E');
+  const [fontFamily, setFontFamily] = useState('system-ui, sans-serif');
+  const [logoUrl, setLogoUrl] = useState<string | undefined>(undefined);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Sync state from currentTheme when dialog opens.
+  useEffect(() => {
+    if (open && currentTheme) {
+      setPrimaryColor(currentTheme.primaryColor || '#FFFFFF');
+      setAccentColor(currentTheme.accentColor || '#1E1E1E');
+      setFontFamily(currentTheme.fontFamily || 'system-ui, sans-serif');
+      setLogoUrl(currentTheme.logoUrl);
+    } else if (open && !currentTheme) {
+      setPrimaryColor('#FFFFFF');
+      setAccentColor('#1E1E1E');
+      setFontFamily('system-ui, sans-serif');
+      setLogoUrl(undefined);
+    }
+  }, [open, currentTheme]);
+
+  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      alert('Logo must be under 2MB.');
+      return;
+    }
+    setUploading(true);
+    try {
+      const ext = file.name.split('.').pop() || 'png';
+      const storageRef = ref(storage, `bars/${barId}/logo.${ext}`);
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+      setLogoUrl(url);
+    } catch (err) {
+      console.error('Logo upload failed:', err);
+      alert('Failed to upload logo.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave({
+        primaryColor,
+        accentColor,
+        fontFamily,
+        ...(logoUrl ? { logoUrl } : {}),
+      });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!confirm('Reset theme to default? This removes all custom branding.')) return;
+    setSaving(true);
+    try {
+      // Save an empty-ish theme to clear it. The updateDoc in App.tsx will overwrite.
+      // Actually we need to delete the theme field. For now, save defaults.
+      await onSave({ primaryColor: '#FFFFFF', accentColor: '#1E1E1E' });
+      setPrimaryColor('#FFFFFF');
+      setAccentColor('#1E1E1E');
+      setFontFamily('system-ui, sans-serif');
+      setLogoUrl(undefined);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const contrastColor = getContrastColor(primaryColor);
+
+  return (
+    <md-dialog open={open || undefined} onClose={onClose} style={{ maxHeight: '85vh' }}>
+      <div slot="headline" className="flex items-center gap-2">
+        <md-icon>palette</md-icon>
+        Customize Theme
+      </div>
+
+      <div slot="content" className="flex flex-col gap-4 min-w-[300px]">
+        {/* Primary Color */}
+        <div className="flex items-center justify-between">
+          <label className="text-sm text-gray-300">Primary Color</label>
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded border border-gray-600" style={{ backgroundColor: primaryColor }} />
+            <input
+              type="color"
+              value={primaryColor}
+              onChange={(e) => setPrimaryColor(e.target.value)}
+              className="w-10 h-8 cursor-pointer bg-transparent border-0"
+            />
+          </div>
+        </div>
+
+        {/* Accent Color */}
+        <div className="flex items-center justify-between">
+          <label className="text-sm text-gray-300">Accent Color</label>
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded border border-gray-600" style={{ backgroundColor: accentColor }} />
+            <input
+              type="color"
+              value={accentColor}
+              onChange={(e) => setAccentColor(e.target.value)}
+              className="w-10 h-8 cursor-pointer bg-transparent border-0"
+            />
+          </div>
+        </div>
+
+        {/* Font Selector */}
+        <div className="flex items-center justify-between">
+          <label className="text-sm text-gray-300">Font</label>
+          <select
+            value={fontFamily}
+            onChange={(e) => setFontFamily(e.target.value)}
+            className="bg-gray-800 text-white border border-gray-600 rounded px-2 py-1 text-sm"
+          >
+            {FONT_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value} style={{ fontFamily: opt.value }}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Logo Upload */}
+        <div className="flex flex-col gap-2">
+          <label className="text-sm text-gray-300">Logo</label>
+          <div className="flex items-center gap-3">
+            {logoUrl ? (
+              <img src={logoUrl} alt="Logo" className="h-12 w-12 rounded-full object-cover border border-gray-600" />
+            ) : (
+              <div className="h-12 w-12 rounded-full bg-gray-800 border border-gray-600 flex items-center justify-center">
+                <md-icon style={{ fontSize: '24px', color: '#666' }}>image</md-icon>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <label className="cursor-pointer">
+                <md-outlined-button disabled={uploading || undefined}>
+                  {uploading ? 'Uploading...' : 'Upload'}
+                </md-outlined-button>
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/svg+xml"
+                  onChange={handleLogoUpload}
+                  className="hidden"
+                />
+              </label>
+              {logoUrl && (
+                <md-text-button onClick={() => setLogoUrl(undefined)}>Remove</md-text-button>
+              )}
+            </div>
+          </div>
+          <span className="text-xs text-gray-500">PNG, JPG, WebP, or SVG. Max 2MB.</span>
+        </div>
+
+        {/* Live Preview */}
+        <div className="border border-gray-700 rounded p-3 mt-2">
+          <div className="text-xs text-gray-500 mb-2 uppercase">Preview</div>
+          <div className="flex items-center gap-3 p-3 rounded" style={{ backgroundColor: accentColor, fontFamily }}>
+            {logoUrl && <img src={logoUrl} alt="Preview logo" className="h-8 w-8 rounded-full object-cover" />}
+            <span className="font-bold" style={{ color: primaryColor }}>Your Bar Name</span>
+          </div>
+          <div className="mt-2 flex gap-2">
+            <button
+              className="px-4 py-2 rounded font-medium text-sm"
+              style={{ backgroundColor: primaryColor, color: contrastColor }}
+            >
+              Sample Button
+            </button>
+            <button
+              className="px-4 py-2 rounded font-medium text-sm border"
+              style={{ borderColor: primaryColor, color: primaryColor, backgroundColor: 'transparent' }}
+            >
+              Outlined
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div slot="actions">
+        <md-text-button onClick={handleReset} disabled={saving || undefined}>Reset</md-text-button>
+        <md-text-button onClick={onClose}>Cancel</md-text-button>
+        <md-filled-button onClick={handleSave} disabled={saving || undefined}>
+          {saving ? 'Saving...' : 'Save'}
+        </md-filled-button>
+      </div>
+    </md-dialog>
+  );
+};
+
+export default ThemeEditor;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -20,6 +20,8 @@ import {
 // 'getToken' retrieves the FCM registration token for the current device.
 // 'onMessage' allows listening for incoming messages when the app is in the foreground.
 import { getMessaging, getToken, onMessage } from "firebase/messaging";
+// Import Firebase Storage for file uploads (e.g., bar logos).
+import { getStorage } from "firebase/storage";
 
 // Define the Firebase configuration object using environment variables.
 // These variables are injected by Vite at build time.
@@ -53,6 +55,10 @@ export const auth = getAuth(app);
 
 // Initialize and export the Firebase Cloud Messaging service instance.
 export const messaging = getMessaging(app);
+
+// Initialize and export the Firebase Storage service instance for
+// file uploads (bar logo uploads from ThemeEditor).
+export const storage = getStorage(app);
 
 // --- Auth Providers ---
 

--- a/src/hooks/useBarTheme.test.ts
+++ b/src/hooks/useBarTheme.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useBarTheme } from './useBarTheme';
+import type { BarTheme } from '../types';
+
+describe('useBarTheme', () => {
+  beforeEach(() => {
+    // Reset any inline styles on the document root.
+    const root = document.documentElement;
+    root.style.removeProperty('--md-sys-color-primary');
+    root.style.removeProperty('--md-sys-color-on-primary');
+    root.style.removeProperty('--md-sys-color-secondary-container');
+    root.style.removeProperty('font-family');
+  });
+
+  it('does nothing when theme is undefined', () => {
+    renderHook(() => useBarTheme(undefined, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-primary')).toBe('');
+  });
+
+  it('does nothing when not premium', () => {
+    const theme: BarTheme = { primaryColor: '#FF0000', accentColor: '#00FF00' };
+    renderHook(() => useBarTheme(theme, false));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-primary')).toBe('');
+  });
+
+  it('applies CSS variables when premium with theme', () => {
+    const theme: BarTheme = { primaryColor: '#FF0000', accentColor: '#00FF00' };
+    renderHook(() => useBarTheme(theme, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-primary')).toBe('#FF0000');
+    expect(root.style.getPropertyValue('--md-sys-color-secondary-container')).toBe('#00FF00');
+  });
+
+  it('sets white contrast for dark primary color', () => {
+    const theme: BarTheme = { primaryColor: '#000000', accentColor: '#1E1E1E' };
+    renderHook(() => useBarTheme(theme, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-on-primary')).toBe('#FFFFFF');
+  });
+
+  it('sets black contrast for light primary color', () => {
+    const theme: BarTheme = { primaryColor: '#FFFFFF', accentColor: '#1E1E1E' };
+    renderHook(() => useBarTheme(theme, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-on-primary')).toBe('#000000');
+  });
+
+  it('applies font family when provided', () => {
+    const theme: BarTheme = { primaryColor: '#FFFFFF', accentColor: '#1E1E1E', fontFamily: 'Inter, sans-serif' };
+    renderHook(() => useBarTheme(theme, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('font-family')).toBe('Inter, sans-serif');
+  });
+
+  it('removes CSS variables on cleanup', () => {
+    const theme: BarTheme = { primaryColor: '#FF0000', accentColor: '#00FF00' };
+    const { unmount } = renderHook(() => useBarTheme(theme, true));
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--md-sys-color-primary')).toBe('#FF0000');
+
+    unmount();
+    expect(root.style.getPropertyValue('--md-sys-color-primary')).toBe('');
+  });
+});

--- a/src/hooks/useBarTheme.ts
+++ b/src/hooks/useBarTheme.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import type { BarTheme } from '../types';
+import { getContrastColor } from '../utils/color';
+
+/**
+ * Applies a bar's custom theme to the document root via CSS custom properties.
+ * Removes custom properties when theme is undefined or bar is not premium.
+ */
+export function useBarTheme(theme: BarTheme | undefined, isPremium: boolean): void {
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (!isPremium || !theme) {
+      root.style.removeProperty('--md-sys-color-primary');
+      root.style.removeProperty('--md-sys-color-on-primary');
+      root.style.removeProperty('--md-sys-color-secondary-container');
+      root.style.removeProperty('font-family');
+      return;
+    }
+
+    if (theme.primaryColor) {
+      root.style.setProperty('--md-sys-color-primary', theme.primaryColor);
+      root.style.setProperty('--md-sys-color-on-primary', getContrastColor(theme.primaryColor));
+    }
+    if (theme.accentColor) {
+      root.style.setProperty('--md-sys-color-secondary-container', theme.accentColor);
+    }
+    if (theme.fontFamily) {
+      root.style.setProperty('font-family', theme.fontFamily);
+    }
+
+    return () => {
+      root.style.removeProperty('--md-sys-color-primary');
+      root.style.removeProperty('--md-sys-color-on-primary');
+      root.style.removeProperty('--md-sys-color-secondary-container');
+      root.style.removeProperty('font-family');
+    };
+  }, [theme, isPremium]);
+}

--- a/src/test/FirebasePersistence.test.ts
+++ b/src/test/FirebasePersistence.test.ts
@@ -41,6 +41,11 @@ vi.mock('firebase/messaging', () => ({
   onMessage: vi.fn(),
 }));
 
+// Mock firebase/storage
+vi.mock('firebase/storage', () => ({
+  getStorage: vi.fn(() => ({})),
+}));
+
 describe('Firebase Persistence', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/src/test/firestore-rules.test.ts
+++ b/src/test/firestore-rules.test.ts
@@ -18,35 +18,39 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const PROJECT_ID = 'barbacker-rules-test';
-
-// Resolve the rules file relative to this test via import.meta.url so
-// it works under vitest's ESM mode in CI, where `__dirname` is not
-// reliably defined for projects with type=module.
 const RULES_PATH = fileURLToPath(new URL('../../firestore.rules', import.meta.url));
 
 let env: RulesTestEnvironment;
 
 const ALICE = 'alice';
 const BOB = 'bob';
+const MANAGER = 'manager-uid';
 const ADMIN = 'admin-uid';
 const BAR_A = 'bar-a';
 const BAR_B = 'bar-b';
 
-// Seed: alice is a member of bar-a, bob is a member of bar-b, no
-// crossover. Admin user has the `admin: true` custom claim but is not a
-// member of either bar.
+// Helper: build claims for the role-based rule model.
+const staffOf = (barId: string) => ({ bars: { [barId]: 'Staff' } });
+const managerOf = (barId: string) => ({ bars: { [barId]: 'Manager' } });
+
+// Seed: alice = Staff at bar-a, bob = Staff at bar-b, no crossover.
+// Manager = Manager at bar-a. Admin user has the `admin: true`
+// custom claim but no per-bar role.
 async function seed() {
   await env.withSecurityRulesDisabled(async (ctx) => {
     const db = ctx.firestore();
     await setDoc(doc(db, 'bars', BAR_A), { name: 'Alice Bar', status: 'verified' });
     await setDoc(doc(db, 'bars', BAR_B), { name: 'Bob Bar', status: 'verified' });
-    await setDoc(doc(db, `bars/${BAR_A}/users`, ALICE), { displayName: 'Alice', role: 'Bartender', status: 'active' });
-    await setDoc(doc(db, `bars/${BAR_B}/users`, BOB), { displayName: 'Bob', role: 'Bartender', status: 'active' });
+    await setDoc(doc(db, `bars/${BAR_A}/users`, ALICE),
+      { displayName: 'Alice', role: 'Staff', status: 'active' });
+    await setDoc(doc(db, `bars/${BAR_A}/users`, MANAGER),
+      { displayName: 'M', role: 'Manager', status: 'active' });
+    await setDoc(doc(db, `bars/${BAR_B}/users`, BOB),
+      { displayName: 'Bob', role: 'Staff', status: 'active' });
     await setDoc(doc(db, 'users', ALICE), { joinedBars: [BAR_A] });
     await setDoc(doc(db, 'users', BOB), { joinedBars: [BAR_B] });
-    await setDoc(doc(db, `bars/${BAR_A}/notices`, 'n1'), {
-      text: 'hello', authorId: ALICE, authorName: 'Alice', timestamp: new Date(),
-    });
+    await setDoc(doc(db, `bars/${BAR_A}/notices`, 'n1'),
+      { text: 'hello', authorId: ALICE, authorName: 'Alice', timestamp: new Date() });
     await setDoc(doc(db, `bars/${BAR_A}/tokens`, ALICE), { token: 'alice-token' });
   });
 }
@@ -92,20 +96,21 @@ describe('Firestore security rules', () => {
 
     it('lets a non-member create a new bar (claim flow)', async () => {
       const db = env.authenticatedContext(BOB).firestore();
-      await assertSucceeds(setDoc(doc(db, 'bars', 'fresh-bar'), { name: 'New', status: 'temporary' }));
+      await assertSucceeds(setDoc(doc(db, 'bars', 'fresh-bar'),
+        { name: 'New', status: 'temporary' }));
     });
 
-    it('denies a non-member updating a bar', async () => {
-      const db = env.authenticatedContext(BOB).firestore();
+    it('denies Staff from updating bar settings', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(updateDoc(doc(db, 'bars', BAR_A), { name: 'pwned' }));
     });
 
-    it('allows a member to update their own bar', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+    it('allows a Manager to update their own bar', async () => {
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
       await assertSucceeds(updateDoc(doc(db, 'bars', BAR_A), { name: 'renamed' }));
     });
 
-    it('allows an admin to update any bar without membership', async () => {
+    it('allows an admin to update any bar without role claims', async () => {
       const db = env.authenticatedContext(ADMIN, { admin: true }).firestore();
       await assertSucceeds(updateDoc(doc(db, 'bars', BAR_A), { name: 'admin renamed' }));
     });
@@ -113,48 +118,48 @@ describe('Firestore security rules', () => {
 
   describe('bars/{barId}/tokens/{userId}', () => {
     it('allows a user to read their own token', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(getDoc(doc(db, `bars/${BAR_A}/tokens`, ALICE)));
     });
 
     it('denies a different user reading another user token (no FCM hijack)', async () => {
-      const db = env.authenticatedContext(BOB).firestore();
+      const db = env.authenticatedContext(BOB, staffOf(BAR_A)).firestore();
       await assertFails(getDoc(doc(db, `bars/${BAR_A}/tokens`, ALICE)));
     });
 
     it('denies a different user writing another user token', async () => {
-      const db = env.authenticatedContext(BOB).firestore();
-      await assertFails(setDoc(doc(db, `bars/${BAR_A}/tokens`, ALICE), { token: 'attacker' }));
+      const db = env.authenticatedContext(BOB, staffOf(BAR_A)).firestore();
+      await assertFails(setDoc(doc(db, `bars/${BAR_A}/tokens`, ALICE),
+        { token: 'attacker' }));
     });
   });
 
   describe('bars/{barId}/notices', () => {
-    it('denies a non-member reading notices', async () => {
+    it('denies a user with no role from reading notices', async () => {
       const db = env.authenticatedContext(BOB).firestore();
       await assertFails(getDoc(doc(db, `bars/${BAR_A}/notices`, 'n1')));
     });
 
-    it('allows a member to read notices', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+    it('allows a user with a role to read notices', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(getDoc(doc(db, `bars/${BAR_A}/notices`, 'n1')));
     });
 
     it('rejects a notice create where authorId does not match auth.uid', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/notices`), {
         text: 'spoof', authorId: BOB, authorName: 'Bob', timestamp: new Date(),
       }));
     });
 
     it('accepts a notice create where authorId matches', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(addDoc(collection(db, `bars/${BAR_A}/notices`), {
         text: 'hi', authorId: ALICE, authorName: 'Alice', timestamp: new Date(),
       }));
     });
 
     it('rejects a notice create within 5s of the previous lastNoticeAt', async () => {
-      // Stamp Alice's lastNoticeAt to "now" via rule-bypass seed.
       await env.withSecurityRulesDisabled(async (ctx) => {
         await setDoc(
           doc(ctx.firestore(), `bars/${BAR_A}/users`, ALICE),
@@ -162,7 +167,7 @@ describe('Firestore security rules', () => {
           { merge: true },
         );
       });
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/notices`), {
         text: 'spam', authorId: ALICE, authorName: 'Alice', timestamp: new Date(),
       }));
@@ -186,31 +191,30 @@ describe('Firestore security rules', () => {
   describe('requests/{requestId}', () => {
     beforeEach(async () => {
       await env.withSecurityRulesDisabled(async (ctx) => {
-        const db = ctx.firestore();
-        await setDoc(doc(db, 'requests', 'r-a'), {
+        await setDoc(doc(ctx.firestore(), 'requests', 'r-a'), {
           barId: BAR_A, label: 'ICE', requesterId: ALICE, status: 'pending', timestamp: new Date(),
         });
       });
     });
 
-    it('denies a non-member reading a request from another bar', async () => {
+    it('denies a no-role user reading a request from another bar', async () => {
       const db = env.authenticatedContext(BOB).firestore();
       await assertFails(getDoc(doc(db, 'requests', 'r-a')));
     });
 
-    it('allows a member to read a request in their bar', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+    it('allows a user with a role to read a request in their bar', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(getDoc(doc(db, 'requests', 'r-a')));
     });
 
     it('rejects a create where requesterId does not match auth.uid', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, 'requests'), {
         barId: BAR_A, label: 'ICE', requesterId: BOB, status: 'pending', timestamp: new Date(),
       }));
     });
 
-    it('rejects a create when the user is not a member of the target bar', async () => {
+    it('rejects a create when the user has no role for the target bar', async () => {
       const db = env.authenticatedContext(BOB).firestore();
       await assertFails(addDoc(collection(db, 'requests'), {
         barId: BAR_A, label: 'ICE', requesterId: BOB, status: 'pending', timestamp: new Date(),
@@ -218,7 +222,7 @@ describe('Firestore security rules', () => {
     });
 
     it('allows a requester to delete (cancel) their own request', async () => {
-      const db = env.authenticatedContext(ALICE).firestore();
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(deleteDoc(doc(db, 'requests', 'r-a')));
     });
 

--- a/src/test/rules/bar.test.ts
+++ b/src/test/rules/bar.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc, updateDoc, getDoc } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+describe("bar rules", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+
+  beforeAll(async () => { env = await getTestEnv(); });
+  beforeEach(async () => {
+    await env.clearFirestore();
+    // Seed: bar_A with manager_alice (Manager), staff_bob (Staff).
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, "bars/bar_A"), { name: "Bar A", joinPolicy: "open" });
+      await setDoc(doc(db, "bars/bar_A/users/manager_alice"), { role: "Manager", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Staff", status: "active" });
+    });
+  });
+  afterAll(async () => { await env.cleanup(); });
+
+  it("Manager can read the bar doc", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("Staff can read the bar doc", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("non-member can read the bar doc (open discovery for search/join)", async () => {
+    // The audit-pass merge kept main's open bar-discovery so the
+    // existing search/join flow can fetch a bar by id before the
+    // user has a role for it. Tightening this requires migrating
+    // the join flow to invite-only first.
+    const db = authedAs(env, "outsider_carol", { bars: {} });
+    await assertSucceeds(getDoc(doc(db, "bars/bar_A")));
+  });
+
+  it("Manager can update operational fields", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
+  });
+
+  it("Staff cannot update bar doc", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
+  });
+
+  it("Staff cannot escalate role via combined-field self-write", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    // Attempt to set status:off_clock AND role:Manager in one update.
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      status: "off_clock",
+      role: "Manager",
+    }));
+  });
+
+  it("Staff can self-set status to off_clock alone", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      status: "off_clock",
+    }));
+  });
+
+  it("Staff cannot set status to active via self-write", async () => {
+    // Seed staff_bob as off_clock so that an attempted change to 'active' is a real diff.
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "bars/bar_A/users/staff_bob"), { role: "Staff", status: "off_clock" });
+    });
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      status: "active",
+    }));
+  });
+});

--- a/src/test/rules/helpers.ts
+++ b/src/test/rules/helpers.ts
@@ -1,0 +1,21 @@
+import {
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export async function getTestEnv(): Promise<RulesTestEnvironment> {
+  return initializeTestEnvironment({
+    projectId: "barbacker-test",
+    firestore: {
+      rules: fs.readFileSync(path.resolve(__dirname, "../../../firestore.rules"), "utf8"),
+      host: "127.0.0.1",
+      port: 8080,
+    },
+  });
+}
+
+export function authedAs(env: RulesTestEnvironment, uid: string, claims: object = {}) {
+  return env.authenticatedContext(uid, claims).firestore();
+}

--- a/src/test/rules/sanity.test.ts
+++ b/src/test/rules/sanity.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+describe("rules sanity", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+  beforeAll(async () => { env = await getTestEnv(); });
+  afterAll(async () => { await env.cleanup(); });
+
+  it("unauthenticated user cannot read /users/anyone", async () => {
+    const db = env.unauthenticatedContext().firestore();
+    await assertFails(setDoc(doc(db, "users/anyone"), { foo: "bar" }));
+  });
+});

--- a/src/test/rules/userRoles.test.ts
+++ b/src/test/rules/userRoles.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, beforeAll, beforeEach, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc, updateDoc, deleteDoc, serverTimestamp } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+describe("user role rules (owner immunity matrix)", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  beforeEach(async () => {
+    await env.clearFirestore();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, "bars/bar_A"), { name: "Bar A", joinPolicy: "open" });
+      await setDoc(doc(db, "bars/bar_A/users/owner_eve"), { role: "Owner", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/owner_frank"), { role: "Owner", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/manager_alice"), { role: "Manager", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/manager_dave"), { role: "Manager", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Staff", status: "active" });
+      await setDoc(doc(db, "bars/bar_A/users/staff_carol"), { role: "Staff", status: "active" });
+    });
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  // Case 1: Staff cannot change any role.
+  it("Staff cannot change any role (Bob → Carol)", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(
+      updateDoc(doc(db, "bars/bar_A/users/staff_carol"), { role: "Manager" }),
+    );
+  });
+
+  // Case 2: Manager can promote Staff → Manager.
+  it("Manager can promote Staff → Manager (Alice promotes Bob)", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Manager" }),
+    );
+  });
+
+  // Case 3: Manager can demote Manager → Staff.
+  it("Manager can demote Manager → Staff (Alice demotes Dave)", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/manager_dave"), { role: "Staff" }),
+    );
+  });
+
+  // Case 4: Manager cannot touch an Owner's record.
+  it("Manager cannot demote an Owner (Alice → Eve)", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertFails(
+      updateDoc(doc(db, "bars/bar_A/users/owner_eve"), { role: "Manager" }),
+    );
+  });
+
+  // Case 5: Owner can promote Manager → Owner.
+  it("Owner can promote Manager → Owner (Eve promotes Dave)", async () => {
+    const db = authedAs(env, "owner_eve", { bars: { bar_A: "Owner" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/manager_dave"), { role: "Owner" }),
+    );
+  });
+
+  // Case 6: Owner can demote Manager → Staff.
+  it("Owner can demote Manager → Staff (Eve demotes Dave)", async () => {
+    const db = authedAs(env, "owner_eve", { bars: { bar_A: "Owner" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/manager_dave"), { role: "Staff" }),
+    );
+  });
+
+  // Case 7: Owner cannot demote another Owner.
+  it("Owner cannot demote another Owner (Eve → Frank)", async () => {
+    const db = authedAs(env, "owner_eve", { bars: { bar_A: "Owner" } });
+    await assertFails(
+      updateDoc(doc(db, "bars/bar_A/users/owner_frank"), { role: "Manager" }),
+    );
+  });
+
+  // Case 8: Self can self-relinquish Owner → Manager.
+  it("Owner can self-relinquish Owner → Manager (Eve demotes Eve)", async () => {
+    const db = authedAs(env, "owner_eve", { bars: { bar_A: "Owner" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/owner_eve"), { role: "Manager" }),
+    );
+  });
+
+  // Case 9: Self can change own lastSeen without role.
+  it("Staff can update own lastSeen without changing role", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(
+      updateDoc(doc(db, "bars/bar_A/users/staff_bob"), { lastSeen: serverTimestamp() }),
+    );
+  });
+
+  it("Manager cannot promote Staff to Owner", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Owner" }));
+  });
+
+  it("Manager cannot promote Manager to Owner", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/manager_dave"), { role: "Owner" }));
+  });
+
+  it("Manager cannot self-promote (via own doc)", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/manager_alice"), { role: "Owner" }));
+  });
+
+  // Create path
+  it("Staff cannot self-mint as Owner via create", async () => {
+    const db = authedAs(env, "new_user_x", { bars: {} });
+    await assertFails(setDoc(doc(db, "bars/bar_A/users/new_user_x"), {
+      role: "Owner",
+      status: "active",
+    }));
+  });
+
+  it("Staff cannot self-mint as Manager via create", async () => {
+    const db = authedAs(env, "new_user_y", { bars: {} });
+    await assertFails(setDoc(doc(db, "bars/bar_A/users/new_user_y"), {
+      role: "Manager",
+      status: "active",
+    }));
+  });
+
+  it("New joiner can self-create with role:Staff status:active (open policy)", async () => {
+    const db = authedAs(env, "new_user_z", { bars: {} });
+    await assertSucceeds(setDoc(doc(db, "bars/bar_A/users/new_user_z"), {
+      role: "Staff",
+      status: "active",
+    }));
+  });
+
+  it("New joiner can self-create with role:Staff status:pending (approval policy)", async () => {
+    const db = authedAs(env, "new_user_w", { bars: {} });
+    await assertSucceeds(setDoc(doc(db, "bars/bar_A/users/new_user_w"), {
+      role: "Staff",
+      status: "pending",
+    }));
+  });
+
+  it("Cannot create user doc at someone else's uid", async () => {
+    const db = authedAs(env, "attacker", { bars: {} });
+    await assertFails(setDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      role: "Staff",
+      status: "active",
+    }));
+  });
+
+  // Delete (kick) path
+  it("Manager can kick Staff", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(deleteDoc(doc(db, "bars/bar_A/users/staff_bob")));
+  });
+
+  it("Manager can kick Manager", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertSucceeds(deleteDoc(doc(db, "bars/bar_A/users/manager_dave")));
+  });
+
+  it("Manager cannot kick Owner", async () => {
+    const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+    await assertFails(deleteDoc(doc(db, "bars/bar_A/users/owner_eve")));
+  });
+
+  it("Owner can kick Manager", async () => {
+    const db = authedAs(env, "owner_eve", { bars: { bar_A: "Owner" } });
+    await assertSucceeds(deleteDoc(doc(db, "bars/bar_A/users/manager_alice")));
+  });
+
+  it("Staff cannot kick anyone", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(deleteDoc(doc(db, "bars/bar_A/users/staff_carol")));
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,14 @@ export interface Bar {
   buttonUsage?: Record<string, number>;
   // Optional: Custom sort orders for button lists (Context ID -> Array of Button IDs).
   customOrders?: Record<string, string[]>;
+  // Optional: Subscription tier for the bar (gates premium features
+  // like custom theme and the private 86'd list).
+  subscription?: 'free' | 'premium';
+  // Join policy for new users. 'open' = auto-active. 'approval' =
+  // pending until a Manager approves.
+  joinPolicy?: 'open' | 'approval';
+  // Optional: Custom branding for premium bars.
+  theme?: BarTheme;
 }
 
 // Define the data model for a 'Request' document in Firestore.
@@ -111,7 +119,7 @@ export interface BarUser {
   // Optional: The user's role (e.g., 'Bartender', 'Barback').
   role?: string;
   // Optional: The user's current status.
-  status?: 'active' | 'off_clock' | 'pending';
+  status?: 'active' | 'off_clock' | 'pending' | 'rejected';
   // Optional: The timestamp of the user's last activity.
   lastSeen?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
   // Optional: The user's email address.
@@ -120,4 +128,71 @@ export interface BarUser {
   notificationPreferences?: string[];
   // Optional: The ntfy topic ID for iOS notifications.
   ntfyTopic?: string;
+  // Optional: Server timestamp of the user's most recent notice
+  // post. Used by firestore.rules to enforce a 5s cooldown between
+  // notice creates. Bumped atomically by saveNotice (batched write).
+  lastNoticeAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}
+
+// Define the data model for a banned-patron entry (86'd list).
+export interface EightySixEntry {
+  // The unique ID of the entry (matches document ID).
+  id: string;
+  // The name of the banned patron.
+  patronName: string;
+  // The UID of the staff member who submitted this entry.
+  submittedBy: string;
+  // The display name of the submitter (snapshot at creation time).
+  submitterName: string;
+  // Optional: The reason for banning (only on private entries).
+  reason?: string;
+  // Visibility level: 'public' is visible to all staff with a role,
+  // 'private' is Owner/Manager only and gated by the bar's premium
+  // subscription.
+  visibility: 'public' | 'private';
+  // The timestamp when the entry was created.
+  timestamp: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}
+
+// Define the structure for custom bar branding/theming. Applied via
+// useBarTheme on premium bars only.
+export interface BarTheme {
+  // Primary brand color (hex).
+  primaryColor: string;
+  // Accent color (hex).
+  accentColor: string;
+  // Optional: URL to the bar's logo in Firebase Storage.
+  logoUrl?: string;
+  // Optional: Font family from a curated list.
+  fontFamily?: string;
+}
+
+// Define an invite for a specific email to join a bar at a specific
+// role. Consumed via Cloud Function; client-side reads scoped to
+// Managers+ or the invited address.
+export interface BarInvite {
+  id: string;
+  email: string;            // normalized lowercase
+  role: 'Staff' | 'Manager' | 'Owner';
+  createdBy: string;        // uid
+  createdByName: string;
+  createdAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+  consumed: boolean;
+  consumedBy?: string;
+  consumedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}
+
+// A claim filed by a user requesting Ownership of a bar (e.g. the
+// real-world owner reclaiming a temporarily-created entry). Writes
+// only go through Cloud Functions.
+export interface OwnershipClaim {
+  id: string;
+  barId: string;
+  claimantId: string;
+  claimantName: string;
+  // Free-form justification supplied by the claimant.
+  justification?: string;
+  // Lifecycle status.
+  status: 'pending' | 'approved' | 'rejected';
+  createdAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
 }

--- a/src/utils/color.test.ts
+++ b/src/utils/color.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { getContrastColor } from './color';
+
+describe('getContrastColor', () => {
+  it('returns white for black', () => {
+    expect(getContrastColor('#000000')).toBe('#FFFFFF');
+  });
+
+  it('returns black for white', () => {
+    expect(getContrastColor('#FFFFFF')).toBe('#000000');
+  });
+
+  it('returns white for dark colors', () => {
+    expect(getContrastColor('#1E1E1E')).toBe('#FFFFFF');
+    expect(getContrastColor('#333333')).toBe('#FFFFFF');
+    expect(getContrastColor('#0000FF')).toBe('#FFFFFF');
+  });
+
+  it('returns black for light colors', () => {
+    expect(getContrastColor('#FFFF00')).toBe('#000000');
+    expect(getContrastColor('#00FF00')).toBe('#000000');
+    expect(getContrastColor('#CCCCCC')).toBe('#000000');
+  });
+
+  it('handles hex without # prefix', () => {
+    expect(getContrastColor('000000')).toBe('#FFFFFF');
+    expect(getContrastColor('FFFFFF')).toBe('#000000');
+  });
+});

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns '#000000' or '#FFFFFF' for readable text contrast against the given hex background.
+ * Uses the WCAG relative luminance formula.
+ */
+export function getContrastColor(hex: string): string {
+  // Remove # prefix if present.
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.substring(0, 2), 16) / 255;
+  const g = parseInt(clean.substring(2, 4), 16) / 255;
+  const b = parseInt(clean.substring(4, 6), 16) / 255;
+
+  // sRGB to linear conversion.
+  const toLinear = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const luminance = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+  return luminance > 0.179 ? '#000000' : '#FFFFFF';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,17 @@ export default defineConfig({
     // node environment + a live emulator process. They are excluded from
     // the default suite and invoked via `npm run test:rules`, which
     // wraps them in `firebase emulators:exec`.
-    exclude: ['**/node_modules/**', '**/dist/**', '**/firestore-rules.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      // Rules tests run against the Firestore emulator via the
+      // `test:rules` npm script (vitest.rules.config.ts) and have no
+      // place in the jsdom suite.
+      '**/firestore-rules.test.ts',
+      'src/test/rules/**',
+      // The Cloud Functions package has its own vitest config; the
+      // root suite shouldn't pick it up.
+      'functions/**',
+    ],
   },
 })

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -8,9 +8,14 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/test/firestore-rules.test.ts'],
+    include: ['src/test/firestore-rules.test.ts', 'src/test/rules/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     reporters: ['verbose'],
+    // Serialize test files. All four test files share the one
+    // Firestore emulator instance started by `firebase emulators:exec`,
+    // and clearFirestore in their beforeEach hooks can stomp on each
+    // other's seeds when run in parallel.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

Forward-ports the unique surfaces from #255 onto the audit-pass main, in a way that doesn't unwind any of the security/refactor work that already landed. Replaces #255 (which would need to be closed once this merges — the file deletions on main make a direct merge impossible).

### What's new (from #255)
- **Cloud Functions** package under `functions/` — `onUserRoleChange` stamps `bars.{barId} = 'Staff' | 'Manager' | 'Owner'` claims on the user's ID token whenever the per-bar user doc's `role` field flips. The rules consume these claims.
- **Role-claim rule model** in `firestore.rules` — replaces main's binary member/admin model with `hasRole`, `isManagerPlus`, `isOwner`. Admins still bypass via `isAdmin()`.
- **86'd list**: `EightySixDialog` + entry type + listener + CRUD in App.tsx. Public/private split, with private entries gated by premium subscription and Manager+ role.
- **Custom theming**: `ThemeEditor` + `useBarTheme` hook + `color` util. Logos upload to Firebase Storage; theme is applied to the document root when premium.
- **New entity types**: `BarTheme`, `EightySixEntry`, `BarInvite`, `OwnershipClaim`, plus `Bar.{subscription,joinPolicy,theme}` and `BarUser.{lastNoticeAt,status='rejected'}`.
- **Structured rule tests** under `src/test/rules/` (bar, userRoles, sanity, helpers).
- **Firebase Storage** initialization in `src/firebase.ts`.
- `BarManager`'s `godMode` prop renamed to `isPremium` throughout.

### What was preserved from main (post-audit)
- **Open bar discovery** for the existing search/join flow — `allow read: if isAuthed()` on `/bars/{barId}`. Phase-1's role-gated read would break joining a bar you don't yet have a role for. One phase-1 test was updated to assert the open semantics, with a note that this should tighten alongside an invite-only join flow migration.
- **Notice cooldown** rule + the batched `lastNoticeAt` write in `useBarNoticeBoard`. Spliced into the new role-based notice rule.
- **Admin claim escape hatch** — folded into `hasRole`/`isManagerPlus`/`isOwner` so admins bypass per-bar checks for moderation.
- **All audit-pass refactor extractions** (12 hooks total). Phase-1's App.tsx wiring slots into the extracted shape, not the pre-extraction one.

### What was skipped from #255
- The `src/modules/subscription/*` and `src/services/subscription.ts` edits — main deleted those stubs in #244.
- The `ListenerRedundancy` threshold relaxation (12 → 14). Main keeps it tight at 12 and still passes.
- The duplicate `pMap concurrency validation` commit — already on main via #243.

### Test plumbing
- `vite.config.ts` default suite excludes `src/test/rules/**` and `functions/**`.
- `vitest.rules.config.ts` includes `src/test/rules/**` and sets `fileParallelism: false` (the four rules test files share one emulator and were stomping each other's seeds).
- `FirebasePersistence.test.ts` now mocks `firebase/storage`.

### Verification
- `npx tsc --noEmit` clean.
- `npm test -- --run` → 74/74 jsdom tests.
- `npm run test:rules` → 53/53 across 3 consecutive runs (determinism confirmed).
- `npm run build` succeeds end-to-end.

### Follow-ups (not in this PR)
- Backfill `bars.{barId}` claims for existing users (Cloud Function only stamps on role change going forward).
- Migrate the join flow to invite-only so `/bars/{barId}` read can become role-gated.
- Cloud Functions tests are present but the Functions vitest config is isolated from the root suite and not yet wired into CI.

Closes #255.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNSVEPNDEKGquk5vwFzr9Z)_