### PR TITLE
Fix broken role model, request races, dialog dismissal, and deploy path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -37,11 +37,27 @@ service cloud.firestore {
     // Bar documents.
     match /bars/{barId} {
       // Bars are discoverable by any signed-in user (search + join).
-      allow read: if isAuthed();
-      // Anyone signed in can claim a new bar.
-      allow create: if isAuthed();
-      // Routine updates by Manager+.
-      allow update: if isManagerPlus(barId);
+      // Split into get/list so a future tightening of `list` (e.g.
+      // routing name search through a Cloud Function) doesn't also
+      // have to relitigate direct-by-id reads.
+      allow get: if isAuthed();
+      allow list: if isAuthed();
+      // Anyone signed in can claim a new bar, but must name
+      // themselves as its owner — this is what lets the per-bar
+      // self-create rule below recognize the bar's creator and grant
+      // them 'Owner' instead of 'Staff'.
+      allow create: if isAuthed() && request.resource.data.get('ownerId', null) == request.auth.uid;
+      // Routine updates by Manager+. Ownership transfer isn't
+      // implemented (see ownershipClaims below) so ownerId is
+      // immutable outside that Cloud-Function-only path. Uses
+      // .get(..., null) rather than dot access on both sides so a bar
+      // document that predates the ownerId field (or was seeded
+      // without one) doesn't hard-error on every routine update —
+      // null == null holds, leaving it unset, and a Manager+ update
+      // that tries to introduce/change ownerId is still rejected
+      // since only one side would be non-null.
+      allow update: if isManagerPlus(barId) &&
+        request.resource.data.get('ownerId', null) == resource.data.get('ownerId', null);
       // Only Owners can delete.
       allow delete: if isOwner(barId);
 
@@ -54,34 +70,59 @@ service cloud.firestore {
       match /users/{userId} {
         allow read: if hasRole(barId);
 
-        // Self-create on join. Role must be 'Staff' — higher roles
-        // only come from Manager/Owner promotion (post-join) or a
-        // Cloud Function (invite consumption). Status may be
-        // 'active' (open policy) or 'pending' (approval policy).
+        // Self-create on join. Role is 'Staff' for everyone except
+        // the bar's own creator (verified against bars/{barId}.ownerId,
+        // set atomically when the bar document was created), who
+        // self-assigns 'Owner' — there is no other user yet to
+        // promote them. `status` follows the bar's joinPolicy:
+        // 'open' (default) activates immediately, 'approval'
+        // requires a Manager to flip pending -> active. The bar's
+        // own creator always activates immediately regardless of
+        // joinPolicy, since they can't be pending approval on a bar
+        // with no other members.
         allow create: if isAuthed() && request.auth.uid == userId &&
-          request.resource.data.role == 'Staff' &&
-          (request.resource.data.status == 'active' ||
-           request.resource.data.status == 'pending');
+          request.resource.data.keys().hasOnly([
+            'role', 'jobTitle', 'status', 'displayName', 'email',
+            'joinedAt', 'lastSeen', 'notificationPreferences', 'ntfyTopic'
+          ]) &&
+          (
+            (request.resource.data.role == 'Staff') ||
+            (request.resource.data.role == 'Owner' &&
+             get(/databases/$(database)/documents/bars/$(barId)).data.get('ownerId', null) == request.auth.uid)
+          ) &&
+          (
+            (request.resource.data.role == 'Owner' && request.resource.data.status == 'active') ||
+            (get(/databases/$(database)/documents/bars/$(barId)).data.get('joinPolicy', 'open') != 'approval' &&
+             request.resource.data.status == 'active') ||
+            (get(/databases/$(database)/documents/bars/$(barId)).data.get('joinPolicy', 'open') == 'approval' &&
+             request.resource.data.status == 'pending')
+          );
 
         // Self-write limited to safe operational fields. `status`
-        // may only be set to 'off_clock' (clocking out). The
-        // lastNoticeAt cooldown stamp is included so saveNotice's
+        // may only toggle between 'active' and 'off_clock' — this
+        // lets a user clock in and back out on their own without
+        // being able to self-approve out of 'pending'/'rejected'.
+        // The lastNoticeAt cooldown stamp is included so saveNotice's
         // batched write succeeds.
         allow write: if isAuthed() && request.auth.uid == userId &&
           request.resource.data.diff(resource.data).affectedKeys()
             .hasOnly(['displayName', 'lastSeen', 'notificationPreferences',
-                      'ntfyTopic', 'email', 'status', 'lastNoticeAt']) &&
+                      'ntfyTopic', 'email', 'status', 'lastNoticeAt', 'jobTitle']) &&
           (!('status' in request.resource.data.diff(resource.data).affectedKeys()) ||
-           request.resource.data.status == 'off_clock');
+           request.resource.data.status == 'off_clock' ||
+           (request.resource.data.status == 'active' && resource.data.status == 'off_clock'));
 
-        // Managers can flip pending → active, set role for
+        // Managers can flip pending → active, set role/jobTitle for
         // non-Owners, or kick non-Owners. They cannot promote to
         // Owner, can't change their own role, can't touch existing
-        // Owners.
+        // Owners, and are limited to the role/status/jobTitle fields
+        // (e.g. they can't rewrite someone else's ntfyTopic).
         allow update: if isManagerPlus(barId) &&
           resource.data.role != 'Owner' &&
           request.resource.data.role != 'Owner' &&
-          request.auth.uid != userId;
+          request.auth.uid != userId &&
+          request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(['role', 'jobTitle', 'status']);
 
         // Owners can do anything to non-Owners and to themselves
         // (self-relinquish only).
@@ -103,10 +144,15 @@ service cloud.firestore {
 
       // Notices (bulletin board). Members read/write. Posts are
       // rate-limited via lastNoticeAt on the writer's per-bar user
-      // doc — saveNotice writes a batch that creates the notice
-      // AND bumps lastNoticeAt = serverTimestamp(), so this rule
-      // blocks bursts faster than once every 5 seconds. Admins
-      // bypass via isAdmin.
+      // doc — saveNotice writes a batch that creates the notice AND
+      // bumps lastNoticeAt = serverTimestamp(). Note this cooldown is
+      // client-cooperative: a client that never bumps lastNoticeAt
+      // sees every create request satisfy "more than 5s since epoch"
+      // and isn't actually throttled. Firestore rules can't enforce
+      // that two independent document writes land atomically, so
+      // this blocks bursts from the shipped app but isn't a hard
+      // backstop against a hostile client hitting the API directly.
+      // Admins bypass via isAdmin.
       match /notices/{noticeId} {
         allow read: if hasRole(barId);
         allow create: if hasRole(barId)
@@ -118,8 +164,10 @@ service cloud.firestore {
                               + duration.value(5, 's')
           );
         allow update: if hasRole(barId)
-          && resource.data.authorId == request.auth.uid;
-        allow delete: if hasRole(barId);
+          && resource.data.authorId == request.auth.uid
+          && request.resource.data.authorId == resource.data.authorId;
+        allow delete: if hasRole(barId)
+          && (resource.data.authorId == request.auth.uid || isManagerPlus(barId));
       }
 
       // 86'd list. Public entries readable by anyone with a role;
@@ -143,14 +191,19 @@ service cloud.firestore {
         allow delete: if isManagerPlus(barId);
       }
 
-      // Invites. Manager+ can read all; invitee can read their own.
-      // Consumption (flipping `consumed`) is the only update the
-      // invitee can do client-side.
+      // Invites. Manager+ can read all; invitee can read their own —
+      // gated on a verified email address so an attacker can't
+      // self-register an unverified account under someone else's
+      // email to read/consume their invite. Consumption (flipping
+      // `consumed`) is the only update the invitee can do
+      // client-side.
       match /invites/{inviteId} {
         allow read: if isManagerPlus(barId) ||
-                       (isAuthed() && resource.data.email == request.auth.token.email);
+                       (isAuthed() && request.auth.token.email_verified == true &&
+                        resource.data.email == request.auth.token.email);
         allow create: if isManagerPlus(barId);
-        allow update: if isAuthed() && resource.data.email == request.auth.token.email &&
+        allow update: if isAuthed() && request.auth.token.email_verified == true &&
+                        resource.data.email == request.auth.token.email &&
                         request.resource.data.diff(resource.data).affectedKeys()
                           .hasOnly(['consumed', 'consumedBy', 'consumedAt']);
         allow delete: if isManagerPlus(barId);
@@ -169,8 +222,26 @@ service cloud.firestore {
       allow read: if isAuthed() && hasRole(resource.data.barId);
       allow create: if isAuthed()
         && hasRole(request.resource.data.barId)
-        && request.resource.data.requesterId == request.auth.uid;
-      allow update: if isAuthed() && hasRole(resource.data.barId);
+        && request.resource.data.requesterId == request.auth.uid
+        && request.resource.data.status == 'pending';
+      // The only client-side update is claiming: pending -> claimed,
+      // touching only the claim fields, with barId/requesterId/label
+      // immutable so a member of one bar can't rewrite a request into
+      // another bar or forge its requester. Firestore serializes
+      // writes to a single document, so this "resource.data.status ==
+      // 'pending'" precondition is itself what prevents two
+      // concurrent claims from both succeeding — whichever commits
+      // first flips status to 'claimed' and the second write is
+      // evaluated against that new state and denied. No client-side
+      // transaction is needed for this invariant.
+      allow update: if isAuthed() && hasRole(resource.data.barId)
+        && request.resource.data.barId == resource.data.barId
+        && request.resource.data.requesterId == resource.data.requesterId
+        && request.resource.data.label == resource.data.label
+        && resource.data.status == 'pending'
+        && request.resource.data.status == 'claimed'
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['status', 'claimedBy', 'claimerName', 'claimedAt']);
       allow delete: if isAuthed() && (
         resource.data.requesterId == request.auth.uid
         || isManagerPlus(resource.data.barId)

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <meta name="theme-color" content="#000000" />
@@ -12,7 +12,17 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet" />
 
     <title>BarBacker</title>
-    <base href="/barbacker/" />
+    <!--
+      No <base href> here on purpose. vite.config.ts already sets
+      base: './', which makes every built asset reference relative to
+      wherever index.html itself is served from — that works
+      regardless of the deploy subpath (or its exact case). A
+      hardcoded absolute base previously pointed at "/barbacker/"
+      while the real GitHub Pages path is "/BarBacker/" (capital B),
+      so every asset 404'd and the deployed site was a blank page.
+      Routing is hash-based (see main.tsx's HashRouter) so it doesn't
+      depend on this either.
+    -->
   </head>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-QEVWXVQY66"></script>

--- a/scripts/generate-sw.js
+++ b/scripts/generate-sw.js
@@ -42,12 +42,19 @@ const messaging = firebase.messaging();
 // Handle background messages.
 messaging.onBackgroundMessage((payload) => {
   console.log('[firebase-messaging-sw.js] Received background message ', payload);
-  
-  // Customize notification display.
-  const notificationTitle = payload.notification.title;
+
+  // payload.notification is absent on data-only messages — guard
+  // instead of throwing (which would drop the notification silently,
+  // since a throwing handler shows nothing rather than falling back).
+  const notificationTitle = payload.notification?.title || 'BarBacker Alert';
   const notificationOptions = {
-    body: payload.notification.body,
-    icon: '/pwa-192x192.png', // Path to PWA icon.
+    body: payload.notification?.body || payload.data?.body || '',
+    // Relative (no leading slash) so it resolves against this
+    // service worker's own scope regardless of the deploy subpath —
+    // the file it previously pointed at ('/pwa-192x192.png', origin-
+    // root-absolute) never existed in public/ at all; the real icons
+    // are named 'icon-<size>.png'.
+    icon: 'icon-192x192.png',
     vibrate: [200, 100, 200, 100, 200, 100, 200], // Custom vibration pattern.
     tag: 'request-alert', // Tag to replace existing notifications (prevent stacking).
     renotify: true // Vibrate/Alert again even if replacing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // Import React hooks for managing state and side effects.
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 // Import 'useSearchParams' to read/write URL query parameters.
 import { useSearchParams } from 'react-router-dom';
 // Import Firebase Auth functions still used directly (handlers below
@@ -81,6 +81,7 @@ import ThemeEditor from './components/ThemeEditor';
 import InputDialog from './components/InputDialog';
 import { WhoIsOnDialog } from './components/WhoIsOnDialog';
 import { SortableButton } from './components/SortableButton';
+import { MdDialog } from './components/MdDialog';
 // Import dnd-kit for drag-and-drop functionality.
 import {
   DndContext,
@@ -127,12 +128,25 @@ function App() {
   // --- User Context in Bar ---
   // Store the name of the current bar.
   const [barName, setBarName] = useState('');
-  // Store the user's role in this bar (e.g., 'Bartender').
+  // Store the user's privilege role in this bar ('Staff' | 'Manager' | 'Owner').
   const [userRole, setUserRole] = useState<string | null>(null);
+  // Store the user's job title/function (e.g. 'Bartender'), used for
+  // display and notification-preference defaults. Distinct from the
+  // privilege role above.
+  const [jobTitle, setJobTitle] = useState<string>('');
   // Store the user's status (active/off_clock/pending).
   const [userStatus, setUserStatus] = useState<string>('active');
   // Store the user's display name.
   const [displayName, setDisplayName] = useState<string>('');
+  // True for the brief window between creating a brand-new bar and
+  // confirming the RoleSelector — lets confirmRole know to assign
+  // 'Owner' instead of 'Staff'. Reset to false the moment it's
+  // consumed or the user backs out of bar selection.
+  const [justCreatedBar, setJustCreatedBar] = useState(false);
+  // The bar's join policy ('open' | 'approval'), read off the bar
+  // document. Determines whether confirmRole writes status 'active'
+  // or 'pending' for a joining (non-creator) user.
+  const [barJoinPolicy, setBarJoinPolicy] = useState<'open' | 'approval'>('open');
   // Store the user's notification preferences (list of button IDs).
   const [notificationPreferences, setNotificationPreferences] = useState<string[]>([]);
   // Store the ntfy topic ID for iOS notifications (per-bar snapshot
@@ -187,15 +201,28 @@ function App() {
   // Notice Board State.
   const [notices, setNotices] = useState<Notice[]>([]);
 
-  // Control the main menu dropdown.
+  // Control the main menu dropdown. md-menu's `onClosed` JSX prop has
+  // the same React-19-custom-element bug as md-dialog's `onClose` (see
+  // MdDialog) — React listens for "Closed" (capitalized) while
+  // md-menu dispatches lowercase 'closed', so it never fires and
+  // dismissing the menu by clicking outside it would strand menuOpen
+  // at true. Bind the real event via a ref instead.
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const handleClosed = () => setMenuOpen(false);
+    el.addEventListener('closed', handleClosed);
+    return () => el.removeEventListener('closed', handleClosed);
+  }, []);
 
   // Fetch latest APK info using custom hook.
   const { downloadUrl: apkUrl, loading: apkLoading } = useLatestRelease();
 
   // Drag-and-drop sensors + handlers (dnd-kit). Persistence of
   // customOrders happens inside the hook on drag end.
-  const { sensors, activeId, handleDragStart, handleDragOver, handleDragEnd } =
+  const { sensors, activeId, isDraggingRef, handleDragStart, handleDragOver, handleDragEnd } =
     useDragAndDrop({ barId, customOrders, setCustomOrders });
 
   // Memoized lookup map for button IDs. Maps both top-level and child labels to top-level button ID.
@@ -317,6 +344,11 @@ function App() {
   // tier.
   const isPremium = isGodMode || barSubscription === 'premium';
 
+  // Privilege check used to gate Manager+ actions in the UI (theme
+  // editing, approving pending joins). firestore.rules is the actual
+  // authority — this only controls what's shown.
+  const isManagerPlus = userRole === 'Owner' || userRole === 'Manager';
+
   // Apply the custom bar theme to the document root when premium.
   useBarTheme(barTheme, isPremium);
 
@@ -346,15 +378,18 @@ function App() {
       if (snapshot.exists()) {
         const data = snapshot.data();
         setUserRole(data.role);
+        setJobTitle(data.jobTitle || data.role || '');
         setUserStatus(data.status || 'active');
         setDisplayName(data.displayName || 'Unknown');
 
         // Load notification preferences or set defaults.
+        const defaultsKey = data.jobTitle || data.role;
         if (data.notificationPreferences) {
           setNotificationPreferences(data.notificationPreferences);
-        } else if (data.role) {
-          // If no preferences saved, use defaults for role.
-          setNotificationPreferences(ROLE_NOTIFICATION_DEFAULTS[data.role] || []);
+        } else if (defaultsKey) {
+          // If no preferences saved, use defaults for job title (or
+          // role, for docs written before jobTitle existed).
+          setNotificationPreferences(ROLE_NOTIFICATION_DEFAULTS[defaultsKey] || []);
         }
 
         // Auto-coordinate ntfy topic. Mirror the global topic from
@@ -372,13 +407,14 @@ function App() {
         // User document doesn't exist (new user).
         setUserRole(null);
       }
-    });
+    }, (err) => console.error('User profile listener failed', err));
 
     // Listen for changes to the Bar configuration.
     const unsubBar = onSnapshot(doc(db, 'bars', barId), (d) => {
       if (d.exists()) {
         const data = d.data() as Bar;
         setBarName(data.name);
+        setBarJoinPolicy(data.joinPolicy === 'approval' ? 'approval' : 'open');
 
         // Merge default buttons with custom bar buttons.
         if (data.buttons) {
@@ -395,11 +431,16 @@ function App() {
         if (data.wells) setWells(data.wells);
         if (data.hiddenButtonIds) setHiddenButtonIds(data.hiddenButtonIds);
         if (data.buttonUsage) setButtonUsage(data.buttonUsage);
-        if (data.customOrders) setCustomOrders(data.customOrders);
+        // Skip while a local drag is in flight — this listener fires
+        // on ANY change to the bar doc (not just customOrders), and
+        // an unconditional overwrite here would clobber an in-progress
+        // reorder with the pre-drag server value the instant another
+        // device touches the same bar document.
+        if (data.customOrders && !isDraggingRef.current) setCustomOrders(data.customOrders);
         setBarSubscription(data.subscription || 'free');
         setBarTheme(data.theme);
       }
-    });
+    }, (err) => console.error('Bar listener failed', err));
 
     // Listen for All Users (for "Who's On").
     // Query varies based on whether we are viewing the "Who's On" dialog (show off_clock users too).
@@ -407,14 +448,14 @@ function App() {
 
     const unsubAllUsers = onSnapshot(userQuery, (s) => {
         setAllUsers(s.docs.map(d => ({ id: d.id, ...d.data() })));
-    });
+    }, (err) => console.error('Bar users listener failed', err));
 
     // Cleanup: Unsubscribe from non-time-windowed listeners. The
     // requests/notices listeners are owned by a separate effect below
     // so they can re-subscribe on the hourly windowEpoch without
     // tearing these down.
     return () => { unsubUser(); unsubBar(); unsubAllUsers(); };
-  }, [user, barId, setSearchParams]);
+  }, [user, barId, setSearchParams, isDraggingRef]);
 
   // Time-window epoch. Bumped every hour so the requests/notices
   // listeners below re-subscribe with a fresh "now" lower bound. In a
@@ -442,6 +483,7 @@ function App() {
         limit(100),
       ),
       (s) => setRequests(s.docs.map(d => ({ id: d.id, ...d.data() } as Request))),
+      (err) => console.error('Requests listener failed', err),
     );
 
     const unsubNotices = onSnapshot(
@@ -452,6 +494,7 @@ function App() {
         limit(100),
       ),
       (s) => setNotices(s.docs.map(d => ({ id: d.id, ...d.data() } as Notice))),
+      (err) => console.error('Notices listener failed', err),
     );
 
     return () => { unsubReq(); unsubNotices(); };
@@ -465,13 +508,13 @@ function App() {
   // can't decode.
   useEffect(() => {
     if (!barId) return;
-    const canSeePrivate = isPremium && (userRole === 'Owner' || userRole === 'Manager');
+    const canSeePrivate = isPremium && isManagerPlus;
     const q = canSeePrivate
       ? query(collection(db, `bars/${barId}/eightySixed`), orderBy('timestamp', 'desc'), limit(200))
       : query(collection(db, `bars/${barId}/eightySixed`), where('visibility', '==', 'public'), orderBy('timestamp', 'desc'), limit(200));
     const unsub = onSnapshot(q, (s) => {
       setEightySixEntries(s.docs.map(d => ({ id: d.id, ...d.data() } as EightySixEntry)));
-    });
+    }, (err) => console.error('86\'d list listener failed', err));
     return () => unsub();
   }, [barId, isPremium, userRole]);
 
@@ -502,11 +545,14 @@ function App() {
         token: fcmToken,
         updated: serverTimestamp()
       });
-      // Set status to active and update heartbeat.
+      // Set status to active and update heartbeat. Rules only permit
+      // this self-write when transitioning from 'off_clock' (or when
+      // status isn't changing at all) — a user still 'pending'
+      // manager approval correctly stays pending here.
       await updateDoc(userRef, {
         status: 'active',
         lastSeen: serverTimestamp()
-      }).catch(() => {});
+      }).catch((e) => console.error('Auto clock-in failed', e));
     };
     autoClockIn();
   }, [user, barId, fcmToken]);
@@ -772,35 +818,55 @@ function App() {
     }
   };
 
-  // Finalize role selection and enter the dashboard.
-  const confirmRole = async (role: string, name: string) => {
+  // Finalize role selection and enter the dashboard. `title` is the
+  // job function (or 'Owner' verbatim, from RoleSelector's new-bar
+  // path) — the security-relevant privilege `role` is computed here,
+  // never taken from the client-selectable list, since firestore.rules
+  // only allows a self-create to claim 'Owner' when bars/{barId}.ownerId
+  // already matches this uid (set atomically at bar-creation time).
+  const confirmRole = async (title: string, name: string) => {
     if (!user || !barId) return;
 
-    const status = 'active';
+    const role = justCreatedBar ? 'Owner' : 'Staff';
+    const status = (role === 'Owner' || barJoinPolicy !== 'approval') ? 'active' : 'pending';
 
-    // Update Global User Document with joined bar.
-    await setDoc(doc(db, 'users', user.uid), {
-        joinedBars: arrayUnion(barId)
-    }, { merge: true });
+    try {
+      // Update Global User Document with joined bar.
+      await setDoc(doc(db, 'users', user.uid), {
+          joinedBars: arrayUnion(barId)
+      }, { merge: true });
 
-    // Update User Document.
-    await setDoc(doc(db, `bars/${barId}/users`, user.uid), {
-      role: role,
-      displayName: name,
-      email: user.email,
-      status: status,
-      joinedAt: serverTimestamp(),
-      lastSeen: serverTimestamp(),
-      // Set default prefs if not exists.
-      notificationPreferences: ROLE_NOTIFICATION_DEFAULTS[role] || []
-    }, { merge: true });
-    
-    // Ensure Token is fresh.
-    if (fcmToken) {
-      await setDoc(doc(db, `bars/${barId}/tokens`, user.uid), {
-        token: fcmToken,
-        updated: serverTimestamp()
-      });
+      // Update User Document.
+      await setDoc(doc(db, `bars/${barId}/users`, user.uid), {
+        role,
+        jobTitle: title,
+        displayName: name,
+        email: user.email,
+        status,
+        joinedAt: serverTimestamp(),
+        lastSeen: serverTimestamp(),
+        // Set default prefs if not exists.
+        notificationPreferences: ROLE_NOTIFICATION_DEFAULTS[title] || []
+      }, { merge: true });
+
+      // Ensure Token is fresh.
+      if (fcmToken) {
+        await setDoc(doc(db, `bars/${barId}/tokens`, user.uid), {
+          token: fcmToken,
+          updated: serverTimestamp()
+        });
+      }
+
+      setJustCreatedBar(false);
+      // The 'bars' claim used by firestore.rules is stamped
+      // asynchronously by the onUserRoleChange Cloud Function and only
+      // reflected on this client's ID token after a refresh. Force one
+      // now so hasRole()-gated reads (requests, notices) don't spend
+      // up to an hour denied while the cached token is stale.
+      await user.getIdToken(true).catch((e) => console.error('Token refresh after join failed', e));
+    } catch (e) {
+      console.error('Failed to join bar', e);
+      alert('Failed to join this bar. Please try again.');
     }
   };
 
@@ -815,6 +881,7 @@ function App() {
     });
     // Cleanup local state.
     setBarId(null);
+    setJustCreatedBar(false);
     localStorage.removeItem('barId');
     setShowOffClockDialog(false);
   };
@@ -822,7 +889,32 @@ function App() {
   // Switch to another bar without clocking out (unless inactive).
   const handleSwitchBar = async () => {
     setBarId(null);
+    setJustCreatedBar(false);
     localStorage.removeItem('barId');
+  };
+
+  // Approve/reject a user waiting on this bar's 'approval' joinPolicy
+  // (WhoIsOnDialog, Manager+ only). Without this, a pending user had
+  // no path off the "Approval Pending" screen — nothing in the app
+  // could ever flip their status to 'active'.
+  const approveUser = async (userId: string) => {
+    if (!barId) return;
+    try {
+      await updateDoc(doc(db, `bars/${barId}/users`, userId), { status: 'active' });
+    } catch (e) {
+      console.error('Failed to approve user', e);
+      alert('Failed to approve. Please try again.');
+    }
+  };
+
+  const rejectUser = async (userId: string) => {
+    if (!barId) return;
+    try {
+      await deleteDoc(doc(db, `bars/${barId}/users`, userId));
+    } catch (e) {
+      console.error('Failed to reject user', e);
+      alert('Failed to reject. Please try again.');
+    }
   };
 
   // Request mutations: submit (+ ntfy fanout), claim, cancel.
@@ -867,6 +959,7 @@ function App() {
         joinedBars: arrayRemove(barId)
     }).catch(() => {});
     setBarId(null);
+    setJustCreatedBar(false);
     localStorage.removeItem('barId');
     setShowAccountDialog(false);
   };
@@ -998,7 +1091,7 @@ function App() {
         )}
 
         <BarSearch onJoin={async (b) => {
-          if(b.id) {
+          if(b.id && user) {
             const barRef = doc(db, 'bars', b.id);
             const existingSnap = await getDoc(barRef);
 
@@ -1013,8 +1106,17 @@ function App() {
                   phone: b.phone || '',
                   status: b.status || 'verified',
                   type: b.type || 'bar',
-                  buttons: []
+                  buttons: [],
+                  ...(b.osmId ? { osmId: b.osmId } : {}),
+                  ...(b.osmType ? { osmType: b.osmType } : {}),
+                  // Names this user as the bar's creator — checked by
+                  // firestore.rules to grant them 'Owner' on their own
+                  // upcoming self-create of bars/{id}/users/{uid}.
+                  ownerId: user.uid,
                 });
+                setJustCreatedBar(true);
+            } else {
+                setJustCreatedBar(false);
             }
 
             setBarId(b.id);
@@ -1045,10 +1147,10 @@ function App() {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center p-6 space-y-6 bg-black">
         <div className="flex w-full justify-between items-center max-w-[300px]">
-            <md-icon-button onClick={() => { setBarId(null); localStorage.removeItem('barId'); }}><md-icon>arrow_back</md-icon></md-icon-button>
+            <md-icon-button onClick={() => { setBarId(null); setJustCreatedBar(false); localStorage.removeItem('barId'); }}><md-icon>arrow_back</md-icon></md-icon-button>
             <md-text-button onClick={signOut}>Sign Out</md-text-button>
         </div>
-        <RoleSelector onSelect={confirmRole} initialName={user?.displayName || ''} key={user?.displayName || 'default'} />
+        <RoleSelector onSelect={confirmRole} initialName={user?.displayName || ''} key={user?.displayName || 'default'} isNewBar={justCreatedBar} />
       </div>
     );
   }
@@ -1094,7 +1196,7 @@ function App() {
             <md-icon style={{ fontSize: 64 }} className="text-yellow-500">hourglass_empty</md-icon>
             <h2 className="text-2xl font-bold text-white">Approval Pending</h2>
             <p className="text-gray-400">A manager must approve your request to join {barName}.</p>
-            <md-text-button onClick={() => { setBarId(null); localStorage.removeItem('barId'); }}>Cancel</md-text-button>
+            <md-text-button onClick={() => { setBarId(null); setJustCreatedBar(false); localStorage.removeItem('barId'); }}>Cancel</md-text-button>
         </div>
       );
   }
@@ -1140,13 +1242,16 @@ function App() {
         open={showWhoIsOn}
         onClose={() => setShowWhoIsOn(false)}
         users={allUsers as BarUser[]}
+        isManagerPlus={isManagerPlus}
+        onApprove={approveUser}
+        onReject={rejectUser}
       />
 
       <NotificationSettings
         open={showNotificationSettings}
         onClose={() => setShowNotificationSettings(false)}
         onSave={saveNotificationPreferences}
-        userRole={userRole || ''}
+        userRole={jobTitle || userRole || ''}
         currentPreferences={notificationPreferences}
         currentNtfyTopic={ntfyTopic}
         allButtons={buttons}
@@ -1181,7 +1286,7 @@ function App() {
         })()}
       />
 
-      <md-dialog open={quantityPicker.open || undefined} onClose={() => setQuantityPicker(prev => ({ ...prev, open: false }))}>
+      <MdDialog open={quantityPicker.open} onClose={() => setQuantityPicker(prev => ({ ...prev, open: false }))}>
         <div slot="headline">Select Quantity</div>
         <div slot="content" className="flex items-center justify-center gap-6 py-6">
            <md-filled-tonal-button onClick={() => setQuantityPicker(prev => ({ ...prev, currentQty: Math.max(1, prev.currentQty - 1) }))}>
@@ -1200,9 +1305,9 @@ function App() {
              setNavStack([]);
           }}>Send</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
-      <md-dialog open={isAddingNotice || undefined} onClose={() => setIsAddingNotice(false)}>
+      <MdDialog open={isAddingNotice} onClose={() => setIsAddingNotice(false)}>
         <div slot="headline">Add Notice</div>
         <div slot="content" className="flex flex-col gap-4">
             <md-filled-text-field
@@ -1218,18 +1323,19 @@ function App() {
             <md-text-button onClick={() => setIsAddingNotice(false)}>Cancel</md-text-button>
             <md-filled-button onClick={() => saveNotice(noticeText)}>Post</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
-      <md-dialog open={showOffClockDialog || undefined} onClose={() => setShowOffClockDialog(false)}>
+      <MdDialog open={showOffClockDialog} onClose={() => setShowOffClockDialog(false)}>
         <div slot="headline">Abandon Ship?</div>
         <div slot="content">
-          Going off clock stops all notifications and signs you out. The bar will be unprotected. Are you sure?
+          Going off clock stops all notifications for you. You can clock back in any time by
+          reopening this bar — the bar itself stays open, this only affects your own device.
         </div>
         <div slot="actions">
           <md-text-button onClick={() => setShowOffClockDialog(false)}>Stay</md-text-button>
           <md-filled-button onClick={goOffClock} className="btn-alert">Clock Out</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
       {/* --- Navbar --- */}
       <div className="flex-none flex flex-wrap justify-between items-center py-12 px-6 bg-[#121212] border-b border-[#333] z-10 gap-4">
@@ -1241,7 +1347,7 @@ function App() {
             <span className="whitespace-pre">    </span>
             <span className="text-white font-bold text-xl truncate">{displayName}</span>
             <span className="text-white text-xl whitespace-pre">        </span>
-            <span className="bg-gray-800 px-4 py-2 rounded text-base text-gray-300 whitespace-nowrap">{userRole}</span>
+            <span className="bg-gray-800 px-4 py-2 rounded text-base text-gray-300 whitespace-nowrap">{jobTitle || userRole}</span>
         </div>
 
         {/* Right Side Actions */}
@@ -1283,9 +1389,9 @@ function App() {
                     </md-icon-button>
 
                     <md-menu
+                        ref={menuRef}
                         anchor="menu-anchor"
                         open={menuOpen}
-                        onClosed={() => setMenuOpen(false)}
                         positioning="fixed"
                         quick
                         style={{ zIndex: 2000 }}
@@ -1302,7 +1408,7 @@ function App() {
                             <md-icon slot="start">store</md-icon>
                             <div slot="headline">Manage Bar</div>
                         </md-menu-item>
-                        {isPremium && (userRole === 'Owner' || userRole === 'Manager') && (
+                        {isPremium && isManagerPlus && (
                           <md-menu-item onClick={() => setShowThemeEditor(true)}>
                               <md-icon slot="start">palette</md-icon>
                               <div slot="headline">Customize Theme</div>
@@ -1358,7 +1464,7 @@ function App() {
           </div>
       )}
 
-      <md-dialog open={showNameEditDialog || undefined} onClose={() => { setShowNameEditDialog(false); setEditNameError(null); }}>
+      <MdDialog open={showNameEditDialog} onClose={() => { setShowNameEditDialog(false); setEditNameError(null); }}>
         <div slot="headline">Edit Name</div>
         <div slot="content" className="flex flex-col gap-4 pt-4">
             <md-filled-text-field
@@ -1391,10 +1497,10 @@ function App() {
                 }
             }}>Save</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
       {/* Account Dialog */}
-      <md-dialog open={showAccountDialog || undefined} onClose={() => setShowAccountDialog(false)}>
+      <MdDialog open={showAccountDialog} onClose={() => setShowAccountDialog(false)}>
         <div slot="headline">Account Options</div>
         <div slot="content" className="flex flex-col gap-4 pt-4">
             <p className="text-gray-300">Manage your account for <strong>{barName}</strong>.</p>
@@ -1419,7 +1525,7 @@ function App() {
                 </div>
             </div>
         </div>
-      </md-dialog>
+      </MdDialog>
 
       {/* --- Main Content Area --- */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden w-full relative pb-[35vh]">
@@ -1449,7 +1555,7 @@ function App() {
                   {currentButtons.map(btn => (
                     <SortableButton key={btn.id} id={btn.id} onClick={() => handleButtonClick(btn)}>
                       <md-filled-tonal-button style={{ height: '100px', fontSize: '18px', width: '100%', pointerEvents: 'none', border: '8px solid #000000', boxSizing: 'border-box' }}>
-                        <span className="text-red-500 font-bold text-3xl">{btn.label}</span>
+                        <span className="font-bold text-3xl line-clamp-2 text-center px-1" style={{ color: 'var(--bb-button-label-color)' }}>{btn.label}</span>
                       </md-filled-tonal-button>
                     </SortableButton>
                   ))}
@@ -1491,8 +1597,8 @@ function App() {
                 <SortableButton key={btn.id} id={btn.id} onClick={() => handleButtonClick(btn)}>
                   <md-filled-tonal-button className={isPending ? 'btn-alert' : ''} style={{ height: '120px', width: '100%', pointerEvents: 'none', border: isPending ? '8px solid #EF4444' : '8px solid #000000', boxSizing: 'border-box' }}>
                       <div className="flex flex-col items-center gap-2">
-                      <md-icon style={{ fontSize: 32 }} className="text-red-500">{btn.icon || 'circle'}</md-icon>
-                      <span className="text-3xl font-bold leading-none text-red-500">{btn.label}</span>
+                      <md-icon style={{ fontSize: 32, color: 'var(--bb-button-label-color)' }}>{btn.icon || 'circle'}</md-icon>
+                      <span className="text-3xl font-bold leading-none line-clamp-2 text-center px-1" style={{ color: 'var(--bb-button-label-color)' }}>{btn.label}</span>
                       {isPending && <span className="text-xs opacity-80 text-red-500">PENDING</span>}
                       </div>
                   </md-filled-tonal-button>
@@ -1528,7 +1634,7 @@ function App() {
             {/* Show Pending Approvals Badge for Managers */}
             {showApprovals && (
                 <md-filled-button
-                    onClick={() => setShowBarManager(true)}
+                    onClick={() => setShowWhoIsOn(true)}
                     style={{ height: '24px', fontSize: '12px', ...{ '--md-filled-button-container-color': '#EAB308', '--md-filled-button-label-text-color': '#000' } as React.CSSProperties }}
                 >
                     {pendingUsers.length} Approvals
@@ -1557,7 +1663,9 @@ function App() {
 
                         {/* Claim Button */}
                         <md-filled-button
-                            onClick={() => claimRequest(req.id)}
+                            onClick={() => claimRequest(req.id).catch(() => {
+                                alert('Someone else already claimed this request.');
+                            })}
                             className={`w-full ${isIgnored ? '' : 'btn-alert'}`}
                             style={{ height: '48px', minWidth: '100px' }}
                         >

--- a/src/components/BarManager.tsx
+++ b/src/components/BarManager.tsx
@@ -13,6 +13,8 @@ import '@material/web/list/list-item.js';
 
 // Import the ButtonConfig type definition.
 import { ButtonConfig } from '../types';
+// Wrapper that fixes md-dialog's onClose not firing under React 19.
+import { MdDialog } from './MdDialog';
 
 // Define the props interface for the BarManager component.
 interface BarManagerProps {
@@ -70,7 +72,7 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
   return (
     <>
       {/* Main Dialog: Lists active buttons */}
-      <md-dialog data-testid="bar-manager-dialog" open={open || undefined} onClose={onClose} style={{ maxHeight: '80vh' }}>
+      <MdDialog data-testid="bar-manager-dialog" open={open} onClose={onClose} style={{ maxHeight: '80vh' }}>
         {/* Dialog Header */}
         <div slot="headline">Manage {barName}</div>
 
@@ -127,20 +129,21 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
         <div slot="actions">
           <md-text-button onClick={onClose} data-testid="bar-manager-close">Close</md-text-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
       {/* Confirmation Dialog: "Are you sure?" */}
-      <md-dialog open={!!confirmDeleteId || undefined} onClose={() => setConfirmDeleteId(null)}>
+      <MdDialog open={!!confirmDeleteId} onClose={() => setConfirmDeleteId(null)}>
         <div slot="headline">Remove Button?</div>
         <div slot="content">
-          Are you sure you want to remove this button from the dashboard?
+          Are you sure you want to remove this button from the dashboard? It will disappear from
+          every device at this bar, and restoring it requires Premium.
         </div>
         <div slot="actions">
           <md-text-button onClick={() => setConfirmDeleteId(null)}>Cancel</md-text-button>
           {/* Use 'btn-alert' class for styling destructive actions */}
           <md-filled-button onClick={confirmDelete} className="btn-alert">Remove</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
     </>
   );
 };

--- a/src/components/BarSearch.tsx
+++ b/src/components/BarSearch.tsx
@@ -43,6 +43,10 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
   const [results, setResults] = useState<OSMResult[]>([]);
   // Boolean indicating if a search is currently in progress.
   const [isSearching, setIsSearching] = useState(false);
+  // Set when both the OSM and Firestore lookups fail — surfaced to
+  // the user instead of silently leaving the previous query's
+  // (unrelated) results on screen and tappable.
+  const [searchError, setSearchError] = useState(false);
 
   // --- Create State ---
   const [createName, setCreateName] = useState('');
@@ -63,6 +67,16 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
     };
   }, []);
 
+  // Tracks which run is the "current" one — i.e. hasn't been
+  // superseded by a later search. A run's own AbortSignal being
+  // aborted isn't the right test for "should I still update
+  // isSearching/results": leaving search mode entirely also aborts
+  // the signal, but there (unlike a rapid-retype race) there's no
+  // newer run to hand off to, so the in-flight one resolving is
+  // exactly what should clear the spinner. Comparing against "am I
+  // still the most recently started run" gets both cases right.
+  const currentControllerRef = useRef<AbortController | null>(null);
+
   // Effect to handle the search logic with debouncing.
   useEffect(() => {
     const controller = new AbortController();
@@ -70,13 +84,17 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
 
     // Only search if in search mode and query is long enough.
     if (mode === 'search' && queryText.length > 2) {
+      currentControllerRef.current = controller;
       // Set a timeout to delay execution.
       const timer = setTimeout(async () => {
         setIsSearching(true);
+        setSearchError(false);
         try {
           // Parallel Search: Query both OpenStreetMap and local Firestore.
           let fetchedFb: OSMResult[] = [];
           let fetchedOsm: OSMResult[] = [];
+          let osmFailed = false;
+          let fbFailed = false;
 
           // 1. OSM Search
           const osmPromise = fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText + ' bar')}`, { signal })
@@ -88,9 +106,10 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
               return data;
             })
             .catch((e) => {
-                // If aborted, return empty array to prevent unhandled rejections
-                if (e.name === 'AbortError') return [];
-                return []; // Fallback to empty array on other errors.
+                // Aborted just means a newer search superseded this
+                // one \u2014 not a failure worth reporting.
+                if (e.name !== 'AbortError') osmFailed = true;
+                return [];
             });
 
           // 2. Firestore Search (Prefix match)
@@ -111,8 +130,8 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
                     osm_id: d.id,
                     display_name: `${data.name}, ${data.city || ''} ${data.state || ''}`,
                     name: data.name,
-                    isFirebase: true
-                } as any;
+                    isFirebase: true,
+                } as OSMResult;
             }))
             .then(data => {
               if (signal.aborted || !isMounted.current) return data;
@@ -120,17 +139,31 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
               setResults([...fetchedFb, ...fetchedOsm]);
               return data;
             })
-            .catch(() => []);
+            .catch(() => {
+                fbFailed = true;
+                return [];
+            });
 
           // Await both promises only to handle loading state
           await Promise.all([osmPromise, fbPromise]);
+
+          // Both sources failed: don't leave the previous (unrelated)
+          // query's results on screen and tappable \u2014 clear them and
+          // tell the user, rather than showing nothing wrong.
+          if (isMounted.current && currentControllerRef.current === controller && osmFailed && fbFailed) {
+              setResults([]);
+              setSearchError(true);
+          }
 
         } catch (e: any) {
           if (e.name !== 'AbortError') {
               console.error(e);
           }
         } finally {
-          if (isMounted.current) {
+          // Only the still-current run (i.e. not superseded by a
+          // later search) gets to clear the spinner \u2014 see
+          // currentControllerRef's comment above.
+          if (isMounted.current && currentControllerRef.current === controller) {
               setIsSearching(false);
           }
         }
@@ -151,11 +184,16 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
   const handleCreate = (e: React.FormEvent) => {
       e.preventDefault();
 
+      const trimmedName = createName.trim();
+      const trimmedCity = city.trim();
+      const trimmedState = state.trim();
+      const trimmedZip = zip.trim();
+
       // Validation logic: Name is required.
       // Must have either a Zip Code OR (City AND State) to be valid.
-      const hasLocation = (city && state) || zip;
+      const hasLocation = (trimmedCity && trimmedState) || trimmedZip;
 
-      if (!createName || !hasLocation) {
+      if (!trimmedName || !hasLocation) {
           alert("Please enter a Business Name and either City/State or Zip Code.");
           return;
       }
@@ -163,12 +201,12 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
       // Call the parent handler with the new bar data.
       onJoin({
           id: `bar_${Date.now()}`, // Generate a temporary timestamp-based ID.
-          name: createName,
-          address: address,
-          city: city,
-          state: state,
-          zip: zip,
-          phone: phone,
+          name: trimmedName,
+          address: address.trim(),
+          city: trimmedCity,
+          state: trimmedState,
+          zip: trimmedZip,
+          phone: phone.trim(),
           status: 'verified', // Publicly available.
           type: barType
       });
@@ -194,22 +232,42 @@ const BarSearch = ({ onJoin }: BarSearchProps) => {
                     </md-filled-text-field>
                 </div>
 
+                {/* Search failure: don't leave the previous query's
+                    (unrelated) results on screen and tappable. */}
+                {searchError && (
+                    <div className="text-red-400 text-sm p-2 border border-red-900 rounded bg-red-900/10">
+                        Search failed. Check your connection and try again.
+                    </div>
+                )}
+
                 {/* Render Result List */}
                 {results.length > 0 && (
                     <md-list className="bg-[#1E1E1E] rounded-xl overflow-hidden border border-gray-800 max-h-60 overflow-y-auto">
-                        {results.map((r) => (
-                            <md-list-item key={r.place_id} type="button" onClick={() => onJoin({
-                                id: String(r.osm_id),
-                                name: r.name || r.display_name.split(',')[0],
-                                address: r.display_name,
-                                status: 'verified',
-                                osmId: String(r.osm_id)
-                            })}>
-                                <div slot="headline" className="text-white">{r.name || r.display_name.split(',')[0]}</div>
-                                <div slot="supporting-text" className="text-gray-400 text-xs truncate">{r.display_name}</div>
-                                <md-icon slot="start">location_on</md-icon>
-                            </md-list-item>
-                        ))}
+                        {results.map((r) => {
+                            // osm_id is only unique WITHIN an osm_type
+                            // (node/way/relation) — two unrelated
+                            // places can share a numeric id across
+                            // types, so the id used for our own
+                            // Firestore bar doc must include the type
+                            // or they'd collide onto the same doc.
+                            const barId = r.isFirebase
+                                ? String(r.osm_id)
+                                : `osm_${r.osm_type || 'unknown'}_${r.osm_id}`;
+                            return (
+                                <md-list-item key={r.place_id} type="button" onClick={() => onJoin({
+                                    id: barId,
+                                    name: r.name || r.display_name.split(',')[0],
+                                    address: r.display_name,
+                                    status: 'verified',
+                                    osmId: String(r.osm_id),
+                                    osmType: r.osm_type,
+                                })}>
+                                    <div slot="headline" className="text-white">{r.name || r.display_name.split(',')[0]}</div>
+                                    <div slot="supporting-text" className="text-gray-400 text-xs truncate">{r.display_name}</div>
+                                    <md-icon slot="start">location_on</md-icon>
+                                </md-list-item>
+                            );
+                        })}
                     </md-list>
                 )}
              </div>

--- a/src/components/EightySixDialog.tsx
+++ b/src/components/EightySixDialog.tsx
@@ -12,6 +12,7 @@ import '@material/web/textfield/filled-text-field.js';
 import '@material/web/switch/switch.js';
 
 import type { EightySixEntry } from '../types';
+import { MdDialog } from './MdDialog';
 
 interface EightySixDialogProps {
   open: boolean;
@@ -82,7 +83,7 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
 
   return (
     <>
-      <md-dialog open={open || undefined} onClose={onClose} style={{ maxHeight: '85vh' }}>
+      <MdDialog open={open} onClose={onClose} style={{ maxHeight: '85vh' }}>
         <div slot="headline" className="flex items-center gap-2">
           <md-icon>block</md-icon>
           86'd List
@@ -185,10 +186,10 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
         <div slot="actions">
           <md-text-button onClick={onClose}>Close</md-text-button>
         </div>
-      </md-dialog>
+      </MdDialog>
 
       {/* Delete confirmation dialog */}
-      <md-dialog open={!!confirmDeleteId || undefined} onClose={() => setConfirmDeleteId(null)}>
+      <MdDialog open={!!confirmDeleteId} onClose={() => setConfirmDeleteId(null)}>
         <div slot="headline">Remove from 86'd List?</div>
         <div slot="content">
           Are you sure you want to remove this person from the 86'd list?
@@ -197,7 +198,7 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
           <md-text-button onClick={() => setConfirmDeleteId(null)}>Cancel</md-text-button>
           <md-filled-button onClick={handleDelete} className="btn-alert">Remove</md-filled-button>
         </div>
-      </md-dialog>
+      </MdDialog>
     </>
   );
 };

--- a/src/components/InputDialog.tsx
+++ b/src/components/InputDialog.tsx
@@ -6,6 +6,12 @@ import '@material/web/textfield/filled-text-field.js';
 import '@material/web/list/list.js';
 import '@material/web/list/list-item.js';
 import '@material/web/icon/icon.js';
+import { MdDialog } from './MdDialog';
+
+// Buttons render inside a fixed-height grid cell — anything much past
+// this renders truncated (see the label span's line-clamp) but a hard
+// cap keeps a pasted wall of text from being stored at all.
+const MAX_LABEL_LENGTH = 60;
 
 // Define props for the input dialog.
 interface InputDialogProps {
@@ -28,15 +34,25 @@ interface InputDialogProps {
 // A reusable dialog component for text input with auto-complete suggestions.
 // Used for adding brands, types, and wells.
 const InputDialog = ({ open, mode, searchTerm, onSearchChange, onClose, onSelect, suggestions }: InputDialogProps) => {
-  // Normalize search term for case-insensitive matching.
-  const term = searchTerm.toLowerCase();
+  // Normalize search term for case-insensitive matching AND for what
+  // actually gets submitted — untrimmed input previously let "Coors "
+  // (trailing space) create a distinct duplicate of an existing
+  // "Coors" entry, and pure-whitespace input created a button with a
+  // blank visible label.
+  const trimmed = searchTerm.trim();
+  const term = trimmed.toLowerCase();
   // Filter suggestions.
   const matches = suggestions.filter(i => i.toLowerCase().includes(term));
   // Check if there is an exact match.
   const exactMatch = matches.some(i => i.toLowerCase() === term);
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_LABEL_LENGTH;
+
+  // Submit the trimmed, length-capped value rather than the raw
+  // (possibly whitespace-padded) input.
+  const submit = (value: string) => onSelect(value.trim().slice(0, MAX_LABEL_LENGTH));
 
   return (
-    <md-dialog open={open || undefined} onClose={onClose}>
+    <MdDialog open={open} onClose={onClose}>
       <div slot="headline">
         {/* Dynamic headline based on mode */}
         {mode === 'brand' && 'Select or Add Brand'}
@@ -65,9 +81,9 @@ const InputDialog = ({ open, mode, searchTerm, onSearchChange, onClose, onSelect
                  ))}
 
                  {/* "Create New" Option: Shown if text exists but doesn't exactly match an existing item */}
-                 {searchTerm && !exactMatch && (
-                   <md-list-item type="button" onClick={() => onSelect(searchTerm)}>
-                     <div slot="headline" className="text-blue-400">Create "{searchTerm}"</div>
+                 {canSubmit && !exactMatch && (
+                   <md-list-item type="button" onClick={() => submit(searchTerm)}>
+                     <div slot="headline" className="text-blue-400">Create "{trimmed}"</div>
                      <md-icon slot="end" className="text-blue-400">add_circle</md-icon>
                    </md-list-item>
                  )}
@@ -76,14 +92,14 @@ const InputDialog = ({ open, mode, searchTerm, onSearchChange, onClose, onSelect
          ) : (
              /* 'Well' mode is just simple input submission */
              <div className="flex justify-center p-4">
-                 <md-filled-button onClick={() => onSelect(searchTerm)}>Save & Request</md-filled-button>
+                 <md-filled-button disabled={!canSubmit || undefined} onClick={() => submit(searchTerm)}>Save & Request</md-filled-button>
              </div>
          )}
       </div>
       <div slot="actions">
         <md-text-button onClick={onClose}>Cancel</md-text-button>
       </div>
-    </md-dialog>
+    </MdDialog>
   );
 };
 

--- a/src/components/MdDialog.tsx
+++ b/src/components/MdDialog.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+
+interface MdDialogProps {
+  open?: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+  [key: string]: any;
+}
+
+// Thin wrapper around the <md-dialog> custom element that fixes a
+// real bug: React 19 binds an `onClose` JSX prop on a custom element
+// (any tag containing a hyphen) by listening for an event literally
+// named "Close" — capitalized, unlowercased. Only the built-in
+// <dialog> tag gets special-cased lowercasing in React's custom-
+// element prop handling; <md-dialog> doesn't qualify. Material's
+// md-dialog dispatches a lowercase 'close' event when it closes
+// itself (Escape key, clicking the scrim), so the React onClose prop
+// silently never fires: the dialog closes itself but React's `open`
+// state never flips back to false, and the next open attempt is a
+// no-op because React sees no state change — the dialog is
+// permanently stuck closed until a full page reload.
+//
+// This wrapper binds the real DOM 'close' event via a ref instead of
+// relying on React's custom-element event mapping, so the callback
+// actually fires regardless of how the dialog was dismissed.
+export function MdDialog({ open, onClose, children, ...rest }: MdDialogProps) {
+  const ref = useRef<HTMLElement | null>(null);
+  // Keep the latest onClose in a ref so the listener doesn't need to
+  // be torn down and rebound every time the callback identity changes.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const handleClose = () => onCloseRef.current();
+    el.addEventListener('close', handleClose);
+    return () => el.removeEventListener('close', handleClose);
+  }, []);
+
+  return (
+    <md-dialog ref={ref} open={open || undefined} {...rest}>
+      {children}
+    </md-dialog>
+  );
+}
+
+export default MdDialog;

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -12,6 +12,7 @@ import '@material/web/textfield/filled-text-field.js';
 // Import types and constants.
 import { ButtonConfig } from '../types';
 import { ROLE_NOTIFICATION_DEFAULTS } from '../constants';
+import { MdDialog } from './MdDialog';
 
 // Define props.
 interface NotificationSettingsProps {
@@ -72,7 +73,7 @@ const NotificationSettings = ({
   };
 
   return (
-    <md-dialog open={open || undefined} onClose={onClose}>
+    <MdDialog open={open} onClose={onClose}>
       <div slot="headline">Notification Settings</div>
       <div slot="content" className="flex flex-col gap-4 min-w-[300px]">
         <div className="text-sm text-gray-400">
@@ -135,7 +136,7 @@ const NotificationSettings = ({
         <md-text-button onClick={onClose}>Cancel</md-text-button>
         <md-filled-button onClick={handleSave}>Save</md-filled-button>
       </div>
-    </md-dialog>
+    </MdDialog>
   );
 };
 

--- a/src/components/RoleSelector.test.tsx
+++ b/src/components/RoleSelector.test.tsx
@@ -1,16 +1,24 @@
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import RoleSelector from '../components/RoleSelector';
-import { ROLES } from '../constants';
+import { JOB_TITLES } from '../constants';
 
 describe('RoleSelector', () => {
-  it('renders all roles', () => {
+  it('renders all job titles', () => {
     render(<RoleSelector onSelect={() => {}} />);
-    ROLES.forEach(role => {
-      expect(screen.getByText(role)).toBeInTheDocument();
+    JOB_TITLES.forEach(title => {
+      expect(screen.getByText(title)).toBeInTheDocument();
     });
-    // Explicitly check for "Owner" since it was added
-    expect(screen.getByText('Owner')).toBeInTheDocument();
+  });
+
+  // Owner/Manager are privilege tiers, not self-selectable job
+  // titles — granting either from this list would let any joiner
+  // self-escalate. Owner is auto-assigned via the isNewBar path
+  // below; Manager only comes from promotion by an existing Manager+.
+  it('does not offer Owner or Manager as self-selectable job titles', () => {
+    render(<RoleSelector onSelect={() => {}} />);
+    expect(screen.queryByText('Owner')).not.toBeInTheDocument();
+    expect(screen.queryByText('Manager')).not.toBeInTheDocument();
   });
 
   it('disables clock in button initially', () => {
@@ -34,7 +42,7 @@ describe('RoleSelector', () => {
     });
 
     // Select role
-    const roleItem = screen.getByText(ROLES[0]);
+    const roleItem = screen.getByText(JOB_TITLES[0]);
     await act(async () => {
         fireEvent.click(roleItem);
     });
@@ -52,6 +60,35 @@ describe('RoleSelector', () => {
         fireEvent.click(button);
     });
 
-    expect(handleSelect).toHaveBeenCalledWith(ROLES[0], 'Steve');
+    expect(handleSelect).toHaveBeenCalledWith(JOB_TITLES[0], 'Steve');
+  });
+
+  it('skips the job-title picker and auto-assigns Owner for a newly created bar', async () => {
+    const handleSelect = vi.fn();
+    const { container } = render(<RoleSelector onSelect={handleSelect} isNewBar />);
+
+    expect(screen.getByText(/You Own This Bar/i)).toBeInTheDocument();
+    // No job-title list in this mode.
+    JOB_TITLES.forEach(title => {
+      expect(screen.queryByText(title)).not.toBeInTheDocument();
+    });
+
+    const input = container.querySelector('md-filled-text-field');
+    if (!input) throw new Error('Input not found');
+    await act(async () => {
+        (input as any).value = 'Steve';
+        fireEvent.input(input);
+    });
+
+    const button = container.querySelector('md-filled-button');
+    if (!button) throw new Error('Button not found');
+    await waitFor(() => {
+        expect(button).not.toHaveAttribute('disabled');
+    });
+    await act(async () => {
+        fireEvent.click(button);
+    });
+
+    expect(handleSelect).toHaveBeenCalledWith('Owner', 'Steve');
   });
 });

--- a/src/components/RoleSelector.tsx
+++ b/src/components/RoleSelector.tsx
@@ -5,20 +5,47 @@ import '@material/web/button/filled-button.js';
 import '@material/web/textfield/filled-text-field.js';
 import '@material/web/icon/icon.js';
 import '@material/web/radio/radio.js';
-// Import roles constant.
-import { ROLES } from '../constants';
+// Import job titles constant.
+import { JOB_TITLES } from '../constants';
 
 // Define props.
 interface RoleSelectorProps {
-  onSelect: (role: string, name: string) => void;
+  onSelect: (jobTitle: string, name: string) => void;
   initialName?: string;
+  // True when this user is the one who just created the bar. They
+  // become the bar's Owner automatically (there's no one else yet to
+  // promote them) so we skip the job-title picker and just confirm
+  // their name.
+  isNewBar?: boolean;
 }
 
 // Component to select user role and set display name upon joining.
-const RoleSelector = ({ onSelect, initialName }: RoleSelectorProps) => {
+const RoleSelector = ({ onSelect, initialName, isNewBar }: RoleSelectorProps) => {
   // Local state.
   const [selectedRole, setSelectedRole] = useState('');
   const [displayName, setDisplayName] = useState(initialName || '');
+
+  if (isNewBar) {
+    return (
+      <div className="w-[300px] space-y-6 animate-in fade-in slide-in-from-bottom-4">
+        <div className="text-center space-y-2">
+          <h2 className="text-2xl font-bold text-white">You Own This Bar</h2>
+          <p className="text-gray-500">You created it, so you're the Owner. What should we call you?</p>
+        </div>
+
+        <md-filled-text-field
+          label="Display Name (e.g. 'Angry Steve')"
+          value={displayName}
+          onInput={(e: any) => setDisplayName(e.target.value)}
+          required
+        />
+
+        <md-filled-button disabled={!displayName || null} onClick={() => onSelect('Owner', displayName)}>
+          Clock In
+        </md-filled-button>
+      </div>
+    );
+  }
 
   return (
     <div className="w-[300px] space-y-6 animate-in fade-in slide-in-from-bottom-4">
@@ -35,9 +62,9 @@ const RoleSelector = ({ onSelect, initialName }: RoleSelectorProps) => {
         required
       />
 
-      {/* Role List */}
+      {/* Job Title List */}
       <div className="bg-[#1E1E1E] rounded-xl overflow-hidden border border-gray-800 max-h-60 overflow-y-auto">
-        {ROLES.map((role) => (
+        {JOB_TITLES.map((role) => (
           <div
             key={role}
             // Selecting via clicking the row.

--- a/src/components/SortableButton.tsx
+++ b/src/components/SortableButton.tsx
@@ -36,6 +36,18 @@ export function SortableButton({ id, children, onClick, disabled }: SortableButt
     touchAction: 'manipulation'
   };
 
+  // dnd-kit's `attributes` add role="button" and tabIndex={0} to this
+  // div, but activation (Enter/Space -> click) is not synthesized by
+  // the browser for a non-native element with an ARIA button role —
+  // that's only automatic for real <button>s. Without this handler
+  // the entire button grid has no keyboard-operable path at all.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
     <div
       ref={setNodeRef}
@@ -44,6 +56,7 @@ export function SortableButton({ id, children, onClick, disabled }: SortableButt
       {...attributes}
       {...listeners}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       className="h-full w-full relative"
     >
       {children}

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -11,6 +11,7 @@ import '@material/web/progress/circular-progress.js';
 
 import type { BarTheme } from '../types';
 import { getContrastColor } from '../utils/color';
+import { MdDialog } from './MdDialog';
 
 const FONT_OPTIONS = [
   { label: 'System Default', value: 'system-ui, sans-serif' },
@@ -115,9 +116,15 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
   };
 
   const contrastColor = getContrastColor(primaryColor);
+  // The actual button grid uses accentColor as the button background
+  // (see useBarTheme) and derives its label color from THIS contrast
+  // pair, not primaryColor's — the preview needs to match or a
+  // red/pink accent would look fine here and illegible on the real
+  // dashboard.
+  const accentContrastColor = getContrastColor(accentColor);
 
   return (
-    <md-dialog open={open || undefined} onClose={onClose} style={{ maxHeight: '85vh' }}>
+    <MdDialog open={open} onClose={onClose} style={{ maxHeight: '85vh' }}>
       <div slot="headline" className="flex items-center gap-2">
         <md-icon>palette</md-icon>
         Customize Theme
@@ -204,7 +211,7 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
           <div className="text-xs text-gray-500 mb-2 uppercase">Preview</div>
           <div className="flex items-center gap-3 p-3 rounded" style={{ backgroundColor: accentColor, fontFamily }}>
             {logoUrl && <img src={logoUrl} alt="Preview logo" className="h-8 w-8 rounded-full object-cover" />}
-            <span className="font-bold" style={{ color: primaryColor }}>Your Bar Name</span>
+            <span className="font-bold" style={{ color: accentContrastColor }}>Your Bar Name</span>
           </div>
           <div className="mt-2 flex gap-2">
             <button
@@ -230,7 +237,7 @@ const ThemeEditor = ({ open, onClose, currentTheme, onSave, barId }: ThemeEditor
           {saving ? 'Saving...' : 'Save'}
         </md-filled-button>
       </div>
-    </md-dialog>
+    </MdDialog>
   );
 };
 

--- a/src/components/WhoIsOnDialog.tsx
+++ b/src/components/WhoIsOnDialog.tsx
@@ -1,29 +1,68 @@
 // Import Material Web components.
 import '@material/web/dialog/dialog.js';
 import '@material/web/button/text-button.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
 import '@material/web/list/list.js';
 import '@material/web/list/list-item.js';
 import '@material/web/icon/icon.js';
 // Import User type.
 import { BarUser } from '../types';
+import { MdDialog } from './MdDialog';
 
 // Define props.
 interface WhoIsOnDialogProps {
   open: boolean;
   onClose: () => void;
   users: BarUser[];
+  // Manager+ only: lets a manager approve or reject someone waiting
+  // on an 'approval' joinPolicy bar. Omit (or pass isManagerPlus:
+  // false) to hide the approvals section entirely.
+  isManagerPlus?: boolean;
+  onApprove?: (userId: string) => void;
+  onReject?: (userId: string) => void;
 }
 
-// Dialog to show list of users in the current bar.
-export const WhoIsOnDialog = ({ open, onClose, users }: WhoIsOnDialogProps) => {
+// Dialog to show list of users in the current bar, and — for
+// Manager+ — approve or reject anyone waiting on 'approval' joinPolicy.
+// This is the other half of a policy firestore.rules already
+// enforces (self-create writes status:'pending' for that policy):
+// without an approve action anywhere in the app, a pending user had
+// no way to ever be let in.
+export const WhoIsOnDialog = ({ open, onClose, users, isManagerPlus, onApprove, onReject }: WhoIsOnDialogProps) => {
   // Filter for active users (clocked in).
   // Note: users with undefined status are treated as active for backward compatibility.
   const clockedInUsers = users.filter(u => u.status === 'active' || u.status === undefined);
+  const pendingUsers = users.filter(u => u.status === 'pending');
 
   return (
-    <md-dialog open={open || undefined} onClose={onClose}>
+    <MdDialog open={open} onClose={onClose}>
       <div slot="headline">Who's On</div>
       <div slot="content" className="flex flex-col gap-4 min-w-[300px]">
+
+        {/* Section: Pending Approval (Manager+ only) */}
+        {isManagerPlus && pendingUsers.length > 0 && (
+          <div>
+            <h3 className="text-yellow-400 font-bold text-sm uppercase tracking-wide mb-2">
+              Waiting for Approval ({pendingUsers.length})
+            </h3>
+            <div className="border border-yellow-900 rounded overflow-hidden">
+              <md-list>
+                {pendingUsers.map(u => (
+                  <md-list-item key={u.id}>
+                    <div slot="headline" className="text-white">{u.displayName || 'Unknown'}</div>
+                    <div slot="supporting-text" className="text-gray-400">{u.jobTitle || u.role}</div>
+                    <md-icon slot="start" className="text-yellow-500">hourglass_empty</md-icon>
+                    <div slot="end" className="flex gap-2">
+                      <md-outlined-button onClick={() => onReject?.(u.id)}>Reject</md-outlined-button>
+                      <md-filled-button onClick={() => onApprove?.(u.id)}>Approve</md-filled-button>
+                    </div>
+                  </md-list-item>
+                ))}
+              </md-list>
+            </div>
+          </div>
+        )}
 
         {/* Section: Clocked In */}
         <div>
@@ -33,7 +72,7 @@ export const WhoIsOnDialog = ({ open, onClose, users }: WhoIsOnDialogProps) => {
                    {clockedInUsers.map(u => (
                        <md-list-item key={u.id}>
                            <div slot="headline" className="text-white">{u.displayName || 'Unknown'}</div>
-                           <div slot="supporting-text" className="text-gray-400">{u.role}</div>
+                           <div slot="supporting-text" className="text-gray-400">{u.jobTitle || u.role}</div>
                            <md-icon slot="start" className="text-green-500">fiber_manual_record</md-icon>
                        </md-list-item>
                    ))}
@@ -45,6 +84,6 @@ export const WhoIsOnDialog = ({ open, onClose, users }: WhoIsOnDialogProps) => {
       <div slot="actions">
         <md-text-button onClick={onClose}>Close</md-text-button>
       </div>
-    </md-dialog>
+    </MdDialog>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,13 @@ import { ButtonConfig } from './types';
 
 export const NTFY_DISPATCH_CONCURRENCY = 5;
 
-// Define the list of available roles in the application.
-// These are used for role selection and permission logic.
-export const ROLES = ['Owner', 'Bartender', 'Barback', 'Server', 'Manager', 'Security', 'Runner'];
+// Job titles a joining user can self-select. This is deliberately
+// NOT the privilege list — 'Owner' is auto-assigned to whoever
+// creates the bar and 'Manager' can only be granted by promotion, so
+// neither is self-selectable here. Selecting a title sets `jobTitle`
+// (display + notification defaults); the security-relevant `role`
+// field is computed separately (see App.tsx confirmRole).
+export const JOB_TITLES = ['Bartender', 'Barback', 'Server', 'Security', 'Runner'];
 
 // Define a default list of common beer brands to populate suggestions.
 export const DEFAULT_BEERS = [

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -8,7 +8,11 @@ declare module 'react' {
         open?: boolean;
         quick?: boolean;
         positioning?: string;
-        onClosed?: () => void;
+        // Deliberately no `onClosed` here — md-menu dispatches a
+        // lowercase 'closed' DOM event which React's custom-element
+        // prop binding does not map correctly (see MdDialog.tsx for
+        // the same issue on md-dialog/onClose). Bind it via a ref +
+        // addEventListener instead, as App.tsx does.
       };
       'md-menu-item': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
         headline?: string;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -81,17 +81,31 @@ export const requestNotificationPermission = async () => {
 
     // Check if the user granted permission.
     if (permission === 'granted') {
+      // getToken() defaults to looking for a service worker at the
+      // origin-root path '/firebase-messaging-sw.js', which 404s once
+      // the app is deployed under a subpath (e.g. GitHub Pages) — the
+      // file is actually served at `${BASE_URL}firebase-messaging-sw.js`.
+      // Register it explicitly at the right path and hand that
+      // registration to getToken() instead of relying on its default.
+      const swRegistration = await navigator.serviceWorker.register(
+        `${import.meta.env.BASE_URL}firebase-messaging-sw.js`
+      );
       // If granted, retrieve the FCM registration token.
       // The 'vapidKey' is required for web push notifications and identifies the sender.
-      const token = await getToken(messaging, { 
-        vapidKey: import.meta.env.VITE_FIREBASE_VAPID_KEY 
+      const token = await getToken(messaging, {
+        vapidKey: import.meta.env.VITE_FIREBASE_VAPID_KEY,
+        serviceWorkerRegistration: swRegistration,
       });
       // Return the token to be used for sending notifications to this device.
       return token;
     }
   } catch (error) {
     // Log any errors that occur during the permission request process.
-    console.error("Notification permission denied", error);
+    // (Despite the message below, this branch also catches SW
+    // registration and getToken() failures, not just a denied prompt
+    // — permission denial is handled by the `if` above, which simply
+    // skips this block and returns null.)
+    console.error("Failed to set up push notifications", error);
   }
   // Return null if permission was denied or an error occurred.
   return null;

--- a/src/hooks/useBarTheme.ts
+++ b/src/hooks/useBarTheme.ts
@@ -14,6 +14,7 @@ export function useBarTheme(theme: BarTheme | undefined, isPremium: boolean): vo
       root.style.removeProperty('--md-sys-color-primary');
       root.style.removeProperty('--md-sys-color-on-primary');
       root.style.removeProperty('--md-sys-color-secondary-container');
+      root.style.removeProperty('--bb-button-label-color');
       root.style.removeProperty('font-family');
       return;
     }
@@ -24,6 +25,12 @@ export function useBarTheme(theme: BarTheme | undefined, isPremium: boolean): vo
     }
     if (theme.accentColor) {
       root.style.setProperty('--md-sys-color-secondary-container', theme.accentColor);
+      // The grid button label/icon color is otherwise a fixed red
+      // (see --bb-button-label-color's default in index.css) — on a
+      // themed bar the button's background IS this accent color, so
+      // a red/pink/orange brand color would make the label illegible
+      // against its own background without this override.
+      root.style.setProperty('--bb-button-label-color', getContrastColor(theme.accentColor));
     }
     if (theme.fontFamily) {
       root.style.setProperty('font-family', theme.fontFamily);
@@ -33,6 +40,7 @@ export function useBarTheme(theme: BarTheme | undefined, isPremium: boolean): vo
       root.style.removeProperty('--md-sys-color-primary');
       root.style.removeProperty('--md-sys-color-on-primary');
       root.style.removeProperty('--md-sys-color-secondary-container');
+      root.style.removeProperty('--bb-button-label-color');
       root.style.removeProperty('font-family');
     };
   }, [theme, isPremium]);

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -2,12 +2,13 @@ import { useRef, useState } from 'react';
 import {
   TouchSensor,
   MouseSensor,
+  KeyboardSensor,
   useSensor,
   useSensors,
   DragEndEvent,
   DragStartEvent,
 } from '@dnd-kit/core';
-import { arrayMove } from '@dnd-kit/sortable';
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { doc, updateDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { ButtonConfig } from '../types';
@@ -36,6 +37,13 @@ export function useDragAndDrop({ barId, customOrders, setCustomOrders }: UseDrag
     }),
     useSensor(MouseSensor, {
       activationConstraint: { distance: 10 },
+    }),
+    // Without this, reordering has no keyboard-operable path at all —
+    // SortableButton is focusable (dnd-kit gives it tabIndex=0) but
+    // Space/arrow-key pickup only works if a KeyboardSensor is
+    // registered here.
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
 

--- a/src/hooks/useNag.ts
+++ b/src/hooks/useNag.ts
@@ -29,8 +29,11 @@ export function useNag(activeRequests: Request[], ignoredIds: string[]) {
        // If there are actionable pending requests...
        if (pending.length > 0) {
            // Initialize the Audio object if it doesn't exist yet.
+           // Root-absolute '/alert.wav' 404s once the app is deployed
+           // under a subpath (e.g. GitHub Pages) — BASE_URL resolves
+           // to wherever the app is actually served from.
            if (!audioRef.current) {
-               audioRef.current = new Audio('/alert.wav');
+               audioRef.current = new Audio(`${import.meta.env.BASE_URL}alert.wav`);
            }
 
            // Reset the audio playback position to the start.

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -46,7 +46,7 @@ export function usePushNotifications() {
 
           await PushNotifications.addListener('pushNotificationReceived', () => {
             if (navigator.vibrate) navigator.vibrate([500, 200, 500]);
-            if (!audioRef.current) audioRef.current = new Audio('/alert.wav');
+            if (!audioRef.current) audioRef.current = new Audio(`${import.meta.env.BASE_URL}alert.wav`);
             const audio = audioRef.current;
             audio.pause();
             audio.onended = null;
@@ -102,14 +102,14 @@ export function usePushNotifications() {
         try {
           new Notification(payload.notification.title, {
             body: payload.notification.body,
-            icon: '/icon-192x192.png',
+            icon: `${import.meta.env.BASE_URL}icon-192x192.png`,
           });
         } catch (e) {
           console.warn('Notification display failed', e);
         }
       }
 
-      if (!audioRef.current) audioRef.current = new Audio('/alert.wav');
+      if (!audioRef.current) audioRef.current = new Audio(`${import.meta.env.BASE_URL}alert.wav`);
       const audio = audioRef.current;
       let plays = 0;
       audio.onended = () => {

--- a/src/hooks/useRequestActions.ts
+++ b/src/hooks/useRequestActions.ts
@@ -75,7 +75,17 @@ export function useRequestActions({
         return;
       }
 
-      if (prefs && btnId && prefs.includes(btnId)) {
+      // Free-text / unrecognized labels (custom requests, "(Ask Me)"
+      // auto-submits) have no btnId to check preferences against.
+      // activeRequests in App.tsx treats this the same way — shown to
+      // everyone as a safety default — so mirror that here instead of
+      // silently notifying nobody.
+      if (!btnId) {
+        topics.add(u.ntfyTopic);
+        return;
+      }
+
+      if (prefs && prefs.includes(btnId)) {
         topics.add(u.ntfyTopic);
       }
     });
@@ -102,13 +112,25 @@ export function useRequestActions({
     );
   }, [user, barId, displayName, userRole, allUsers, getButtonIdForLabel]);
 
+  // Firestore serializes writes to a single document, and
+  // firestore.rules requires resource.data.status == 'pending' for
+  // this update — so if two barbacks tap CLAIM on the same request,
+  // whichever write commits first flips it to 'claimed' and the
+  // second is evaluated against that new state and denied. The
+  // rejection surfaces here as a thrown error so the UI can tell the
+  // loser they lost the race instead of failing silently.
   const claimRequest = useCallback(async (reqId: string) => {
-    await updateDoc(doc(db, 'requests', reqId), {
-      status: 'claimed',
-      claimedBy: user?.uid,
-      claimerName: displayName,
-      claimedAt: serverTimestamp(),
-    });
+    try {
+      await updateDoc(doc(db, 'requests', reqId), {
+        status: 'claimed',
+        claimedBy: user?.uid,
+        claimerName: displayName,
+        claimedAt: serverTimestamp(),
+      });
+    } catch (e) {
+      console.error('Failed to claim request (likely already claimed)', e);
+      throw e;
+    }
   }, [user, displayName]);
 
   const cancelRequest = useCallback(async (reqId: string) => {

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,14 @@
   --md-sys-color-secondary-container: #333333;
   --md-sys-color-on-secondary-container: #E2E2E2;
 
+  /* Grid button label/icon color. Defaults to the app's red accent;
+     overridden by useBarTheme to a WCAG-contrasted color against the
+     premium bar's chosen accentColor (which becomes the button
+     background via --md-sys-color-secondary-container above) so a
+     red/pink brand color can't make the label illegible against
+     itself. */
+  --bb-button-label-color: #EF4444;
+
   /* Shape - Expressive but Precise */
   --md-sys-shape-corner-small: 8px;
   --md-sys-shape-corner-medium: 12px;

--- a/src/test/firestore-rules.test.ts
+++ b/src/test/firestore-rules.test.ts
@@ -96,8 +96,18 @@ describe('Firestore security rules', () => {
 
     it('lets a non-member create a new bar (claim flow)', async () => {
       const db = env.authenticatedContext(BOB).firestore();
+      // The creator must name themselves as ownerId — this is what
+      // lets their own upcoming bars/{id}/users/{uid} self-create
+      // claim the 'Owner' role (see the userRoles.test.ts create-path
+      // cases for that half of the flow).
       await assertSucceeds(setDoc(doc(db, 'bars', 'fresh-bar'),
-        { name: 'New', status: 'temporary' }));
+        { name: 'New', status: 'temporary', ownerId: BOB }));
+    });
+
+    it('denies creating a bar with someone else named as ownerId', async () => {
+      const db = env.authenticatedContext(BOB).firestore();
+      await assertFails(setDoc(doc(db, 'bars', 'fresh-bar-2'),
+        { name: 'New', status: 'temporary', ownerId: ALICE }));
     });
 
     it('denies Staff from updating bar settings', async () => {

--- a/src/test/rules/bar.test.ts
+++ b/src/test/rules/bar.test.ts
@@ -64,10 +64,25 @@ describe("bar rules", () => {
     }));
   });
 
-  it("Staff cannot set status to active via self-write", async () => {
-    // Seed staff_bob as off_clock so that an attempted change to 'active' is a real diff.
+  it("Staff can clock back in (self-write status active, from off_clock)", async () => {
+    // A user who clocks out must be able to clock back in on their
+    // own — without this, off_clock was a one-way door that silently
+    // dropped them from every notification fanout forever.
     await env.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(doc(ctx.firestore(), "bars/bar_A/users/staff_bob"), { role: "Staff", status: "off_clock" });
+    });
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      status: "active",
+    }));
+  });
+
+  it("Staff cannot self-activate out of pending (still requires Manager approval)", async () => {
+    // The self-write active<->off_clock toggle must not become a way
+    // to skip the 'approval' joinPolicy — only a Manager+ update (or
+    // starting from off_clock) may set status to 'active'.
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "bars/bar_A/users/staff_bob"), { role: "Staff", status: "pending" });
     });
     const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
     await assertFails(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {

--- a/src/test/rules/userRoles.test.ts
+++ b/src/test/rules/userRoles.test.ts
@@ -141,10 +141,28 @@ describe("user role rules (owner immunity matrix)", () => {
   });
 
   it("New joiner can self-create with role:Staff status:pending (approval policy)", async () => {
+    // bar_A defaults to joinPolicy 'open' in the top-level seed;
+    // switch it to 'approval' for this case so a self-create is only
+    // accepted with status 'pending', matching what confirmRole
+    // actually writes for an approval-gated bar.
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "bars/bar_A"), { name: "Bar A", joinPolicy: "approval" });
+    });
     const db = authedAs(env, "new_user_w", { bars: {} });
     await assertSucceeds(setDoc(doc(db, "bars/bar_A/users/new_user_w"), {
       role: "Staff",
       status: "pending",
+    }));
+  });
+
+  it("New joiner cannot self-create with status:active on an approval-policy bar", async () => {
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "bars/bar_A"), { name: "Bar A", joinPolicy: "approval" });
+    });
+    const db = authedAs(env, "new_user_v", { bars: {} });
+    await assertFails(setDoc(doc(db, "bars/bar_A/users/new_user_v"), {
+      role: "Staff",
+      status: "active",
     }));
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,18 @@ export interface Bar {
   phone?: string;
   // Optional: OpenStreetMap ID, if linked.
   osmId?: string;
+  // Optional: OpenStreetMap element type ('node' | 'way' | 'relation').
+  // osm_id is only unique within a given osm_type, so the pair is
+  // what actually identifies an OSM place — osmId alone can collide
+  // across two unrelated venues.
+  osmType?: string;
   // The verification status of the bar ('verified' is public, 'temporary' is for shift-only use).
   status: 'verified' | 'temporary';
+  // The uid of the user who created this bar document. Set once at
+  // creation and immutable thereafter (see firestore.rules). Lets a
+  // brand-new bar's creator self-assign the 'Owner' role on join,
+  // since there's no existing Owner/Manager to promote them.
+  ownerId: string;
   // Optional: The type of establishment.
   type?: 'bar' | 'restaurant';
   // Optional: Inventory mapping for beer (Brand -> Array of Types).
@@ -101,13 +111,23 @@ export interface Notice {
 // Define the structure of a result from the OpenStreetMap API search.
 export interface OSMResult {
   // The unique Place ID from OSM.
-  place_id: number;
-  // The unique OSM object ID.
-  osm_id: number;
+  place_id: number | string;
+  // The unique OSM object ID. NOTE: osm_id is only unique within a
+  // given osm_type ('node' | 'way' | 'relation') — two unrelated
+  // places can share the same osm_id if they're different element
+  // types, so osm_id alone is not a safe identity key.
+  osm_id: number | string;
+  // The OSM element type. Present on live Nominatim results; absent
+  // on results synthesized from our own Firestore `bars` collection
+  // (isFirebase: true), which already have a stable Firestore doc id.
+  osm_type?: string;
   // The full display name (address).
   display_name: string;
   // The specific name of the place.
   name: string;
+  // True for results synthesized from our own Firestore `bars`
+  // collection rather than a live Nominatim lookup.
+  isFirebase?: boolean;
 }
 
 // Define the data model for a User profile within a specific Bar context.
@@ -116,8 +136,14 @@ export interface BarUser {
   id: string;
   // Optional: The user's display name.
   displayName?: string;
-  // Optional: The user's role (e.g., 'Bartender', 'Barback').
+  // Optional: The user's privilege tier ('Staff' | 'Manager' | 'Owner').
+  // This is what firestore.rules and the `bars` token claim key off
+  // of — it is NOT the user's job function, see `jobTitle`.
   role?: string;
+  // Optional: The user's job function (e.g. 'Bartender', 'Barback'),
+  // used for display and as the key into ROLE_NOTIFICATION_DEFAULTS.
+  // Distinct from `role`, which is the privilege tier.
+  jobTitle?: string;
   // Optional: The user's current status.
   status?: 'active' | 'off_clock' | 'pending' | 'rejected';
   // Optional: The timestamp of the user's last activity.

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -3,8 +3,14 @@
  * Uses the WCAG relative luminance formula.
  */
 export function getContrastColor(hex: string): string {
-  // Remove # prefix if present.
-  const clean = hex.replace('#', '');
+  // Remove # prefix if present, and expand 3-digit shorthand (#fff ->
+  // ffffff) so the fixed-width substring reads below don't silently
+  // misparse a short hex code (e.g. reading "f" as "6%" instead of
+  // "100%" for the green channel of #fff).
+  let clean = hex.replace('#', '');
+  if (clean.length === 3) {
+    clean = clean.split('').map(c => c + c).join('');
+  }
   const r = parseInt(clean.substring(0, 2), 16) / 255;
   const g = parseInt(clean.substring(2, 4), 16) / 255;
   const b = parseInt(clean.substring(4, 6), 16) / 255;


### PR DESCRIPTION
## Summary

Fixes a set of app-breaking and security-critical issues surfaced by a multi-pass adversarial audit (7 parallel reviews covering app shell, bar discovery, auth/rules, notifications/PWA, request lifecycle, theming/UI, and the end-to-end UX flow). Two headline findings made the app effectively unusable as shipped:

1. **Nobody could join a bar.** `firestore.rules` required `role == 'Staff'` on self-join, but the client wrote job titles like `'Bartender'` as the privilege `role` — every first join was a silent `permission-denied`.
2. **The deployed site was a blank page.** `index.html`'s `<base href="/barbacker/">` used the wrong case for the real GitHub Pages path (`/BarBacker/`), so every asset 404'd.

### Core / app-breaking
- Split the security-relevant `role` (`'Staff' | 'Manager' | 'Owner'`) from a new `jobTitle` field (display + notification defaults). Bar creators auto-become `'Owner'` via a new `ownerId` field on the bar doc; everyone else self-joins as `'Staff'`.
- Removed the wrong-case `<base href>` — Vite's `base: './'` and the app's `HashRouter` don't need it, and it was actively causing the 404s.
- Clocking out was a one-way door: the self-write rule only ever allowed `status: 'off_clock'`, never back to `'active'` — a user who clocked out silently stopped receiving every notification, forever, with the error swallowed. Rules now allow the `off_clock ⇄ active` self-toggle (but not self-activating out of `'pending'`).

### Security (`firestore.rules`)
- Claiming a request had no precondition — two barbacks could both "win" a claim. Now requires `resource.data.status == 'pending'`; Firestore's own write serialization then makes this race-free without a client-side transaction.
- Request updates could rewrite `barId`/`requesterId`/`label`, letting any bar member hijack a request into another bar or forge its requester. Locked to a claim-only field diff.
- The `'approval'` joinPolicy was declared in the type but never enforced or actionable — self-create now checks it server-side, and a Manager+ approve/reject UI was added to the Who's On dialog (previously nothing in the app could ever move a pending user to active).
- Tightened notice `authorId`/delete rules, the per-bar-user create field allowlist, the Manager-update field allowlist (can no longer rewrite a colleague's `ntfyTopic`), and gated invite read/consume on a verified email address.

### UI/UX
- `md-dialog`'s `onClose` (and `md-menu`'s `onClosed`) never fired under React 19 — it binds custom-element event props without lowercasing, while Material dispatches lowercase `close`/`closed`, so every dialog in the app got permanently stuck open after the first Escape/scrim dismissal. Added an `MdDialog` wrapper that binds the real DOM event via a ref.
- The button grid had no keyboard-operable path at all — added Enter/Space activation plus a dnd-kit `KeyboardSensor`.
- A themed bar's accent color could make button labels illegible against their own background — labels/icons now derive their color from the same contrast pair as the background.
- `BarSearch`: fixed OSM identity collisions across element types (`osm_id` alone isn't unique), stale results left on screen after a failed search, and untrimmed create/search input.
- `InputDialog`: trim/whitespace/length validation; button labels truncate instead of overflowing the grid.
- Unmatched free-text requests (custom / "(Ask Me)") now fan out to everyone via ntfy, matching the in-app "show to everyone" safety default instead of paging nobody.
- Fixed the messaging service worker's registration path and icon paths so they resolve correctly under a deployed subpath.

## Test plan

- [x] `npm run build` (tsc + vite build) passes
- [x] `npm test` — 76/76 jsdom tests pass (added/updated `RoleSelector.test.tsx` for the job-title/Owner-auto-assign split)
- [x] `npm run test:rules` — 56/56 Firestore rules tests pass against the emulator (added/updated cases for `ownerId`, claim-race precondition, approval-policy self-create, and the off-clock ⇄ active self-toggle)
- [x] `functions` package build + tests pass
- [ ] Manual smoke test of the deployed site once merged (base-path fix can only be fully verified against the real GitHub Pages URL)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Split user privilege roles from display job titles, enforce bar join policies and ownership in both client and rules, and harden request, notification, and deployment behavior.

New Features:
- Introduce jobTitle as a separate, user-selectable job function distinct from privilege role, with Owner auto-assigned to bar creators via ownerId.
- Add Manager+ approval and rejection controls for pending bar join requests in the Who’s On dialog based on bar joinPolicy.
- Enable keyboard-accessible button reordering and activation via dnd-kit KeyboardSensor and explicit Enter/Space handling.

Bug Fixes:
- Fix md-dialog and md-menu dismissal so close events correctly update React state, preventing dialogs and menus from getting stuck open or closed.
- Correct GitHub Pages deployment paths for favicon, icons, alert audio, service worker, and push notifications so assets resolve under the app’s subpath.
- Ensure request claiming is race-safe and surfaces conflicts to the UI, and fan out unmatched free-text requests to all staff instead of notifying nobody.
- Prevent request and user documents from being silently miswritten by tightening client logic around status transitions, bar ownership, and data fanout.
- Resolve BarSearch issues around OSM identity collisions, stale or failing search states, and untrimmed create fields, and add better error feedback.
- Prevent off_clock from being a one-way state by allowing users to clock back in while still blocking self-activation out of pending.
- Guard background notification handling when payloads lack notification fields to avoid dropped alerts.

Enhancements:
- Gate Manager-level UI actions on privilege role while keeping Firestore rules as the source of truth.
- Improve theming legibility by deriving button label/icon colors from a contrast-aware accent color and honoring 3-digit hex codes.
- Refine dialog copy and behaviors around clocking out, button removal, and bar management to clarify impact across devices and premium requirements.
- Add error logging for key Firestore listeners and token operations to aid diagnostics.
- Trim and length-cap InputDialog values to avoid duplicate or blank button labels and align grid rendering with stored data.

Build:
- Adjust service worker generation and notification icons to work correctly with data-only payloads and relative asset paths under the deployed scope.

Tests:
- Expand Firestore rules tests to cover ownerId semantics, approval-policy joins, staff clock-in/clock-out toggles, and bar creation ownership constraints.
- Update RoleSelector tests for the job-title model and the new Owner auto-assignment flow for freshly created bars.