### PR TITLE
Notification pipeline parity, CI/build config, iOS push, listener redundancy

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -27,20 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Inject Google Services
+      - name: Inject ARCore API Key
         env:
-          GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
         run: |
-          if [ -f "app/google-services.json.template" ]; then
-            echo "Template found. Injecting secrets..."
-            sed -e 's/{{\([^}]*\)}}/${\1}/g' app/google-services.json.template | envsubst > app/google-services.json
-          else
-            echo "Warning: google-services.json.template not found. Skipping injection."
-          fi
-
           # Inject ARCore API Key into local.properties for build.gradle.kts to pick up
           echo "ARCORE_API_KEY=$ARCORE_API_KEY" >> local.properties
 
@@ -63,14 +53,19 @@ jobs:
               -name "$KEY_ALIAS" -out keystore.p12 \
               -password pass:"$KEYSTORE_PASSWORD"
 
-            # Convert the PKCS12 file to a JKS keystore
+            # Convert the PKCS12 file to a JKS keystore. Written under
+            # android/app/ — the Capacitor Android app's actual
+            # location; this previously wrote to app/keystore.jks (a
+            # directory that doesn't exist in this repo), so the
+            # existence check below always failed and every release
+            # silently fell back to the default debug keystore.
             keytool -importkeystore -srckeystore keystore.p12 -srcstoretype PKCS12 \
-              -destkeystore app/keystore.jks -deststoretype JKS \
+              -destkeystore android/app/keystore.jks -deststoretype JKS \
               -srcstorepass "$KEYSTORE_PASSWORD" \
               -deststorepass "$KEYSTORE_PASSWORD" \
               -alias "$KEY_ALIAS" -noprompt
 
-            echo "Keystore generated successfully at app/keystore.jks"
+            echo "Keystore generated successfully at android/app/keystore.jks"
 
             # Clean up temporary files
             rm private_key.pem certificate_chain.crt keystore.p12
@@ -87,7 +82,35 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Generate google-services.json
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+        run: |
+          # The step that used to live here looked for
+          # app/google-services.json.template using secret names
+          # (GOOGLE_SERVICES_API_KEY, PROJECT_ID, CLIENT_ID) that exist
+          # nowhere else in this repo, at a path ("app/") that isn't
+          # where the Capacitor Android app lives ("android/app/"), and
+          # no such template file was ever checked in — so the
+          # injection silently no-op'd on every run and every built APK
+          # shipped with FCM compiled out. This script writes directly
+          # to android/app/google-services.json from the same
+          # VITE_FIREBASE_* secrets used for the web build below.
+          node scripts/generate-google-services.js
+
       - name: Build Web App
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}
         run: npm run build
 
       - name: Sync Capacitor
@@ -118,10 +141,10 @@ jobs:
           export BUILD_NUMBER=$(git rev-list --count HEAD)
           
           # Build the APK
-          if [ -f "app/keystore.jks" ]; then
+          if [ -f "android/app/keystore.jks" ]; then
             echo "Building with custom keystore..."
             ./android/gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache \
-              -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
+              -Pandroid.injected.signing.store.file=$(pwd)/android/app/keystore.jks \
               -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
               -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
               -Pandroid.injected.signing.key.password=$KEY_PASSWORD \

--- a/.github/workflows/nag.yml
+++ b/.github/workflows/nag.yml
@@ -33,10 +33,35 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.create({
+            // This runs every 5 minutes — without a dedupe check, a
+            // single expired secret or persistent bug files up to 288
+            // duplicate issues per day. Reuse an existing open one
+            // instead of creating a fresh issue on every run.
+            const title = `Workflow Failed: ${context.workflow}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Workflow Failed: ${context.workflow}`,
-              body: `The workflow failed. See logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              assignees: ['Jules']
-            })
+              state: 'open',
+              labels: 'nag-bot-failure',
+            });
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The workflow failed. See logs: ${runUrl}`,
+                labels: ['nag-bot-failure'],
+                assignees: ['Jules']
+              });
+            }

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;
@@ -317,6 +318,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -32,6 +32,10 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/scripts/nag-bot.js
+++ b/scripts/nag-bot.js
@@ -33,11 +33,40 @@ initializeApp({
 const db = getFirestore();
 const messaging = getMessaging();
 
+// Mirrors src/constants.ts's ROLE_NOTIFICATION_DEFAULTS. This script
+// runs standalone under plain Node (no Vite/TS build step), so it
+// can't import the TypeScript source directly — keep this in sync by
+// hand if the defaults there change.
+const ROLE_NOTIFICATION_DEFAULTS = {
+  'Owner': ['manager', 'security', 'keg', 'trash', 'ice', 'glass', 'fruit', 'restock', 'mixers', 'restock_beer', 'break'],
+  'Manager': ['manager', 'security', 'keg', 'trash', 'break'],
+  'Bartender': ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer'],
+  'Barback': ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer', 'break'],
+  'Server': [],
+  'Runner': ['ice', 'glass', 'restock', 'mixers', 'restock_beer'],
+  'Security': ['security', 'manager', 'break'],
+};
+
+// Given a pending request and a bar member, decide whether this nag
+// should mention it — mirrors useRequestActions.ts's immediate fanout
+// so a "reminder" push doesn't reach someone who was never subscribed
+// (or was explicitly excluded, e.g. off-clock) in the first place.
+function shouldNagUserAbout(req, member) {
+  if (member.status !== 'active' && member.status !== undefined) return false;
+  if ((req.label || '').includes('BREAK') || req.buttonId === 'break') return true;
+  // No resolvable button (free-text/custom request): shown to
+  // everyone in-app as a safety default, so nag everyone too.
+  if (!req.buttonId) return true;
+  const prefs = member.notificationPreferences
+    || ROLE_NOTIFICATION_DEFAULTS[member.jobTitle] || ROLE_NOTIFICATION_DEFAULTS[member.role] || [];
+  return prefs.includes(req.buttonId);
+}
+
 // Main function to check for ignored requests and send reminders ("Nags").
 async function nag() {
   // Define the threshold for "ignored": 5 minutes since the last notification/creation.
   const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
-  
+
   // --- Step 1: Query Ignored Requests ---
   // Find requests that are 'pending' AND haven't been notified about since 'fiveMinutesAgo'.
   const snapshot = await db.collection('requests')
@@ -55,61 +84,88 @@ async function nag() {
   // --- Step 2: Group by Bar ---
   // We group requests by Bar ID to send a single consolidated notification per bar,
   // preventing notification spam if there are multiple pending items (e.g., 10 "Ice" requests).
-  const barUpdates = {}; // Map of barId -> [requestLabels]
+  const barUpdates = {}; // Map of barId -> [{ label, buttonId }]
 
   snapshot.docs.forEach(doc => {
     const data = doc.data();
     if (!barUpdates[data.barId]) barUpdates[data.barId] = [];
-    barUpdates[data.barId].push(data.label);
+    barUpdates[data.barId].push({ label: data.label, buttonId: data.buttonId });
   });
 
   // --- Step 3: Send Notifications per Bar ---
-  for (const [barId, labels] of Object.entries(barUpdates)) {
-    // Fetch all user tokens associated with this bar.
-    // In BarBacker, `bars/{barId}/tokens` contains documents where the ID is the User UID and the data contains the FCM token.
-    const tokensSnap = await db.collection(`bars/${barId}/tokens`).get();
-    const tokens = tokensSnap.docs.map(d => d.data().token).filter(t => t);
+  for (const [barId, requests] of Object.entries(barUpdates)) {
+    // Fetch bar members (for status/prefs filtering) and tokens
+    // together — `bars/{barId}/tokens` has one doc per uid holding
+    // the FCM token; `bars/{barId}/users` has the same uid holding
+    // status/notificationPreferences/jobTitle.
+    const [tokensSnap, usersSnap] = await Promise.all([
+      db.collection(`bars/${barId}/tokens`).get(),
+      db.collection(`bars/${barId}/users`).get(),
+    ]);
+    const membersById = new Map(usersSnap.docs.map(d => [d.id, d.data()]));
 
-    // If no devices are registered, skip.
-    if (tokens.length === 0) continue;
+    // Group recipients by the exact subset of requests they should be
+    // nagged about, so someone who only cares about ICE doesn't get
+    // paged about a KEG request too, and so we send the minimum
+    // number of distinct multicast calls.
+    const groups = new Map(); // key (sorted buttonId/label list) -> { labels, tokens }
+    for (const tokenDoc of tokensSnap.docs) {
+      const token = tokenDoc.data().token;
+      if (!token) continue;
+      const member = membersById.get(tokenDoc.id);
+      if (!member) continue; // Token orphaned from a removed member.
 
-    // Construct the notification payload.
-    const summary = labels.join(', ');
-    const title = `IGNORED: ${labels.length} TASKS`;
-    const body = `${summary} are still waiting. DO YOUR JOB.`;
+      const relevant = requests.filter(r => shouldNagUserAbout(r, member));
+      if (relevant.length === 0) continue;
 
-    // Send the Multicast Push Notification to all tokens.
-    // This uses FCM to reach Android and iOS devices.
-    await messaging.sendEachForMulticast({
-      tokens: tokens,
-      notification: {
-        title: title,
-        body: body,
-      },
-      data: {
-        type: 'nag_alert',
-        barId: barId
-      },
-      // Android specific config for high priority.
-      android: {
-        priority: 'high',
+      const key = relevant.map(r => r.buttonId || r.label).sort().join('|');
+      if (!groups.has(key)) groups.set(key, { labels: relevant.map(r => r.label), tokens: [] });
+      groups.get(key).tokens.push(token);
+    }
+
+    if (groups.size === 0) {
+      console.log(`No subscribed/active recipients for bar ${barId}; skipping.`);
+      continue;
+    }
+
+    for (const { labels, tokens } of groups.values()) {
+      const summary = labels.join(', ');
+      const title = `IGNORED: ${labels.length} TASK${labels.length === 1 ? '' : 'S'}`;
+      const body = `${summary} still waiting. DO YOUR JOB.`;
+
+      // Send the Multicast Push Notification to this recipient group.
+      // This uses FCM to reach Android and iOS devices.
+      await messaging.sendEachForMulticast({
+        tokens,
         notification: {
-          sound: 'default',
-          channelId: 'urgent_alerts'
-        }
-      },
-      // APNs (iOS) specific config.
-      apns: {
-        payload: {
-          aps: {
+          title: title,
+          body: body,
+        },
+        data: {
+          type: 'nag_alert',
+          barId: barId
+        },
+        // Android specific config for high priority.
+        android: {
+          priority: 'high',
+          notification: {
             sound: 'default',
-            'content-available': 1
+            channelId: 'urgent_alerts'
+          }
+        },
+        // APNs (iOS) specific config.
+        apns: {
+          payload: {
+            aps: {
+              sound: 'default',
+              'content-available': 1
+            }
           }
         }
-      }
-    });
+      });
 
-    console.log(`Nagged bar ${barId} regarding: ${summary}`);
+      console.log(`Nagged ${tokens.length} recipient(s) at bar ${barId} regarding: ${summary}`);
+    }
   }
 
   // --- Step 4: Update Last Notification Timestamp ---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,16 @@ function App() {
   // --- Routing & Bar State ---
   // Access URL query parameters.
   const [searchParams, setSearchParams] = useSearchParams();
+  // react-router's setSearchParams is not identity-stable across the
+  // URL change it itself causes (its identity depends on
+  // location.search) — depending on it directly in the listener
+  // effect below made that effect re-run a second time immediately
+  // after mount purely because it had just called setSearchParams,
+  // tearing down and re-establishing all three listeners for no
+  // reason. Route calls through a ref instead so the effect only
+  // depends on values that should actually trigger it.
+  const setSearchParamsRef = useRef(setSearchParams);
+  useEffect(() => { setSearchParamsRef.current = setSearchParams; }, [setSearchParams]);
   // Get the 'bar' param from URL or fallback to localStorage.
   const initialBarId = searchParams.get('bar') || localStorage.getItem('barId');
   // Store the current Bar ID.
@@ -367,7 +377,7 @@ function App() {
     if (!user || !barId) return;
 
     // Persist Bar ID to URL and LocalStorage.
-    setSearchParams({ bar: barId });
+    setSearchParamsRef.current({ bar: barId });
     localStorage.setItem('barId', barId);
 
     // References to Firestore documents.
@@ -455,7 +465,7 @@ function App() {
     // so they can re-subscribe on the hourly windowEpoch without
     // tearing these down.
     return () => { unsubUser(); unsubBar(); unsubAllUsers(); };
-  }, [user, barId, setSearchParams, isDraggingRef]);
+  }, [user, barId, isDraggingRef]);
 
   // Time-window epoch. Bumped every hour so the requests/notices
   // listeners below re-subscribe with a fresh "now" lower bound. In a

--- a/src/benchmarks/NtfyDispatch.test.tsx
+++ b/src/benchmarks/NtfyDispatch.test.tsx
@@ -1,32 +1,167 @@
-import { describe, it, expect, vi } from 'vitest';
-import { pMap } from '../utils/async';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRequestActions } from '../hooks/useRequestActions';
+import type { BarUser } from '../types';
 
-describe('pMap Concurrency', () => {
-    it('should respect concurrency limits', async () => {
-        let activeCount = 0;
-        let maxActive = 0;
-        const totalItems = 10;
-        const concurrency = 2;
+// This file used to only benchmark pMap's concurrency in isolation
+// (now covered by src/utils/async.test.ts) under a name that promised
+// coverage of the actual ntfy dispatch behavior in useRequestActions
+// but never imported it. These tests exercise the real hook instead.
 
-        await pMap(
-            Array.from({ length: totalItems }),
-            async () => {
-                activeCount++;
-                maxActive = Math.max(maxActive, activeCount);
-                // Simulate work
-                await new Promise(resolve => setTimeout(resolve, 10));
-                activeCount--;
-                return 'done';
-            },
-            concurrency
-        );
+vi.mock('../firebase', () => ({ db: {} }));
 
-        expect(maxActive).toBeLessThanOrEqual(concurrency);
-    });
+const addDocMock = vi.fn(() => Promise.resolve({ id: 'req1' }));
+const updateDocMock = vi.fn(() => Promise.resolve());
+const deleteDocMock = vi.fn(() => Promise.resolve());
 
-    it('should process all items', async () => {
-        const input = [1, 2, 3, 4, 5];
-        const result = await pMap(input, async (x) => x * 2, 2);
-        expect(result).toEqual([2, 4, 6, 8, 10]);
-    });
+vi.mock('firebase/firestore', async () => {
+  const actual = await vi.importActual('firebase/firestore');
+  return {
+    ...actual,
+    collection: vi.fn(() => ({})),
+    doc: vi.fn(() => ({})),
+    addDoc: (...args: unknown[]) => addDocMock(...args),
+    updateDoc: (...args: unknown[]) => updateDocMock(...args),
+    deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
+    serverTimestamp: vi.fn(() => 'server-timestamp'),
+  };
+});
+
+const user = { uid: 'me' } as any;
+
+function makeUser(overrides: Partial<BarUser> & { id: string }): BarUser {
+  return {
+    displayName: overrides.id,
+    status: 'active',
+    ntfyTopic: `topic-${overrides.id}`,
+    notificationPreferences: [],
+    ...overrides,
+  };
+}
+
+describe('useRequestActions ntfy dispatch', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    addDocMock.mockClear();
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock as any;
+  });
+
+  const setup = (allUsers: BarUser[], getButtonIdForLabel: (label: string) => string | undefined) =>
+    renderHook(() =>
+      useRequestActions({
+        user,
+        barId: 'bar1',
+        displayName: 'Me',
+        userRole: 'Staff',
+        allUsers,
+        getButtonIdForLabel,
+      })
+    ).result.current;
+
+  it('only pages users subscribed to the resolved button id', async () => {
+    const allUsers = [
+      makeUser({ id: 'subscribed', notificationPreferences: ['ice'] }),
+      makeUser({ id: 'unsubscribed', notificationPreferences: ['keg'] }),
+    ];
+    const { submitRequest } = setup(allUsers, () => 'ice');
+
+    await submitRequest('ICE: Well 1');
+
+    const topics = fetchMock.mock.calls.map((c) => c[0]);
+    expect(topics).toContain('https://ntfy.sh/topic-subscribed');
+    expect(topics).not.toContain('https://ntfy.sh/topic-unsubscribed');
+  });
+
+  it('excludes the requester from their own fanout', async () => {
+    const allUsers = [
+      makeUser({ id: 'me', notificationPreferences: ['ice'] }),
+      makeUser({ id: 'other', notificationPreferences: ['ice'] }),
+    ];
+    const { submitRequest } = setup(allUsers, () => 'ice');
+
+    await submitRequest('ICE: Well 1');
+
+    const topics = fetchMock.mock.calls.map((c) => c[0]);
+    expect(topics).not.toContain('https://ntfy.sh/topic-me');
+    expect(topics).toContain('https://ntfy.sh/topic-other');
+  });
+
+  it('excludes off-clock users regardless of preferences', async () => {
+    const allUsers = [
+      makeUser({ id: 'offclock', status: 'off_clock', notificationPreferences: ['ice'] }),
+    ];
+    const { submitRequest } = setup(allUsers, () => 'ice');
+
+    await submitRequest('ICE: Well 1');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('pages everyone on a BREAK request, bypassing individual preferences', async () => {
+    const allUsers = [
+      makeUser({ id: 'a', notificationPreferences: [] }),
+      makeUser({ id: 'b', notificationPreferences: ['ice'] }),
+    ];
+    const { submitRequest } = setup(allUsers, () => 'break');
+
+    await submitRequest('BREAK');
+
+    const topics = fetchMock.mock.calls.map((c) => c[0]);
+    expect(topics).toContain('https://ntfy.sh/topic-a');
+    expect(topics).toContain('https://ntfy.sh/topic-b');
+  });
+
+  it('pages everyone for a free-text request with no resolvable button id', async () => {
+    // Matches the in-app "show to everyone" safety default for
+    // requests activeRequests can't classify (App.tsx) — a custom
+    // request should page the same set of people it's shown to, not
+    // page nobody while appearing to everyone in-app.
+    const allUsers = [
+      makeUser({ id: 'a', notificationPreferences: [] }),
+      makeUser({ id: 'b', notificationPreferences: ['ice'] }),
+    ];
+    const { submitRequest } = setup(allUsers, () => undefined);
+
+    await submitRequest('Someone spilled a whole tray of glasses at the end of the bar');
+
+    const topics = fetchMock.mock.calls.map((c) => c[0]);
+    expect(topics).toContain('https://ntfy.sh/topic-a');
+    expect(topics).toContain('https://ntfy.sh/topic-b');
+  });
+
+  it('does not fan out to a user with no ntfy topic', async () => {
+    const allUsers = [
+      makeUser({ id: 'no-topic', notificationPreferences: ['ice'], ntfyTopic: undefined }),
+    ];
+    const { submitRequest } = setup(allUsers, () => 'ice');
+
+    await submitRequest('ICE: Well 1');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('one failing topic does not prevent the others from being dispatched', async () => {
+    const allUsers = [
+      makeUser({ id: 'fails', notificationPreferences: ['ice'] }),
+      makeUser({ id: 'succeeds', notificationPreferences: ['ice'] }),
+    ];
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('topic-fails') ? Promise.reject(new Error('network error')) : Promise.resolve({ ok: true })
+    );
+    const { submitRequest } = setup(allUsers, () => 'ice');
+
+    await expect(submitRequest('ICE: Well 1')).resolves.toBeUndefined();
+
+    const topics = fetchMock.mock.calls.map((c) => c[0]);
+    expect(topics).toContain('https://ntfy.sh/topic-succeeds');
+  });
+
+  it('claimRequest rejects when the write is denied (already claimed by someone else)', async () => {
+    updateDocMock.mockRejectedValueOnce(new Error('permission-denied'));
+    const { claimRequest } = setup([], () => undefined);
+
+    await expect(claimRequest('req1')).rejects.toThrow('permission-denied');
+  });
 });

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -36,6 +36,24 @@ export function usePushNotifications() {
           // Capacitor's plugin registry is the source of truth.
           await PushNotifications.removeAllListeners();
 
+          // nag-bot.js sends Android pushes with
+          // android.notification.channelId: 'urgent_alerts', but on
+          // Android 8+ a channel that was never created falls back to
+          // a default-importance one — the message still arrives, but
+          // silently, with no heads-up popup or sound. Create it once
+          // up front; createChannel() is a no-op if it already exists.
+          if (Capacitor.getPlatform() === 'android') {
+            await PushNotifications.createChannel({
+              id: 'urgent_alerts',
+              name: 'Urgent Alerts',
+              description: 'Reminders for pending requests nobody has claimed yet.',
+              importance: 4, // HIGH: heads-up popup + sound.
+              visibility: 1, // PUBLIC: shows full content on the lock screen.
+              sound: 'default',
+              vibration: true,
+            }).catch((e) => console.error('Failed to create urgent_alerts channel', e));
+          }
+
           await PushNotifications.addListener('registration', token => {
             setFcmToken(token.value);
           });

--- a/src/hooks/useRequestActions.ts
+++ b/src/hooks/useRequestActions.ts
@@ -46,6 +46,8 @@ export function useRequestActions({
     if (!user || !barId) return;
     if (navigator.vibrate) navigator.vibrate(100);
 
+    const btnId = getButtonIdForLabel(label);
+
     await addDoc(collection(db, 'requests'), {
       barId,
       label,
@@ -55,9 +57,13 @@ export function useRequestActions({
       status: 'pending',
       timestamp: serverTimestamp(),
       lastNotification: serverTimestamp(),
+      // Persisted so the (separate, Admin-SDK) nag-bot script can
+      // apply the same notificationPreferences filtering as this
+      // in-app fanout without re-deriving it from the bar's button
+      // config, which it has no access to.
+      ...(btnId ? { buttonId: btnId } : {}),
     });
 
-    const btnId = getButtonIdForLabel(label);
     const topics = new Set<string>();
 
     allUsers.forEach(u => {

--- a/src/test/ListenerRedundancy.test.tsx
+++ b/src/test/ListenerRedundancy.test.tsx
@@ -168,8 +168,18 @@ describe('Performance Optimization: Listener Redundancy', () => {
     const calls = onSnapshotSpy.mock.calls.length;
     console.log(`Total onSnapshot calls: ${calls}`);
 
-    // Assert that we see improvement vs the original 16-call unoptimized version.
-    // Threshold accommodates legitimate new listeners while still catching redundancy regressions.
-    expect(calls).toBeLessThan(14);
+    // 6 real listeners (user profile, bar doc, bar users, requests,
+    // notices, 86'd list) plus 2 legitimate re-subscribes: the 86'd
+    // list query depends on userRole/isPremium, both of which resolve
+    // asynchronously after mount (userRole off the per-bar user
+    // snapshot, isPremium off useGodMode's getIdTokenResult()), so
+    // that listener re-subscribes with the real query shape once each
+    // resolves. This is a tight, exact bound rather than a loose "<N"
+    // — a `setSearchParams` identity-churn bug used to cause 3 more
+    // (11 total) by re-running the whole first effect immediately
+    // after mount; that's fixed (see the setSearchParamsRef comment
+    // in App.tsx), and an exact count here is what actually catches a
+    // regression reintroducing it or something like it.
+    expect(calls).toBe(8);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,12 @@ export interface Request {
   claimedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
   // The ID of the bar this request belongs to.
   barId: string;
+  // Optional: the top-level button id this request resolved to at
+  // creation time (see getButtonIdForLabel), if any — free-text
+  // custom requests have none. Persisted so nag-bot.js can filter by
+  // notification preference without re-deriving it from the bar's
+  // button config.
+  buttonId?: string;
   // Optional: The name of the user who claimed the request.
   claimerName?: string;
   // Optional: The timestamp of the last notification sent for this request (used for throttling).

--- a/src/utils/async.test.ts
+++ b/src/utils/async.test.ts
@@ -19,7 +19,13 @@ describe('pMap', () => {
         }, 3); // Concurrency 3
 
         expect(results).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
-        expect(maxRunning).toBeLessThanOrEqual(3);
+        // Exact equality, not just an upper bound: all 3 workers start
+        // synchronously and increment `running` before their first
+        // await, so with 10 equal-duration items this deterministically
+        // reaches the concurrency limit. A `<=` check here would also
+        // pass for a fully serial implementation (maxRunning === 1),
+        // which is the actual regression this test exists to catch.
+        expect(maxRunning).toBe(3);
     });
 
     it('handles empty array', async () => {


### PR DESCRIPTION
## Summary

Second pass through the audit findings, covering what was deferred from #285 (role model / deploy-path / dialog-dismissal / rules-hardening fixes):

- **`scripts/nag-bot.js` ignored notification preferences and off-clock status.** It paged every registered token in a bar unconditionally, while the in-app fanout (`useRequestActions.ts`) respects both. A `Server` with an empty preference list, or anyone clocked out, still got the "IGNORED: DO YOUR JOB" nag. Requests now persist the button id they resolved to at creation (`Request.buttonId`) so the standalone Admin-SDK script can filter the same way without re-deriving button config it has no access to; recipients are grouped by their actual relevant-request subset so a personalized nag doesn't mention requests they were never subscribed to.
- **CI issue spam.** `.github/workflows/nag.yml` filed a brand-new GitHub issue on every failed run with no dedupe — at a 5-minute schedule, a single expired secret could produce close to 300 duplicate issues in a day. Now reuses an existing open one via a comment instead.
- **Every built Android APK shipped with FCM compiled out.** `build-mobile.yml`'s Google Services injection looked for `app/google-services.json.template` — a path and a template file that don't exist anywhere in this repo (the Capacitor Android app lives at `android/app/`) — using secret names (`GOOGLE_SERVICES_API_KEY`, `PROJECT_ID`, `CLIENT_ID`) nothing else in the codebase defines. Replaced with `scripts/generate-google-services.js`, which was already correct but never wired into CI, fed by the same `VITE_FIREBASE_*` secrets already used for the web build — which itself wasn't receiving those secrets either, so the web bundle baked into the APK had broken Firebase config too. Also fixed the release keystore path (`app/keystore.jks` → `android/app/keystore.jks`, same mismatch), which silently fell back to the debug keystore on every "signed" release.
- **Android notification channel.** `nag-bot.js` sends pushes on `channelId: 'urgent_alerts'`, which nothing ever created — added the `createChannel()` call on native Android so Android 8+ doesn't silently downgrade it to default importance (no heads-up popup/sound).
- **iOS push entitlements.** `ios/App` had no `aps-environment` entitlement or `UIBackgroundModes` at all, so native push registration could never succeed. Added `App.entitlements` (wired into both Debug/Release build configs) and the background mode. Note: enabling the actual Push Notifications *capability* on the Apple Developer portal / regenerating the provisioning profile is still a manual step outside what's fixable from source.
- **A real redundant-listener bug**, found while writing this pass's own tests: `react-router`'s `setSearchParams` isn't identity-stable across the URL change it itself causes, so depending on it directly in the bar-listener effect made that effect immediately re-run right after mount — tearing down and re-establishing 3 live Firestore listeners for no reason. Routed the call through a ref instead.
- **Strengthened three tests** that passed without verifying what they were named for: `pMap`'s concurrency test only asserted an upper bound (a fully serial implementation would still pass — tightened to an exact, deterministic count); `NtfyDispatch.test.tsx` tested `pMap` in isolation and never touched ntfy dispatch, now exercises `useRequestActions`'s real fanout logic (topic selection, requester exclusion, off-clock exclusion, BREAK bypass, the free-text/no-button safety default, per-topic error isolation, claim-rejection surfacing); `ListenerRedundancy.test.tsx`'s bound (`<14`) was loose enough to stay green with the redundancy bug above still present — now an exact, justified count.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 82/82 jsdom tests pass (up from 76; new fanout coverage)
- [x] `npm run test:rules` — 56/56 Firestore rules tests pass against the emulator
- [x] `functions` package build + tests pass
- [x] Workflow YAML changes parsed with `yaml.safe_load` (can't actually run these CI jobs from here — they need real secrets)
- [x] iOS `Info.plist`/`App.entitlements` parsed with `plistlib`, `project.pbxproj` brace-balance checked (can't open in Xcode from here)
- [ ] Manual: verify the Android build actually produces a working `google-services.json` and signs with the intended keystore
- [ ] Manual: Apple Developer portal — enable Push Notifications capability for `com.barbacker.app` and regenerate the provisioning profile

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Align notification nag-bot behavior and mobile push configuration with in-app logic, fix listener redundancy, and tighten related tests and CI workflows.

New Features:
- Persist the resolved button ID on requests so external scripts can respect user notification preferences.
- Create an Android notification channel for urgent nag alerts to ensure high-importance pushes.
- Add iOS background remote-notification support and entitlements necessary for push notifications.

Bug Fixes:
- Update nag-bot to filter and group recipients based on status and notification preferences so only relevant users are paged and receive appropriate nag content.
- Fix redundant Firestore listener re-subscriptions caused by react-router setSearchParams identity changes.
- Restore proper Firebase configuration and signing for Android builds by generating google-services.json in CI and using the correct keystore path.

Enhancements:
- Expand useRequestActions ntfy dispatch tests to cover subscription filtering, requester exclusion, BREAK behavior, free-text fallback, topic absence, per-topic failure isolation, and claim conflicts.
- Tighten listener redundancy tests to assert an exact expected listener count, catching regressions more reliably.
- Strengthen pMap concurrency testing to assert the exact concurrency level rather than just an upper bound.

Build:
- Wire Firebase VITE secrets into the web build in the mobile CI workflow and generate google-services.json for the Android app from the same values.
- Correct the Android keystore generation and usage paths in the mobile build workflow so release builds use the intended signing key.

CI:
- Update the nag workflow to reuse a labeled open failure issue via comments instead of creating a new issue on every failure run.