### PR TITLE
Fix request send/visibility bugs, notification cleanup, storage rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ In a busy bar, bartenders often need items—ice, glassware, fruit, restocking�
 
 ## Key Features
 
-*   **⚡ Instant Requests**: One-tap buttons for common needs like "ICE", "GLASSWARE", or "RESTOCK".
-*   **🔔 Real-Time Alerts**: Requests appear instantly on all connected devices.
-*   **📍 Location Aware**: Uses OpenStreetMap to verify bar locations and ensure you join the right team.
+*   **⚡ Quick Requests**: Simple button grids for common needs like "ICE", "GLASSWARE", or "RESTOCK" — some are one tap, others (like picking a well or a beer brand/type) are a couple of taps deep.
+*   **🔔 Real-Time Alerts**: Requests appear instantly for anyone subscribed to that request type and clocked in; ntfy.sh handles push delivery.
+*   **🔎 Bar Search**: Find your bar by name via OpenStreetMap, or create an entry for your venue if it isn't listed yet.
 *   **👥 Role-Based**: Distinct interfaces for Bartenders (sending requests) and Barbacks/Support (fulfilling requests).
 *   **📱 Installable PWA**: Works like a native app on iOS and Android.
 
 ## How to Use
 
 1.  **Open the App**: Navigate to the deployed URL.
-2.  **Join a Bar**: Search for your bar by name or location. If it's your first time, you can create a temporary bar for your shift.
+2.  **Join a Bar**: Search for your bar by name. If it isn't listed yet, you can create it.
 3.  **Select Your Role**:
     *   **Bartender**: You will see a grid of buttons. Tap to request items.
     *   **Barback**: You will see a list of incoming requests. Tap a request to claim it.

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "emulators": {
     "firestore": {
       "host": "127.0.0.1",

--- a/firestore.rules
+++ b/firestore.rules
@@ -58,6 +58,15 @@ service cloud.firestore {
       // since only one side would be non-null.
       allow update: if isManagerPlus(barId) &&
         request.resource.data.get('ownerId', null) == resource.data.get('ownerId', null);
+      // Any bar member (not just Manager+) may bump buttonUsage —
+      // it's just per-button tap counts driving sort order, not
+      // privileged config, and restricting it to Manager+ meant every
+      // non-Manager's usage flush (useUsageBatching.ts) was silently
+      // denied, so the "most used" sort only ever reflected whichever
+      // Manager happened to be clocked in. Scoped via affectedKeys()
+      // so this can't be used to slip other fields through.
+      allow update: if hasRole(barId) &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['buttonUsage']);
       // Only Owners can delete.
       allow delete: if isOwner(barId);
 

--- a/scripts/nag-bot.js
+++ b/scripts/nag-bot.js
@@ -53,7 +53,10 @@ const ROLE_NOTIFICATION_DEFAULTS = {
 // (or was explicitly excluded, e.g. off-clock) in the first place.
 function shouldNagUserAbout(req, member) {
   if (member.status !== 'active' && member.status !== undefined) return false;
-  if ((req.label || '').includes('BREAK') || req.buttonId === 'break') return true;
+  // Exact resolved-id match only, matching useRequestActions.ts — a
+  // substring check on the label would let free text like "BREAKAGE
+  // AT WELL 3" mass-notify everyone regardless of preferences.
+  if (req.buttonId === 'break') return true;
   // No resolvable button (free-text/custom request): shown to
   // everyone in-app as a safety default, so nag everyone too.
   if (!req.buttonId) return true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,8 +205,21 @@ function App() {
   const [editNameValue, setEditNameValue] = useState('');
   const [editNameError, setEditNameError] = useState<string | null>(null);
 
-  // List of request IDs the user has locally ignored/muted.
-  const [ignoredIds, setIgnoredIds] = useState<string[]>([]);
+  // List of request IDs the user has locally ignored/muted. Persisted
+  // to localStorage — previously plain useState, so a reload (or the
+  // app being killed and reopened, routine on mobile) brought back
+  // every previously-dismissed nag.
+  const [ignoredIds, setIgnoredIds] = useState<string[]>(() => {
+    try {
+      const raw = localStorage.getItem('ignoredRequestIds');
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  });
+  useEffect(() => {
+    localStorage.setItem('ignoredRequestIds', JSON.stringify(ignoredIds));
+  }, [ignoredIds]);
 
   // Notice Board State.
   const [notices, setNotices] = useState<Notice[]>([]);
@@ -301,10 +314,19 @@ function App() {
           // Only show pending requests.
           if (r.status !== 'pending') return false;
 
+          // Always show the requester's own pending requests, regardless
+          // of their notification preferences — otherwise a bartender's
+          // own SECURITY/MANAGER tap (not in their default prefs) never
+          // appears in their own footer: no confirmation it sent, no way
+          // to cancel a mis-tap.
+          if (user && r.requesterId === user.uid) return true;
+
           const btnId = getButtonIdForLabel(r.label);
 
-          // Special Logic: ALWAYS show BREAK requests.
-          if (btnId === 'break' || r.label.includes('BREAK')) {
+          // Special Logic: ALWAYS show BREAK requests. Exact match only
+          // (not a substring check) — free text containing "BREAK" (e.g.
+          // "BREAKAGE AT WELL 3") shouldn't bypass everyone's preferences.
+          if (btnId === 'break') {
              return true;
           }
 
@@ -322,7 +344,7 @@ function App() {
           }
           return aIgnored ? 1 : -1;
       });
-  }, [requests, getButtonIdForLabel, notificationPreferences, ignoredIds]);
+  }, [requests, getButtonIdForLabel, notificationPreferences, ignoredIds, user]);
 
   // Activate the Nag hook to play sounds for these requests.
   useNag(activeRequests, ignoredIds);
@@ -569,7 +591,7 @@ function App() {
 
 
   // Auto-submit an "(Ask Me)" request if a sub-menu sits open for 60s.
-  useInactivityAutoSubmit(navStack, (label) => submitRequest(label), () => setNavStack([]));
+  useInactivityAutoSubmit(navStack, (label) => submitRequestSafe(label), () => setNavStack([]));
 
   // --- Actions ---
 
@@ -634,7 +656,7 @@ function App() {
     // If exists, request ice for it.
     if (wells.includes(wellName)) {
         setInputDialog(prev => ({ ...prev, open: false, searchTerm: '' }));
-        submitRequest(`ICE: ${wellName}`);
+        submitRequestSafe(`ICE: ${wellName}`);
         setNavStack([]);
         return;
     }
@@ -649,7 +671,7 @@ function App() {
     setInputDialog(prev => ({ ...prev, open: false, searchTerm: '' }));
 
     // Submit request.
-    submitRequest(`ICE: ${wellName}`);
+    submitRequestSafe(`ICE: ${wellName}`);
     setNavStack([]);
   };
 
@@ -823,7 +845,7 @@ function App() {
     } else {
       // Leaf node: Submit Request.
       // Construct label from stack + current button.
-      submitRequest([...navStack, btn].map(b => b.label).join(': '));
+      submitRequestSafe([...navStack, btn].map(b => b.label).join(': '));
       setNavStack([]);
     }
   };
@@ -896,8 +918,19 @@ function App() {
     setShowOffClockDialog(false);
   };
 
-  // Switch to another bar without clocking out (unless inactive).
+  // Switch to another bar. Despite the old name/comment, this DOES
+  // clock the user out of the bar being left — otherwise they kept
+  // getting paged (in-app and via push) from a bar they're no longer
+  // standing in. Clocking back in later is a one-tap self-write (see
+  // the auto-clock-in effect above), so this doesn't cost them
+  // anything beyond a page they wouldn't have wanted anyway.
   const handleSwitchBar = async () => {
+    if (user && barId) {
+      const oldBarId = barId;
+      await updateDoc(doc(db, `bars/${oldBarId}/users`, user.uid), { status: 'off_clock' })
+        .catch((e) => console.error('Failed to clock out of previous bar', e));
+      await deleteDoc(doc(db, `bars/${oldBarId}/tokens`, user.uid)).catch(() => {});
+    }
     setBarId(null);
     setJustCreatedBar(false);
     localStorage.removeItem('barId');
@@ -932,6 +965,26 @@ function App() {
     user, barId, displayName, userRole, allUsers, getButtonIdForLabel,
   });
 
+  // True while a request submission is in flight. Guards against a
+  // double-tap or fat-finger creating two identical requests (none of
+  // the submit call sites previously had any disabled/pending state),
+  // and lets us surface a real failure instead of the previous
+  // fire-and-forget submitRequest(...) with no await/catch — a failed
+  // or offline-queued send used to look identical to a successful one.
+  const [isSubmittingRequest, setIsSubmittingRequest] = useState(false);
+  const submitRequestSafe = useCallback(async (label: string) => {
+    if (isSubmittingRequest) return;
+    setIsSubmittingRequest(true);
+    try {
+      await submitRequest(label);
+    } catch (e) {
+      console.error('Failed to submit request', e);
+      alert('Failed to send request. Please try again.');
+    } finally {
+      setIsSubmittingRequest(false);
+    }
+  }, [isSubmittingRequest, submitRequest]);
+
   // Save new notification settings. Write to Firestore first, then
   // update local state on success — the previous order set local
   // state optimistically before awaiting the write, so a sign-out or
@@ -964,6 +1017,11 @@ function App() {
     if (!user || !barId) return;
     if (!confirm('Are you sure you want to leave this bar? You will need to join again.')) return;
     await deleteDoc(doc(db, `bars/${barId}/users`, user.uid));
+    // Also drop the FCM token — otherwise it's orphaned (the rules
+    // restrict bars/{barId}/tokens/{uid} to its owner, and this user
+    // never visits this bar's docs again to clean it up) and nag-bot
+    // keeps paging a device that's no longer staff here, forever.
+    await deleteDoc(doc(db, `bars/${barId}/tokens`, user.uid)).catch(() => {});
     // Remove from joinedBars list.
     await updateDoc(doc(db, 'users', user.uid), {
         joinedBars: arrayRemove(barId)
@@ -1194,6 +1252,15 @@ function App() {
   // Sorting for main screen.
   const sortedAllButtons = sortButtons(buttons, 'main');
   const mainScreenButtons = sortedAllButtons.filter(btn => !hiddenButtonIds.includes(btn.id));
+  // CUSTOM is a permanent, non-configurable tile appended to every
+  // bar's grid — it must be part of the SAME array passed to
+  // SortableContext's `items` and to handleDragOver's `items` param
+  // as the one actually rendered, or dnd-kit's active/over index
+  // lookups go out of sync with what's on screen: dragging CUSTOM
+  // itself resolves to index -1 and silently reorders a different
+  // (the last "real") button instead.
+  const customRequestButton: ButtonConfig = { id: 'custom_req_btn', label: 'CUSTOM', icon: 'add', isCustom: true };
+  const mainScreenButtonsWithCustom = [...mainScreenButtons, customRequestButton];
 
   // Check for pending users (for Managers).
   const pendingUsers = allUsers.filter(u => u.status === 'pending');
@@ -1269,23 +1336,29 @@ function App() {
 
       <InputDialog
         open={inputDialog.open}
-        mode={inputDialog.type as 'brand' | 'type' | 'well'}
+        mode={inputDialog.type}
         searchTerm={inputDialog.searchTerm}
         onSearchChange={(val) => setInputDialog(prev => ({ ...prev, searchTerm: val }))}
         onClose={() => setInputDialog(prev => ({ ...prev, open: false }))}
         onSelect={(val) => {
-            // Deduplication Check.
-            const existingLabels = currentButtonsSource.map(b => b.label.toLowerCase());
-            if (existingLabels.includes(val.toLowerCase())) {
-                alert('This button already exists!');
-                return;
+            // Deduplication check — only meaningful for brand/type/well,
+            // which create a new persistent button. 'custom' is free-text
+            // request text, not a button; it should never be blocked just
+            // because the words happen to match an existing button label
+            // (e.g. typing "ice" as a custom note).
+            if (inputDialog.type !== 'custom') {
+                const existingLabels = currentButtonsSource.map(b => b.label.toLowerCase());
+                if (existingLabels.includes(val.toLowerCase())) {
+                    alert('This button already exists!');
+                    return;
+                }
             }
 
             if (inputDialog.type === 'brand') saveBrand(val);
             else if (inputDialog.type === 'type') saveType(val);
             else if (inputDialog.type === 'well') saveWell(val);
             else if (inputDialog.type === 'custom') {
-                submitRequest(val);
+                submitRequestSafe(val);
                 setInputDialog(prev => ({ ...prev, open: false }));
             }
         }}
@@ -1310,7 +1383,7 @@ function App() {
         <div slot="actions">
           <md-text-button onClick={() => setQuantityPicker(prev => ({ ...prev, open: false }))}>Cancel</md-text-button>
           <md-filled-button onClick={() => {
-             submitRequest(`${quantityPicker.context}: ${quantityPicker.currentQty}`);
+             submitRequestSafe(`${quantityPicker.context}: ${quantityPicker.currentQty}`);
              setQuantityPicker(prev => ({ ...prev, open: false }));
              setNavStack([]);
           }}>Send</md-filled-button>
@@ -1594,13 +1667,13 @@ function App() {
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragStart={handleDragStart}
-        onDragOver={(e) => handleDragOver(e, 'main', mainScreenButtons)}
+        onDragOver={(e) => handleDragOver(e, 'main', mainScreenButtonsWithCustom)}
         onDragEnd={(e) => handleDragEnd(e, 'main')}
       >
-        <SortableContext items={mainScreenButtons} strategy={rectSortingStrategy}>
+        <SortableContext items={mainScreenButtonsWithCustom} strategy={rectSortingStrategy}>
           <div className="grid grid-cols-2 gap-8 p-6">
             {/* Render Standard Buttons + Custom Request Button */}
-            {[...mainScreenButtons, { id: 'custom_req_btn', label: 'CUSTOM', icon: 'add', isCustom: true }].map(btn => {
+            {mainScreenButtonsWithCustom.map(btn => {
               // Highlight pending requests.
               const isPending = activeRequests.some(r => r.label.startsWith(btn.label));
               return (
@@ -1620,7 +1693,7 @@ function App() {
         <DragOverlay>
             {activeId ? (
                 (() => {
-                    const btn = buttons.find(b => b.id === activeId);
+                    const btn = mainScreenButtonsWithCustom.find(b => b.id === activeId);
                     if (!btn) return null;
                     const isPending = activeRequests.some(r => r.label.startsWith(btn.label));
                     return (

--- a/src/components/InputDialog.tsx
+++ b/src/components/InputDialog.tsx
@@ -17,8 +17,9 @@ const MAX_LABEL_LENGTH = 60;
 interface InputDialogProps {
   // Is the dialog open?
   open: boolean;
-  // The context mode: searching for a brand, type, or adding a well.
-  mode: 'brand' | 'type' | 'well';
+  // The context mode: searching for a brand, type, adding a well, or
+  // a free-text custom request.
+  mode: 'brand' | 'type' | 'well' | 'custom';
   // The current text in the input field.
   searchTerm: string;
   // Callback when input changes.
@@ -58,11 +59,12 @@ const InputDialog = ({ open, mode, searchTerm, onSearchChange, onClose, onSelect
         {mode === 'brand' && 'Select or Add Brand'}
         {mode === 'type' && 'Select or Add Type'}
         {mode === 'well' && 'Add Well'}
+        {mode === 'custom' && 'Custom Request'}
       </div>
       <div slot="content" className="flex flex-col gap-4 min-w-[300px] h-[300px]">
          {/* Input Field */}
          <md-filled-text-field
-           label={mode === 'well' ? 'Well Name' : 'Search...'}
+           label={mode === 'well' ? 'Well Name' : mode === 'custom' ? 'What do you need?' : 'Search...'}
            value={searchTerm}
            onInput={(e: any) => onSearchChange(e.target.value)}
            style={{ width: '100%' }}

--- a/src/hooks/useRequestActions.ts
+++ b/src/hooks/useRequestActions.ts
@@ -75,8 +75,11 @@ export function useRequestActions({
         prefs = ROLE_NOTIFICATION_DEFAULTS[u.role] || [];
       }
 
-      // BREAK requests always fan out to everyone.
-      if (label.includes('BREAK') || btnId === 'break') {
+      // BREAK requests always fan out to everyone. Exact resolved-id
+      // match only — a substring check on the label would let free
+      // text like "BREAKAGE AT WELL 3" mass-notify everyone regardless
+      // of preferences.
+      if (btnId === 'break') {
         topics.add(u.ntfyTopic);
         return;
       }

--- a/src/test/rules/bar.test.ts
+++ b/src/test/rules/bar.test.ts
@@ -48,6 +48,22 @@ describe("bar rules", () => {
     await assertFails(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
   });
 
+  it("Staff can bump buttonUsage alone (useUsageBatching)", async () => {
+    // buttonUsage drives sort order, not privileged config — this
+    // must work for every clocked-in member, not just Manager+, or
+    // sort order only ever reflects a Manager's taps.
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertSucceeds(updateDoc(doc(db, "bars/bar_A"), { "buttonUsage.ice": 1 }));
+  });
+
+  it("Staff cannot slip other fields through alongside buttonUsage", async () => {
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A"), {
+      "buttonUsage.ice": 1,
+      name: "pwned",
+    }));
+  });
+
   it("Staff cannot escalate role via combined-field self-write", async () => {
     const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
     // Attempt to set status:off_clock AND role:Manager in one update.

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,26 @@
+rules_version = '2';
+
+// Governs Firebase Storage. Previously there was no storage.rules
+// file (and no "storage" block in firebase.json), so bar logo
+// uploads (ThemeEditor.tsx -> bars/{barId}/logo.*) were governed
+// entirely by whatever rules happened to be set in the Firebase
+// console rather than anything checked into this repo.
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Bar logo. Logos are public branding, not sensitive — readable
+    // by any signed-in user. Writes are restricted to Manager+ of
+    // that specific bar, checked against the same `bars` custom claim
+    // firestore.rules uses (stamped by the onUserRoleChange Cloud
+    // Function), plus the `admin` claim for moderation. Size/type
+    // limits mirror the client-side check in ThemeEditor.tsx so a
+    // client that skips the UI validation can't bypass it.
+    match /bars/{barId}/logo.{ext} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null &&
+        (request.auth.token.admin == true ||
+         request.auth.token.get('bars', {}).get(barId, '') in ['Manager', 'Owner']) &&
+        request.resource.size < 2 * 1024 * 1024 &&
+        request.resource.contentType.matches('image/.*');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Third pass closing out the remaining items from the original 7-audit sweep (after #285 and #286).

### Request handling
- `submitRequest` was fire-and-forget everywhere it was called (button taps, quantity picker, custom dialog, ICE well, inactivity auto-submit) — a failed or offline-queued send looked identical to success. Added a submitting guard + error surfacing shared across all five call sites, which also fixes double-tap duplicate sends.
- A requester's own pending request is now always shown in their own footer regardless of notification preferences — previously a bartender's own SECURITY/MANAGER tap (not in their default prefs) never appeared in their own feed: no confirmation, no way to cancel a mis-tap.
- The BREAK bypass (shown/paged to everyone regardless of prefs) now requires an exact resolved button id instead of a label substring match — closes off free text like "BREAKAGE AT WELL 3" mass-notifying the whole bar. Applied consistently in `useRequestActions.ts`, `App.tsx`, and `nag-bot.js`.
- The CUSTOM request dialog's existing-label dedupe check no longer blocks free text that happens to match a button label, and the CUSTOM tile is now part of the same array passed to dnd-kit's `SortableContext`/`handleDragOver` as what's actually rendered — it previously resolved to index `-1` during a drag and silently reordered a different button instead.
- `InputDialog`'s `mode` prop now has a real `'custom'` variant instead of being cast away, so the custom-request dialog gets a real headline instead of a blank one.

### Notifications
- Switching bars now clocks the user out of the one they're leaving (a self-write, no approval needed) and drops its FCM token — they no longer keep getting paged from a bar they're not standing in. Leaving a bar entirely now also drops its token, which was previously left orphaned and kept nagging the device forever.
- `firestore.rules`: any bar member (not just Manager+) can now bump `buttonUsage`, scoped via `affectedKeys()` to that field alone — previously every non-Manager's usage flush was silently denied, so the "most used" sort order only ever reflected one person's taps.

### Other
- `ignoredIds` now persists to localStorage instead of resetting (and re-nagging on every previously-dismissed request) on every reload.
- Added `storage.rules` for bar logo uploads (read: signed-in, write: Manager+ of that bar, size/type checked server-side) and wired it into `firebase.json` — there was previously no rules file governing Storage access at all.
- Corrected README claims: no geolocation/location-verification exists, and most buttons are 2-4 taps rather than one.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 82/82 jsdom tests pass
- [x] `npm run test:rules` — 58/58 Firestore rules tests pass against the emulator (added coverage for the new `buttonUsage` rule branch, including a negative test that other fields can't ride along with it)
- [x] `functions` package tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Tighten request handling, notification visibility, and access rules, while improving persistence and configurability for bar operations.

New Features:
- Persist locally ignored request IDs across reloads using localStorage so dismissed nags stay muted.
- Introduce a guarded request submission helper that tracks in-flight submissions and surfaces failures to the user.
- Add a dedicated 'custom' mode to the input dialog with appropriate headings and prompts for free-text requests.
- Add Cloud Storage security rules for bar logo uploads and wire them into the Firebase config.

Bug Fixes:
- Ensure a requester always sees their own pending requests in the footer regardless of notification preferences.
- Require an exact BREAK button ID for global fan-out and nagging instead of relying on label substrings, preventing unintended mass notifications from free text labels.
- Fix the CUSTOM request tile integration with drag-and-drop so it participates in the same sortable items list and no longer mis-reorders other buttons during drags.
- Prevent duplicate requests from rapid taps or inactivity auto-submit by blocking concurrent submissions.
- Allow custom free-text requests even when the text matches an existing button label, while still deduplicating new brand/type/well buttons.

Enhancements:
- Clock users out of the bar they are leaving and remove their FCM token when switching or leaving bars to avoid paging staff at bars they no longer work.
- Improve request list filtering so BREAK visibility and custom/free-text behavior align consistently between client, hooks, and the nag-bot script.
- Refine the main-screen button wiring so drag overlays and sorting use the same derived button list, including the permanent CUSTOM tile.

Deployment:
- Add Storage rules configuration to the Firebase project for securing logo uploads.

Documentation:
- Update the README to clarify request depth, real-time alert behavior, bar search behavior, and remove inaccurate location-verification claims.

Tests:
- Extend Firestore security rules tests to cover staff updates to buttonUsage and block attempts to modify other bar fields alongside it.