### PR TITLE
Server-side notification fanout, notice rate-limit enforcement, unclaim, invite/ownership Cloud Functions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -41,6 +41,34 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "notices",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "authorId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -92,7 +92,7 @@ service cloud.firestore {
         allow create: if isAuthed() && request.auth.uid == userId &&
           request.resource.data.keys().hasOnly([
             'role', 'jobTitle', 'status', 'displayName', 'email',
-            'joinedAt', 'lastSeen', 'notificationPreferences', 'ntfyTopic'
+            'joinedAt', 'lastSeen', 'notificationPreferences'
           ]) &&
           (
             (request.resource.data.role == 'Staff') ||
@@ -112,11 +112,21 @@ service cloud.firestore {
         // lets a user clock in and back out on their own without
         // being able to self-approve out of 'pending'/'rejected'.
         // The lastNoticeAt cooldown stamp is included so saveNotice's
-        // batched write succeeds.
+        // batched write succeeds. ntfyTopic deliberately is NOT
+        // writable here (or readable — see the `read` rule above,
+        // which still exposes this whole doc to any hasRole() peer):
+        // it used to be mirrored onto this doc so client-side fanout
+        // could read every member's topic to compute who to notify,
+        // which is exactly what made it possible for any bar member
+        // to read (and keep, even after being kicked) a colleague's
+        // ntfy topic. Fanout is now server-side (onRequestCreated
+        // Cloud Function, Admin SDK), which reads the topic off the
+        // global users/{uid} doc instead — self-only, see that match
+        // block above.
         allow write: if isAuthed() && request.auth.uid == userId &&
           request.resource.data.diff(resource.data).affectedKeys()
             .hasOnly(['displayName', 'lastSeen', 'notificationPreferences',
-                      'ntfyTopic', 'email', 'status', 'lastNoticeAt', 'jobTitle']) &&
+                      'email', 'status', 'lastNoticeAt', 'jobTitle']) &&
           (!('status' in request.resource.data.diff(resource.data).affectedKeys()) ||
            request.resource.data.status == 'off_clock' ||
            (request.resource.data.status == 'active' && resource.data.status == 'off_clock'));
@@ -249,6 +259,19 @@ service cloud.firestore {
         && request.resource.data.label == resource.data.label
         && resource.data.status == 'pending'
         && request.resource.data.status == 'claimed'
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['status', 'claimedBy', 'claimerName', 'claimedAt']);
+      // Unclaim: claimed -> pending, only by whoever holds the claim.
+      // Without this a claim that goes stale (the claimer got pulled
+      // away mid-task) is invisible forever — nothing could ever move
+      // it back into anyone's active list.
+      allow update: if isAuthed() && hasRole(resource.data.barId)
+        && request.resource.data.barId == resource.data.barId
+        && request.resource.data.requesterId == resource.data.requesterId
+        && request.resource.data.label == resource.data.label
+        && resource.data.status == 'claimed'
+        && resource.data.claimedBy == request.auth.uid
+        && request.resource.data.status == 'pending'
         && request.resource.data.diff(resource.data).affectedKeys()
              .hasOnly(['status', 'claimedBy', 'claimerName', 'claimedAt']);
       allow delete: if isAuthed() && (

--- a/functions/src/__tests__/notifyEligibility.test.ts
+++ b/functions/src/__tests__/notifyEligibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { shouldNotifyMember } from "../notifyEligibility";
+
+describe("shouldNotifyMember", () => {
+  it("excludes the requester", () => {
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "me", status: "active", notificationPreferences: ["ice"] }, "me")).toBe(false);
+  });
+
+  it("excludes off-clock members regardless of preferences", () => {
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "off_clock", notificationPreferences: ["ice"] }, "me")).toBe(false);
+  });
+
+  it("treats undefined status as active (legacy docs)", () => {
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", notificationPreferences: ["ice"] }, "me")).toBe(true);
+  });
+
+  it("notifies everyone active on an exact BREAK match", () => {
+    expect(shouldNotifyMember({ buttonId: "break", label: "BREAK" }, { id: "them", status: "active", notificationPreferences: [] }, "me")).toBe(true);
+  });
+
+  it("does not bypass preferences on a label merely containing BREAK", () => {
+    expect(shouldNotifyMember({ buttonId: undefined, label: "BREAKAGE AT WELL 3" }, { id: "them", status: "active", notificationPreferences: [] }, "me")).toBe(true); // no buttonId -> safety default, not the BREAK bypass
+    expect(shouldNotifyMember({ buttonId: "trash", label: "BREAKAGE AT WELL 3" }, { id: "them", status: "active", notificationPreferences: [] }, "me")).toBe(false);
+  });
+
+  it("notifies everyone on a free-text request with no resolvable buttonId (safety default)", () => {
+    expect(shouldNotifyMember({ buttonId: undefined, label: "Someone spilled a tray of glasses" }, { id: "them", status: "active", notificationPreferences: [] }, "me")).toBe(true);
+  });
+
+  it("only notifies members subscribed to the resolved buttonId", () => {
+    expect(shouldNotifyMember({ buttonId: "keg", label: "KEG" }, { id: "them", status: "active", notificationPreferences: ["ice"] }, "me")).toBe(false);
+    expect(shouldNotifyMember({ buttonId: "keg", label: "KEG" }, { id: "them", status: "active", notificationPreferences: ["keg"] }, "me")).toBe(true);
+  });
+
+  it("falls back to ROLE_NOTIFICATION_DEFAULTS keyed by jobTitle when no explicit preferences are set", () => {
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "active", jobTitle: "Server" }, "me")).toBe(false);
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "active", jobTitle: "Bartender" }, "me")).toBe(true);
+  });
+});

--- a/functions/src/cleanupStaleRequests.ts
+++ b/functions/src/cleanupStaleRequests.ts
@@ -1,0 +1,33 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+const STALE_AFTER_MS = 12 * 60 * 60 * 1000; // 12 hours
+const BATCH_SIZE = 400; // Firestore batch limit is 500; leave headroom.
+
+// Requests never expired on their own — a page nobody claimed at 11pm
+// was still 'pending', still rendered in the requester's footer, and
+// still re-triggering useNag's audio/vibrate loop at 6pm the next
+// day. Runs hourly and clears anything that's been sitting pending
+// for 12+ hours; a shift that long without anyone claiming a request
+// means it's stale, not that it's still actionable.
+export const cleanupStaleRequests = onSchedule("every 60 minutes", async () => {
+  const db = getFirestore();
+  const cutoff = Timestamp.fromMillis(Date.now() - STALE_AFTER_MS);
+
+  const snap = await db
+    .collection("requests")
+    .where("status", "==", "pending")
+    .where("timestamp", "<", cutoff)
+    .limit(BATCH_SIZE)
+    .get();
+
+  if (snap.empty) {
+    console.log("No stale pending requests found.");
+    return;
+  }
+
+  const batch = db.batch();
+  snap.docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+  console.log(`Cleared ${snap.size} stale pending request(s).`);
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,3 +3,8 @@ import * as admin from "firebase-admin";
 admin.initializeApp();
 
 export { onUserRoleChange } from "./onUserRoleChange";
+export { onRequestCreated } from "./onRequestCreated";
+export { onNoticeCreated } from "./onNoticeCreated";
+export { cleanupStaleRequests } from "./cleanupStaleRequests";
+export { onInviteConsumed } from "./onInviteConsumed";
+export { fileOwnershipClaim, reviewOwnershipClaim } from "./ownershipClaims";

--- a/functions/src/notifyEligibility.ts
+++ b/functions/src/notifyEligibility.ts
@@ -1,0 +1,50 @@
+// Mirrors src/constants.ts's ROLE_NOTIFICATION_DEFAULTS. Functions
+// run under a separate TypeScript project from the Vite app (no
+// shared build step), so this is a hand-kept copy — see
+// scripts/nag-bot.js for the same duplication on the plain-JS side.
+export const ROLE_NOTIFICATION_DEFAULTS: Record<string, string[]> = {
+  Owner: ['manager', 'security', 'keg', 'trash', 'ice', 'glass', 'fruit', 'restock', 'mixers', 'restock_beer', 'break'],
+  Manager: ['manager', 'security', 'keg', 'trash', 'break'],
+  Bartender: ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer'],
+  Barback: ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer', 'break'],
+  Server: [],
+  Runner: ['ice', 'glass', 'restock', 'mixers', 'restock_beer'],
+  Security: ['security', 'manager', 'break'],
+};
+
+export interface NotifiableRequest {
+  buttonId?: string | null;
+  label: string;
+}
+
+export interface BarMember {
+  id: string;
+  status?: string;
+  notificationPreferences?: string[];
+  jobTitle?: string;
+  role?: string;
+}
+
+// Mirrors useRequestActions.ts's client-side fanout decision (and
+// nag-bot.js's shouldNagUserAbout) exactly, so a request notifies the
+// same people regardless of which path sends it.
+export function shouldNotifyMember(req: NotifiableRequest, member: BarMember, requesterId: string): boolean {
+  if (member.id === requesterId) return false;
+  const isActive = member.status === 'active' || member.status === undefined;
+  if (!isActive) return false;
+
+  // Exact resolved-id match only — a substring check on the label
+  // would let free text like "BREAKAGE AT WELL 3" mass-notify
+  // everyone regardless of preferences.
+  if (req.buttonId === 'break') return true;
+
+  // Free-text / unrecognized labels (custom requests, "(Ask Me)"
+  // auto-submits) have no buttonId to check preferences against.
+  // The client's activeRequests treats this the same way — shown to
+  // everyone as a safety default — so mirror that here.
+  if (!req.buttonId) return true;
+
+  const prefs = member.notificationPreferences
+    ?? ROLE_NOTIFICATION_DEFAULTS[member.jobTitle ?? ''] ?? ROLE_NOTIFICATION_DEFAULTS[member.role ?? ''] ?? [];
+  return prefs.includes(req.buttonId);
+}

--- a/functions/src/onInviteConsumed.ts
+++ b/functions/src/onInviteConsumed.ts
@@ -1,0 +1,51 @@
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+// Grants the invited role once the invitee flips `consumed` to true
+// (the only update firestore.rules lets them make client-side — see
+// the invites match block). Without this the invites collection had
+// rules but nothing that ever acted on a consumption: an invite could
+// be created and "consumed" and still grant nothing.
+//
+// Ownership is deliberately never grantable via invite — only bar
+// creation or the ownershipClaims approval flow can produce an Owner
+// — so an invite that somehow specifies role:'Owner' (the rules don't
+// block Manager+ from creating one) is downgraded to 'Manager' here.
+export const onInviteConsumed = onDocumentUpdated(
+  "bars/{barId}/invites/{inviteId}",
+  async (event) => {
+    const before = event.data?.before.data();
+    const after = event.data?.after.data();
+    if (!before || !after) return;
+    if (before.consumed === true || after.consumed !== true) return;
+
+    const { barId } = event.params;
+    const consumedBy: string | undefined = after.consumedBy;
+    const invitedRole: string | undefined = after.role;
+    if (!consumedBy || !invitedRole) return;
+
+    const role = invitedRole === "Owner" ? "Manager" : invitedRole;
+    const db = getFirestore();
+    const userRef = db.doc(`bars/${barId}/users/${consumedBy}`);
+    const existing = await userRef.get();
+    const existingData = existing.data();
+
+    await userRef.set(
+      {
+        role,
+        jobTitle: existingData?.jobTitle ?? role,
+        status: "active",
+        displayName: existingData?.displayName ?? after.email,
+        email: after.email,
+        joinedAt: existingData?.joinedAt ?? FieldValue.serverTimestamp(),
+        lastSeen: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    await db.doc(`users/${consumedBy}`).set(
+      { joinedBars: FieldValue.arrayUnion(barId) },
+      { merge: true }
+    );
+  }
+);

--- a/functions/src/onNoticeCreated.ts
+++ b/functions/src/onNoticeCreated.ts
@@ -1,0 +1,40 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+const COOLDOWN_MS = 5000;
+
+// firestore.rules' 5s notice cooldown is client-cooperative: it only
+// blocks a create if the SAME write also (separately) bumped
+// lastNoticeAt on the author's user doc, which nothing forces a
+// hostile client to do — see the comment on that rule. This trigger
+// is the authoritative backstop: it looks at the author's *actual*
+// prior notices (which can't be spoofed, since they're real committed
+// documents) rather than trusting any client-supplied timestamp
+// field, and deletes this notice if the same author posted another
+// one within the cooldown window.
+export const onNoticeCreated = onDocumentCreated(
+  "bars/{barId}/notices/{noticeId}",
+  async (event) => {
+    const snap = event.data;
+    if (!snap) return;
+    const notice = snap.data() as { authorId?: string; timestamp?: Timestamp };
+    const { authorId, timestamp } = notice;
+    if (!authorId || !timestamp) return;
+
+    const db = getFirestore();
+    const cutoff = Timestamp.fromMillis(timestamp.toMillis() - COOLDOWN_MS);
+
+    const priorSnap = await db
+      .collection(`bars/${event.params.barId}/notices`)
+      .where("authorId", "==", authorId)
+      .where("timestamp", ">", cutoff)
+      .where("timestamp", "<", timestamp)
+      .limit(1)
+      .get();
+
+    if (!priorSnap.empty) {
+      console.warn(`Notice ${snap.id} from ${authorId} violates the 5s cooldown; deleting.`);
+      await snap.ref.delete();
+    }
+  }
+);

--- a/functions/src/onRequestCreated.ts
+++ b/functions/src/onRequestCreated.ts
@@ -1,0 +1,100 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { getFirestore } from "firebase-admin/firestore";
+import { getMessaging } from "firebase-admin/messaging";
+import { shouldNotifyMember, BarMember, NotifiableRequest } from "./notifyEligibility";
+
+const NTFY_CONCURRENCY = 5;
+
+// Runs `items` through `fn` with at most `concurrency` in flight at
+// once. functions/ is a separate TS project from src/ (no shared
+// build step), so this is a minimal standalone copy of the same
+// worker-pool shape as src/utils/async.ts's pMap rather than a
+// cross-project import.
+async function withConcurrency<T>(items: T[], concurrency: number, fn: (item: T) => Promise<void>): Promise<void> {
+  let index = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (index < items.length) {
+      const current = items[index++];
+      await fn(current);
+    }
+  });
+  await Promise.all(workers);
+}
+
+type RequestDoc = {
+  barId?: string;
+  label?: string;
+  buttonId?: string;
+  requesterId?: string;
+  requesterName?: string;
+};
+
+// Fires immediately on every new /requests doc — the client only
+// writes the request itself now (see useRequestActions.ts); actual
+// delivery (FCM + ntfy) is decided and sent here, server-side, using
+// the Admin SDK. This replaces two things that used to be true:
+//   1. Native push (FCM) only ever went out via nag-bot's 5-minute
+//      cron — a fresh request had no instant push at all.
+//   2. Every client had to be able to read every bar member's ntfy
+//      topic (via the bars/{barId}/users mirror) to compute the
+//      fanout itself, which is exactly what made those topics
+//      readable by any bar member. The topic now only needs to be
+//      readable here, via Admin SDK, which bypasses rules entirely —
+//      see firestore.rules for the corresponding removal of ntfyTopic
+//      from the per-bar user doc's readable/writable fields.
+export const onRequestCreated = onDocumentCreated("requests/{requestId}", async (event) => {
+  const snap = event.data;
+  if (!snap) return;
+  const request = snap.data() as RequestDoc;
+  const { barId, requesterId } = request;
+  if (!barId || !requesterId) return;
+
+  const db = getFirestore();
+  const [usersSnap, tokensSnap] = await Promise.all([
+    db.collection(`bars/${barId}/users`).get(),
+    db.collection(`bars/${barId}/tokens`).get(),
+  ]);
+
+  const members: BarMember[] = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }) as BarMember);
+  const eligible = members.filter((m) => shouldNotifyMember(request as NotifiableRequest, m, requesterId));
+  if (eligible.length === 0) return;
+  const eligibleIds = new Set(eligible.map((m) => m.id));
+
+  const body = `New Request: ${request.label} (by ${request.requesterName || "a teammate"})`;
+
+  // FCM push (Android / native).
+  const tokens = tokensSnap.docs
+    .filter((d) => eligibleIds.has(d.id))
+    .map((d) => d.data().token)
+    .filter((t): t is string => !!t);
+
+  const fcmPromise = tokens.length > 0
+    ? getMessaging().sendEachForMulticast({
+        tokens,
+        notification: { title: "BarBacker Alert", body },
+        data: { type: "new_request", barId },
+        android: { priority: "high", notification: { sound: "default", channelId: "urgent_alerts" } },
+        apns: { payload: { aps: { sound: "default", "content-available": 1 } } },
+      }).catch((e) => { console.error("FCM send failed", e); })
+    : Promise.resolve();
+
+  // ntfy push (iOS / web). The topic lives on the global users/{uid}
+  // doc (self-only per firestore.rules), not mirrored per-bar, so
+  // it's looked up per eligible member here.
+  const ntfyPromise = withConcurrency(eligible, NTFY_CONCURRENCY, async (member) => {
+    const userDoc = await db.doc(`users/${member.id}`).get();
+    const topic = userDoc.data()?.ntfyTopic;
+    if (!topic) return;
+    try {
+      await fetch(`https://ntfy.sh/${topic}`, {
+        method: "POST",
+        body,
+        headers: { Title: "BarBacker Alert", Priority: "high", Tags: "bell,bar_chart" },
+      });
+    } catch (e) {
+      console.error(`Failed to send ntfy to ${member.id}`, e);
+    }
+  });
+
+  await Promise.all([fcmPromise, ntfyPromise]);
+});

--- a/functions/src/ownershipClaims.ts
+++ b/functions/src/ownershipClaims.ts
@@ -1,0 +1,131 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+// ownershipClaims is `allow write: if false` in firestore.rules —
+// writes flow through these two callables only, which is what the
+// rules comment on that collection has always claimed but nothing
+// previously implemented. Without this, a real-world bar owner had no
+// way to reclaim a bar someone else set up (e.g. a temporary/claimed
+// entry created by staff before the owner ever signed up), since the
+// collection existed but no client write and no function ever touched
+// it.
+
+// Files a claim requesting ownership of `barId`. Any signed-in user
+// may file one; approval is a separate step gated to the bar's
+// current Manager+.
+export const fileOwnershipClaim = onCall(async (request) => {
+  const auth = request.auth;
+  if (!auth) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { barId, justification } = (request.data ?? {}) as { barId?: string; justification?: string };
+  if (!barId || typeof barId !== "string") {
+    throw new HttpsError("invalid-argument", "barId is required.");
+  }
+
+  const db = getFirestore();
+  const barDoc = await db.doc(`bars/${barId}`).get();
+  if (!barDoc.exists) throw new HttpsError("not-found", "Bar not found.");
+  if (barDoc.data()?.ownerId === auth.uid) {
+    throw new HttpsError("failed-precondition", "You already own this bar.");
+  }
+
+  const existing = await db
+    .collection(`bars/${barId}/ownershipClaims`)
+    .where("claimantId", "==", auth.uid)
+    .where("status", "==", "pending")
+    .limit(1)
+    .get();
+  if (!existing.empty) {
+    throw new HttpsError("already-exists", "You already have a pending claim for this bar.");
+  }
+
+  const claimantName = (auth.token.name as string | undefined) || auth.token.email || "Unknown";
+  const claimRef = await db.collection(`bars/${barId}/ownershipClaims`).add({
+    barId,
+    claimantId: auth.uid,
+    claimantName,
+    ...(justification ? { justification } : {}),
+    status: "pending",
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  return { claimId: claimRef.id };
+});
+
+// Approves or rejects a claim. Caller must be Manager+ (or admin) on
+// the bar the claim is against — checked against the same `bars`
+// custom claim firestore.rules uses. On approval: transfers
+// bars/{barId}.ownerId, promotes the claimant to 'Owner' (creating
+// their per-bar user doc if they aren't a member yet — a real owner
+// reclaiming a bar staff set up may never have joined it), and
+// demotes whoever held ownerId previously to 'Manager' so the bar
+// isn't left with a stale, now-inaccurate Owner role floating around.
+export const reviewOwnershipClaim = onCall(async (request) => {
+  const auth = request.auth;
+  if (!auth) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { barId, claimId, approve } = (request.data ?? {}) as { barId?: string; claimId?: string; approve?: boolean };
+  if (!barId || !claimId || typeof approve !== "boolean") {
+    throw new HttpsError("invalid-argument", "barId, claimId, and approve are required.");
+  }
+
+  const barsClaims = (auth.token.bars as Record<string, string> | undefined) ?? {};
+  const isAdmin = auth.token.admin === true;
+  const role = barsClaims[barId];
+  if (!isAdmin && role !== "Owner" && role !== "Manager") {
+    throw new HttpsError("permission-denied", "Only a Manager or Owner of this bar can review claims.");
+  }
+
+  const db = getFirestore();
+  const claimRef = db.doc(`bars/${barId}/ownershipClaims/${claimId}`);
+  const claimDoc = await claimRef.get();
+  if (!claimDoc.exists) throw new HttpsError("not-found", "Claim not found.");
+  const claim = claimDoc.data()!;
+  if (claim.status !== "pending") {
+    throw new HttpsError("failed-precondition", "This claim was already reviewed.");
+  }
+
+  if (!approve) {
+    await claimRef.update({
+      status: "rejected",
+      reviewedAt: FieldValue.serverTimestamp(),
+      reviewedBy: auth.uid,
+    });
+    return { status: "rejected" };
+  }
+
+  const barRef = db.doc(`bars/${barId}`);
+  const barDoc = await barRef.get();
+  const previousOwnerId = barDoc.data()?.ownerId as string | undefined;
+
+  const batch = db.batch();
+  batch.update(barRef, { ownerId: claim.claimantId });
+  batch.set(
+    db.doc(`bars/${barId}/users/${claim.claimantId}`),
+    {
+      role: "Owner",
+      jobTitle: "Owner",
+      status: "active",
+      displayName: claim.claimantName || "Owner",
+      joinedAt: FieldValue.serverTimestamp(),
+      lastSeen: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+  if (previousOwnerId && previousOwnerId !== claim.claimantId) {
+    batch.set(db.doc(`bars/${barId}/users/${previousOwnerId}`), { role: "Manager" }, { merge: true });
+  }
+  batch.update(claimRef, {
+    status: "approved",
+    reviewedAt: FieldValue.serverTimestamp(),
+    reviewedBy: auth.uid,
+  });
+  await batch.commit();
+
+  await db.doc(`users/${claim.claimantId}`).set(
+    { joinedBars: FieldValue.arrayUnion(barId) },
+    { merge: true }
+  );
+
+  return { status: "approved" };
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   serverTimestamp,
   setDoc,
   getDoc,
+  getDocs,
   addDoc,
   deleteDoc,
   arrayUnion,
@@ -30,8 +31,10 @@ import {
 // Import initialized Firebase instances and helper functions.
 import {
   db,
+  functions,
   requestNotificationPermission,
 } from './firebase';
+import { httpsCallable } from 'firebase/functions';
 // Import custom hook for fetching the latest APK release.
 import { useLatestRelease } from './hooks/useLatestRelease';
 import { usePwaInstallPrompt } from './hooks/usePwaInstallPrompt';
@@ -109,6 +112,7 @@ function App() {
   // Auth state + actions (sign in, sign up, sign out, google).
   const {
     user,
+    loading: authLoading,
     authError,
     isRegistering,
     setIsRegistering,
@@ -159,9 +163,6 @@ function App() {
   const [barJoinPolicy, setBarJoinPolicy] = useState<'open' | 'approval'>('open');
   // Store the user's notification preferences (list of button IDs).
   const [notificationPreferences, setNotificationPreferences] = useState<string[]>([]);
-  // Store the ntfy topic ID for iOS notifications (per-bar snapshot
-  // of the global topic, kept in sync via the bar listener).
-  const [ntfyTopic, setNtfyTopic] = useState<string | null>(null);
 
   // --- Data State ---
   // Store the list of active requests.
@@ -424,17 +425,6 @@ function App() {
           setNotificationPreferences(ROLE_NOTIFICATION_DEFAULTS[defaultsKey] || []);
         }
 
-        // Auto-coordinate ntfy topic. Mirror the global topic from
-        // users/{uid} into this bar's user profile so the fanout
-        // (which reads ntfyTopic off the per-bar user docs) stays in
-        // sync. If the global topic hasn't loaded yet, leave the
-        // per-bar value alone and pick it up on the next snapshot.
-        if (globalNtfyTopic && data.ntfyTopic !== globalNtfyTopic) {
-            updateDoc(userRef, { ntfyTopic: globalNtfyTopic }).catch(console.error);
-            setNtfyTopic(globalNtfyTopic);
-        } else {
-            setNtfyTopic(data.ntfyTopic || globalNtfyTopic);
-        }
       } else {
         // User document doesn't exist (new user).
         setUserRole(null);
@@ -550,19 +540,48 @@ function App() {
     return () => unsub();
   }, [barId, isPremium, userRole]);
 
-  // Mirror globalNtfyTopic into the per-bar user doc whenever the
-  // account-level topic changes. The per-bar user snapshot above also
-  // mirrors it on its own update, but if the global topic changes
-  // while the per-bar user doc is otherwise quiet (no role change,
-  // status flip, etc.) the snapshot wouldn't fire and the per-bar
-  // value would stay stale. This effect plugs that gap without
-  // re-subscribing the listeners.
+  // Pending ownership-claim listener (Manager+ only — matches the
+  // read rule on ownershipClaims). Writes to this collection are
+  // Cloud-Function-only (see functions/src/ownershipClaims.ts); this
+  // just surfaces what's pending for review in WhoIsOnDialog.
+  const [pendingOwnershipClaims, setPendingOwnershipClaims] = useState<Array<{ id: string; claimantName?: string; justification?: string }>>([]);
   useEffect(() => {
-    if (!user || !barId || !globalNtfyTopic) return;
-    const userRef = doc(db, `bars/${barId}/users`, user.uid);
-    updateDoc(userRef, { ntfyTopic: globalNtfyTopic }).catch(console.error);
-    setNtfyTopic(globalNtfyTopic);
-  }, [user, barId, globalNtfyTopic]);
+    if (!barId || !isManagerPlus) {
+      setPendingOwnershipClaims([]);
+      return;
+    }
+    const q = query(collection(db, `bars/${barId}/ownershipClaims`), where('status', '==', 'pending'));
+    const unsub = onSnapshot(q, (s) => {
+      setPendingOwnershipClaims(s.docs.map(d => ({ id: d.id, ...d.data() })));
+    }, (err) => console.error('Ownership claims listener failed', err));
+    return () => unsub();
+  }, [barId, isManagerPlus]);
+
+  // File a claim requesting ownership of the current bar (Account
+  // dialog). Writes go through the Cloud Function only — the client
+  // never touches ownershipClaims directly (allow write: if false).
+  const fileOwnershipClaim = async () => {
+    if (!barId) return;
+    try {
+      await httpsCallable(functions, 'fileOwnershipClaim')({ barId });
+      alert('Ownership claim filed. A manager or the current owner needs to approve it.');
+    } catch (e) {
+      console.error('Failed to file ownership claim', e);
+      alert(e instanceof Error ? e.message : 'Failed to file ownership claim.');
+    }
+  };
+
+  // Approve/reject a pending ownership claim (WhoIsOnDialog, Manager+).
+  const reviewOwnershipClaim = async (claimId: string, approve: boolean) => {
+    if (!barId) return;
+    try {
+      await httpsCallable(functions, 'reviewOwnershipClaim')({ barId, claimId, approve });
+    } catch (e) {
+      console.error('Failed to review ownership claim', e);
+      alert(e instanceof Error ? e.message : 'Failed to review ownership claim.');
+    }
+  };
+
 
   // --- 2.5 Auto-Clock In (Token Update) ---
   useEffect(() => {
@@ -960,9 +979,69 @@ function App() {
     }
   };
 
+  // Manager+ invites someone by email (BarManager). Consumption and
+  // role-granting happen server-side — see the invite-check effect
+  // below and functions/src/onInviteConsumed.ts.
+  const sendInvite = async (email: string, role: 'Staff' | 'Manager') => {
+    if (!user || !barId) return;
+    await addDoc(collection(db, `bars/${barId}/invites`), {
+      email,
+      role,
+      createdBy: user.uid,
+      createdByName: displayName,
+      createdAt: serverTimestamp(),
+      consumed: false,
+    });
+  };
+
+  // True while checking for (and possibly consuming) a pending invite
+  // for this bar/email as soon as the user lands here with no role
+  // yet. Gates the Role Selection screen so an invited user doesn't
+  // see "pick a job title" for the instant before their invited role
+  // lands — falls back to the normal flow if no invite is found, or
+  // after a timeout if granting is taking unexpectedly long.
+  const [checkingInvite, setCheckingInvite] = useState(false);
+  useEffect(() => {
+    if (userRole) setCheckingInvite(false);
+  }, [userRole]);
+  useEffect(() => {
+    if (!user || !barId || userRole || !user.email) return;
+    let cancelled = false;
+    setCheckingInvite(true);
+    const timeoutId = setTimeout(() => { if (!cancelled) setCheckingInvite(false); }, 8000);
+    (async () => {
+      try {
+        const q = query(
+          collection(db, `bars/${barId}/invites`),
+          where('email', '==', user.email!.toLowerCase()),
+          where('consumed', '==', false),
+          limit(1),
+        );
+        const snap = await getDocs(q);
+        if (cancelled) return;
+        if (snap.empty) {
+          setCheckingInvite(false);
+          return;
+        }
+        await updateDoc(snap.docs[0].ref, {
+          consumed: true,
+          consumedBy: user.uid,
+          consumedAt: serverTimestamp(),
+        });
+        // Leave checkingInvite true — the per-bar user listener will
+        // clear it (via the effect above) once onInviteConsumed grants
+        // the role, or the timeout above will if that takes too long.
+      } catch (e) {
+        console.error('Invite check failed', e);
+        if (!cancelled) setCheckingInvite(false);
+      }
+    })();
+    return () => { cancelled = true; clearTimeout(timeoutId); };
+  }, [user, barId, userRole]);
+
   // Request mutations: submit (+ ntfy fanout), claim, cancel.
-  const { submitRequest, claimRequest, cancelRequest } = useRequestActions({
-    user, barId, displayName, userRole, allUsers, getButtonIdForLabel,
+  const { submitRequest, claimRequest, unclaimRequest, cancelRequest } = useRequestActions({
+    user, barId, displayName, userRole, getButtonIdForLabel,
   });
 
   // True while a request submission is in flight. Guards against a
@@ -992,15 +1071,13 @@ function App() {
   // persisted. The per-bar user snapshot will also reconcile this
   // state once the write lands, so the local set is mostly a latency
   // smoother now.
-  const saveNotificationPreferences = async (prefs: string[], topic: string) => {
+  const saveNotificationPreferences = async (prefs: string[]) => {
     if (!user || !barId) return;
     try {
       await setDoc(doc(db, `bars/${barId}/users`, user.uid), {
         notificationPreferences: prefs,
-        ntfyTopic: topic,
       }, { merge: true });
       setNotificationPreferences(prefs);
-      setNtfyTopic(topic);
     } catch (e) {
       console.error('Failed to save notification preferences', e);
     }
@@ -1105,6 +1182,16 @@ function App() {
   };
 
   // --- Views ---
+
+  // 0. Auth still restoring — without this a returning signed-in user
+  // sees the login form flash before onAuthStateChanged resolves.
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-black">
+        <md-circular-progress indeterminate style={{ width: '32px', height: '32px' }} />
+      </div>
+    );
+  }
 
   // 1. Auth Screen
   if (!user) {
@@ -1212,6 +1299,14 @@ function App() {
 
   // 3. Role Selection Screen
   if (!userRole) {
+    if (checkingInvite) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center p-6 space-y-4 bg-black">
+          <md-circular-progress indeterminate style={{ width: '32px', height: '32px' }} />
+          <p className="text-gray-400 text-sm">Checking for an invite...</p>
+        </div>
+      );
+    }
     return (
       <div className="min-h-screen flex flex-col items-center justify-center p-6 space-y-6 bg-black">
         <div className="flex w-full justify-between items-center max-w-[300px]">
@@ -1292,6 +1387,8 @@ function App() {
         onHideButton={hideButton}
         isPremium={isPremium}
         onUnhideButton={unhideButton}
+        isManagerPlus={isManagerPlus}
+        onInvite={sendInvite}
       />
 
       <EightySixDialog
@@ -1322,6 +1419,9 @@ function App() {
         isManagerPlus={isManagerPlus}
         onApprove={approveUser}
         onReject={rejectUser}
+        pendingOwnershipClaims={pendingOwnershipClaims}
+        onApproveOwnershipClaim={(id) => reviewOwnershipClaim(id, true)}
+        onRejectOwnershipClaim={(id) => reviewOwnershipClaim(id, false)}
       />
 
       <NotificationSettings
@@ -1330,7 +1430,7 @@ function App() {
         onSave={saveNotificationPreferences}
         userRole={jobTitle || userRole || ''}
         currentPreferences={notificationPreferences}
-        currentNtfyTopic={ntfyTopic}
+        currentNtfyTopic={globalNtfyTopic}
         allButtons={buttons}
       />
 
@@ -1595,6 +1695,16 @@ function App() {
                 <md-icon slot="icon">edit</md-icon>
                 Edit Name
             </md-outlined-button>
+            {userRole !== 'Owner' && (
+                <md-outlined-button onClick={() => {
+                    if (confirm(`File a claim requesting ownership of ${barName}? A manager or the current owner will need to approve it.`)) {
+                        fileOwnershipClaim();
+                    }
+                }}>
+                    <md-icon slot="icon">verified</md-icon>
+                    Claim Ownership
+                </md-outlined-button>
+            )}
         </div>
         <div slot="actions">
             <div className="flex flex-col gap-2 w-full items-end">
@@ -1800,6 +1910,16 @@ function App() {
                  {req.claimerName || 'Someone'} claimed {req.claimedAt ? formatTime(req.claimedAt) : ''} • Asked {formatTime(req.timestamp)}
               </div>
               <md-icon slot="start" className="text-green-800">check_circle</md-icon>
+              {/* Let the claimer release a stale/mistaken claim back to
+                  pending — otherwise a claim that goes stale (they got
+                  pulled away mid-task) is invisible forever. */}
+              {user && req.claimedBy === user.uid && (
+                <md-text-button slot="end" onClick={() => unclaimRequest(req.id).catch(() => {
+                    alert('Failed to unclaim. Please try again.');
+                })}>
+                  Unclaim
+                </md-text-button>
+              )}
             </md-list-item>
           ))}
         </md-list>

--- a/src/benchmarks/NtfyDispatch.test.tsx
+++ b/src/benchmarks/NtfyDispatch.test.tsx
@@ -1,12 +1,17 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useRequestActions } from '../hooks/useRequestActions';
-import type { BarUser } from '../types';
 
-// This file used to only benchmark pMap's concurrency in isolation
-// (now covered by src/utils/async.test.ts) under a name that promised
-// coverage of the actual ntfy dispatch behavior in useRequestActions
-// but never imported it. These tests exercise the real hook instead.
+// This file originally benchmarked pMap's concurrency in isolation,
+// then (after a rewrite) exercised the client-side ntfy fanout that
+// used to live in useRequestActions.ts. That fanout has since moved
+// server-side into functions/src/onRequestCreated.ts (see
+// functions/src/__tests__/notifyEligibility.test.ts for the
+// who-gets-notified logic coverage) — this file now just verifies
+// what submitRequest itself is actually responsible for: writing the
+// request doc and vibrating, and nothing else. Moving delivery
+// server-side is also what makes double-notifying impossible; a
+// lingering client-side fetch loop here would be exactly that bug.
 
 vi.mock('../firebase', () => ({ db: {} }));
 
@@ -23,145 +28,97 @@ vi.mock('firebase/firestore', async () => {
     addDoc: (...args: unknown[]) => addDocMock(...args),
     updateDoc: (...args: unknown[]) => updateDocMock(...args),
     deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
+    deleteField: vi.fn(() => 'DELETE_FIELD_SENTINEL'),
     serverTimestamp: vi.fn(() => 'server-timestamp'),
   };
 });
 
 const user = { uid: 'me' } as any;
 
-function makeUser(overrides: Partial<BarUser> & { id: string }): BarUser {
-  return {
-    displayName: overrides.id,
-    status: 'active',
-    ntfyTopic: `topic-${overrides.id}`,
-    notificationPreferences: [],
-    ...overrides,
-  };
-}
-
-describe('useRequestActions ntfy dispatch', () => {
+describe('useRequestActions', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
+  let vibrateMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     addDocMock.mockClear();
+    updateDocMock.mockClear();
     fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
     global.fetch = fetchMock as any;
+    vibrateMock = vi.fn();
+    Object.defineProperty(navigator, 'vibrate', { value: vibrateMock, configurable: true });
   });
 
-  const setup = (allUsers: BarUser[], getButtonIdForLabel: (label: string) => string | undefined) =>
+  const setup = (getButtonIdForLabel: (label: string) => string | undefined = () => undefined) =>
     renderHook(() =>
       useRequestActions({
         user,
         barId: 'bar1',
         displayName: 'Me',
         userRole: 'Staff',
-        allUsers,
         getButtonIdForLabel,
       })
     ).result.current;
 
-  it('only pages users subscribed to the resolved button id', async () => {
-    const allUsers = [
-      makeUser({ id: 'subscribed', notificationPreferences: ['ice'] }),
-      makeUser({ id: 'unsubscribed', notificationPreferences: ['keg'] }),
-    ];
-    const { submitRequest } = setup(allUsers, () => 'ice');
+  it('submitRequest writes the request doc with the resolved buttonId and does not call fetch itself', async () => {
+    const { submitRequest } = setup(() => 'ice');
 
     await submitRequest('ICE: Well 1');
 
-    const topics = fetchMock.mock.calls.map((c) => c[0]);
-    expect(topics).toContain('https://ntfy.sh/topic-subscribed');
-    expect(topics).not.toContain('https://ntfy.sh/topic-unsubscribed');
-  });
-
-  it('excludes the requester from their own fanout', async () => {
-    const allUsers = [
-      makeUser({ id: 'me', notificationPreferences: ['ice'] }),
-      makeUser({ id: 'other', notificationPreferences: ['ice'] }),
-    ];
-    const { submitRequest } = setup(allUsers, () => 'ice');
-
-    await submitRequest('ICE: Well 1');
-
-    const topics = fetchMock.mock.calls.map((c) => c[0]);
-    expect(topics).not.toContain('https://ntfy.sh/topic-me');
-    expect(topics).toContain('https://ntfy.sh/topic-other');
-  });
-
-  it('excludes off-clock users regardless of preferences', async () => {
-    const allUsers = [
-      makeUser({ id: 'offclock', status: 'off_clock', notificationPreferences: ['ice'] }),
-    ];
-    const { submitRequest } = setup(allUsers, () => 'ice');
-
-    await submitRequest('ICE: Well 1');
-
+    expect(addDocMock).toHaveBeenCalledTimes(1);
+    const [, payload] = addDocMock.mock.calls[0];
+    expect(payload).toMatchObject({
+      barId: 'bar1',
+      label: 'ICE: Well 1',
+      requesterId: 'me',
+      status: 'pending',
+      buttonId: 'ice',
+    });
+    // Delivery is server-side now (onRequestCreated) — a lingering
+    // client-side fetch loop here would double-notify everyone.
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('pages everyone on a BREAK request, bypassing individual preferences', async () => {
-    const allUsers = [
-      makeUser({ id: 'a', notificationPreferences: [] }),
-      makeUser({ id: 'b', notificationPreferences: ['ice'] }),
-    ];
-    const { submitRequest } = setup(allUsers, () => 'break');
+  it('submitRequest omits buttonId entirely for free text with no resolvable button', async () => {
+    const { submitRequest } = setup(() => undefined);
 
-    await submitRequest('BREAK');
+    await submitRequest('Someone spilled a tray of glasses');
 
-    const topics = fetchMock.mock.calls.map((c) => c[0]);
-    expect(topics).toContain('https://ntfy.sh/topic-a');
-    expect(topics).toContain('https://ntfy.sh/topic-b');
+    const [, payload] = addDocMock.mock.calls[0];
+    expect(payload).not.toHaveProperty('buttonId');
   });
 
-  it('pages everyone for a free-text request with no resolvable button id', async () => {
-    // Matches the in-app "show to everyone" safety default for
-    // requests activeRequests can't classify (App.tsx) — a custom
-    // request should page the same set of people it's shown to, not
-    // page nobody while appearing to everyone in-app.
-    const allUsers = [
-      makeUser({ id: 'a', notificationPreferences: [] }),
-      makeUser({ id: 'b', notificationPreferences: ['ice'] }),
-    ];
-    const { submitRequest } = setup(allUsers, () => undefined);
-
-    await submitRequest('Someone spilled a whole tray of glasses at the end of the bar');
-
-    const topics = fetchMock.mock.calls.map((c) => c[0]);
-    expect(topics).toContain('https://ntfy.sh/topic-a');
-    expect(topics).toContain('https://ntfy.sh/topic-b');
-  });
-
-  it('does not fan out to a user with no ntfy topic', async () => {
-    const allUsers = [
-      makeUser({ id: 'no-topic', notificationPreferences: ['ice'], ntfyTopic: undefined }),
-    ];
-    const { submitRequest } = setup(allUsers, () => 'ice');
-
+  it('submitRequest vibrates for immediate haptic feedback', async () => {
+    const { submitRequest } = setup(() => 'ice');
     await submitRequest('ICE: Well 1');
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('one failing topic does not prevent the others from being dispatched', async () => {
-    const allUsers = [
-      makeUser({ id: 'fails', notificationPreferences: ['ice'] }),
-      makeUser({ id: 'succeeds', notificationPreferences: ['ice'] }),
-    ];
-    fetchMock.mockImplementation((url: string) =>
-      url.includes('topic-fails') ? Promise.reject(new Error('network error')) : Promise.resolve({ ok: true })
-    );
-    const { submitRequest } = setup(allUsers, () => 'ice');
-
-    await expect(submitRequest('ICE: Well 1')).resolves.toBeUndefined();
-
-    const topics = fetchMock.mock.calls.map((c) => c[0]);
-    expect(topics).toContain('https://ntfy.sh/topic-succeeds');
+    expect(vibrateMock).toHaveBeenCalledWith(100);
   });
 
   it('claimRequest rejects when the write is denied (already claimed by someone else)', async () => {
     updateDocMock.mockRejectedValueOnce(new Error('permission-denied'));
-    const { claimRequest } = setup([], () => undefined);
+    const { claimRequest } = setup();
 
     await expect(claimRequest('req1')).rejects.toThrow('permission-denied');
+  });
+
+  it('unclaimRequest reverts status to pending and clears claim fields', async () => {
+    const { unclaimRequest } = setup();
+
+    await unclaimRequest('req1');
+
+    expect(updateDocMock).toHaveBeenCalledTimes(1);
+    const [, payload] = updateDocMock.mock.calls[0];
+    expect(payload).toMatchObject({
+      status: 'pending',
+      claimedBy: 'DELETE_FIELD_SENTINEL',
+      claimerName: 'DELETE_FIELD_SENTINEL',
+      claimedAt: 'DELETE_FIELD_SENTINEL',
+    });
+  });
+
+  it('unclaimRequest rejects when the write is denied (not the current claimer)', async () => {
+    updateDocMock.mockRejectedValueOnce(new Error('permission-denied'));
+    const { unclaimRequest } = setup();
+
+    await expect(unclaimRequest('req1')).rejects.toThrow('permission-denied');
   });
 });

--- a/src/components/BarManager.tsx
+++ b/src/components/BarManager.tsx
@@ -10,6 +10,7 @@ import '@material/web/icon/icon.js';
 import '@material/web/iconbutton/icon-button.js';
 import '@material/web/list/list.js';
 import '@material/web/list/list-item.js';
+import '@material/web/textfield/filled-text-field.js';
 
 // Import the ButtonConfig type definition.
 import { ButtonConfig } from '../types';
@@ -34,13 +35,38 @@ interface BarManagerProps {
   isPremium?: boolean;
   // Callback function to unhide/restore a button.
   onUnhideButton?: (id: string) => void;
+  // Whether the current user can send invites (Manager+).
+  isManagerPlus?: boolean;
+  // Sends an invite for the given email at the given (non-Owner) role.
+  onInvite?: (email: string, role: 'Staff' | 'Manager') => Promise<void>;
 }
 
 // The BarManager component provides an interface for managers to configure which buttons are visible on the dashboard.
 // Currently, it only supports "hiding" (soft deleting) buttons.
-const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHideButton, isPremium, onUnhideButton }: BarManagerProps) => {
+const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHideButton, isPremium, onUnhideButton, isManagerPlus, onInvite }: BarManagerProps) => {
   // State to track the ID of the button currently selected for deletion confirmation.
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<'Staff' | 'Manager'>('Staff');
+  const [inviteSending, setInviteSending] = useState(false);
+  const [inviteMessage, setInviteMessage] = useState<string | null>(null);
+
+  const handleSendInvite = async () => {
+    const email = inviteEmail.trim().toLowerCase();
+    if (!email || !onInvite) return;
+    setInviteSending(true);
+    setInviteMessage(null);
+    try {
+      await onInvite(email, inviteRole);
+      setInviteEmail('');
+      setInviteMessage(`Invite sent to ${email}.`);
+    } catch (e) {
+      console.error('Failed to send invite', e);
+      setInviteMessage('Failed to send invite. Please try again.');
+    } finally {
+      setInviteSending(false);
+    }
+  };
 
   // Create a Set for O(1) lookups of hidden IDs.
   const hiddenButtonSet = useMemo(() => new Set(hiddenButtonIds), [hiddenButtonIds]);
@@ -105,6 +131,36 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
                 )}
                 </md-list>
            </div>
+
+           {/* Invite (Manager+ only) */}
+           {isManagerPlus && onInvite && (
+             <div className="mt-2 border border-gray-800 rounded p-3 flex flex-col gap-2">
+               <div className="text-xs font-bold text-gray-400 uppercase">Invite Staff</div>
+               <md-filled-text-field
+                 label="Email"
+                 type="email"
+                 value={inviteEmail}
+                 onInput={(e: any) => setInviteEmail(e.target.value)}
+               />
+               <div className="flex gap-4 items-center">
+                 <label className="flex items-center gap-1 text-sm text-gray-300 cursor-pointer">
+                   <input type="radio" name="inviteRole" checked={inviteRole === 'Staff'} onChange={() => setInviteRole('Staff')} />
+                   Staff
+                 </label>
+                 <label className="flex items-center gap-1 text-sm text-gray-300 cursor-pointer">
+                   <input type="radio" name="inviteRole" checked={inviteRole === 'Manager'} onChange={() => setInviteRole('Manager')} />
+                   Manager
+                 </label>
+               </div>
+               <md-filled-button disabled={!inviteEmail.trim() || inviteSending || undefined} onClick={handleSendInvite}>
+                 {inviteSending ? 'Sending...' : 'Send Invite'}
+               </md-filled-button>
+               {inviteMessage && <div className="text-xs text-gray-400">{inviteMessage}</div>}
+               <div className="text-[10px] text-gray-600">
+                 They'll be added automatically the next time they open this bar while signed in with that email.
+               </div>
+             </div>
+           )}
 
            {/* Hidden Buttons (Premium Only) */}
            {isPremium && hiddenButtons.length > 0 && (

--- a/src/components/NotificationSettings.test.tsx
+++ b/src/components/NotificationSettings.test.tsx
@@ -54,7 +54,7 @@ describe('NotificationSettings', () => {
 
         // Click Save immediately
         fireEvent.click(screen.getByText('Save'));
-        expect(mockOnSave).toHaveBeenCalledWith(['ice'], '');
+        expect(mockOnSave).toHaveBeenCalledWith(['ice']);
     });
 
     it('toggles preferences', async () => {
@@ -93,7 +93,7 @@ describe('NotificationSettings', () => {
         fireEvent.click(screen.getByText('Save'));
 
         // Should now include 'ice' and 'security'
-        expect(mockOnSave).toHaveBeenCalledWith(['ice', 'security'], '');
+        expect(mockOnSave).toHaveBeenCalledWith(['ice', 'security']);
     });
 
     it('resets to defaults', async () => {
@@ -127,5 +127,36 @@ describe('NotificationSettings', () => {
         expect(saved).toContain('glass');
         expect(saved).toContain('keg'); // Default
         expect(saved).not.toContain('security'); // Bartender doesn't have security default
+    });
+
+    it('shows a Loading badge (not a hardcoded Active) before the ntfy topic arrives', () => {
+        render(
+            <NotificationSettings
+                open={true}
+                onClose={mockOnClose}
+                onSave={mockOnSave}
+                userRole="Bartender"
+                currentPreferences={[]}
+                currentNtfyTopic={null}
+                allButtons={MOCK_BUTTONS}
+            />
+        );
+        expect(screen.getAllByText('Loading...').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    });
+
+    it('shows an Active badge once the ntfy topic has loaded', () => {
+        render(
+            <NotificationSettings
+                open={true}
+                onClose={mockOnClose}
+                onSave={mockOnSave}
+                userRole="Bartender"
+                currentPreferences={[]}
+                currentNtfyTopic="barbacker-abc123"
+                allButtons={MOCK_BUTTONS}
+            />
+        );
+        expect(screen.getByText('Active')).toBeInTheDocument();
     });
 });

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -18,8 +18,8 @@ import { MdDialog } from './MdDialog';
 interface NotificationSettingsProps {
   open: boolean;
   onClose: () => void;
-  // Callback to save: returns the list of enabled button IDs and the ntfy topic.
-  onSave: (preferences: string[], ntfyTopic: string) => void;
+  // Callback to save the list of enabled button IDs.
+  onSave: (preferences: string[]) => void;
   userRole: string;
   currentPreferences: string[]; // List of enabled IDs
   currentNtfyTopic?: string | null;
@@ -38,16 +38,36 @@ const NotificationSettings = ({
 }: NotificationSettingsProps) => {
   // Local state for the list of enabled IDs.
   const [preferences, setPreferences] = useState<string[]>([]);
-  // Local state for the ntfy topic (read-only mostly, but passed back).
-  const [ntfyTopic, setNtfyTopic] = useState<string>('');
 
   // Initialize preferences when the dialog opens or props change.
   useEffect(() => {
     if (open) {
       setPreferences(currentPreferences);
-      setNtfyTopic(currentNtfyTopic || '');
     }
-  }, [open, currentPreferences, currentNtfyTopic]);
+  }, [open, currentPreferences]);
+
+  // The "Active" badge used to be hardcoded regardless of whether
+  // notifications actually work. This checks the one signal available
+  // cross-platform from plain web APIs: on web, the Notification
+  // permission; the ntfy topic itself is the other precondition
+  // (still loading right after signup). Native (Capacitor) apps don't
+  // have a `Notification` global at all, so they fall through to
+  // "assume granted" here — the OS-level permission prompt is handled
+  // by usePushNotifications on that path and isn't re-checked in this
+  // dialog.
+  const [webPermission, setWebPermission] = useState<NotificationPermission | 'unsupported'>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'unsupported'
+  );
+  useEffect(() => {
+    if (!open || typeof Notification === 'undefined') return;
+    setWebPermission(Notification.permission);
+  }, [open]);
+
+  const status: { label: string; className: string } = !currentNtfyTopic
+    ? { label: 'Loading...', className: 'text-gray-400 bg-gray-800/50' }
+    : webPermission === 'denied'
+      ? { label: 'Blocked', className: 'text-red-400 bg-red-900/30' }
+      : { label: 'Active', className: 'text-green-400 bg-green-900/30' };
 
   // Handler for toggling a specific button's notification.
   const handleToggle = (id: string, selected: boolean) => {
@@ -68,7 +88,7 @@ const NotificationSettings = ({
 
   // Save changes.
   const handleSave = () => {
-    onSave(preferences, ntfyTopic);
+    onSave(preferences);
     onClose();
   };
 
@@ -84,18 +104,23 @@ const NotificationSettings = ({
         <div className="p-4 bg-[#2D2D2D] rounded-lg border border-[#444] flex flex-col gap-3">
              <div className="flex items-center justify-between">
                  <span className="font-bold text-gray-300">iOS Alerts (ntfy)</span>
-                 <span className="text-xs text-green-400 font-mono bg-green-900/30 px-2 py-1 rounded">Active</span>
+                 <span className={`text-xs font-mono px-2 py-1 rounded ${status.className}`}>{status.label}</span>
              </div>
+             {status.label === 'Blocked' && (
+                 <p className="text-xs text-red-400">
+                     Notifications are blocked in this browser. Enable them in your browser/OS settings, then reopen this dialog.
+                 </p>
+             )}
 
              {/* Display Topic ID */}
              <div className="text-xs text-gray-400 font-mono break-all p-2 bg-black/50 rounded select-all">
-                {ntfyTopic || 'Loading...'}
+                {currentNtfyTopic || 'Loading...'}
              </div>
 
              {/* Subscribe Link (Deep Link) */}
-             {ntfyTopic && (
+             {currentNtfyTopic && (
                  <a
-                    href={`ntfy://subscribe/${ntfyTopic}`}
+                    href={`ntfy://subscribe/${currentNtfyTopic}`}
                     className="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-lg font-bold text-sm transition-colors text-center no-underline"
                  >
                     <md-icon style={{ fontSize: '18px' }}>notifications_active</md-icon>

--- a/src/components/WhoIsOnDialog.tsx
+++ b/src/components/WhoIsOnDialog.tsx
@@ -21,15 +21,25 @@ interface WhoIsOnDialogProps {
   isManagerPlus?: boolean;
   onApprove?: (userId: string) => void;
   onReject?: (userId: string) => void;
+  // Pending ownership claims (Manager+ only), and handlers to approve
+  // or reject them. See functions/src/ownershipClaims.ts — writes to
+  // this collection are Cloud-Function-only.
+  pendingOwnershipClaims?: Array<{ id: string; claimantName?: string; justification?: string }>;
+  onApproveOwnershipClaim?: (claimId: string) => void;
+  onRejectOwnershipClaim?: (claimId: string) => void;
 }
 
 // Dialog to show list of users in the current bar, and — for
-// Manager+ — approve or reject anyone waiting on 'approval' joinPolicy.
-// This is the other half of a policy firestore.rules already
-// enforces (self-create writes status:'pending' for that policy):
-// without an approve action anywhere in the app, a pending user had
-// no way to ever be let in.
-export const WhoIsOnDialog = ({ open, onClose, users, isManagerPlus, onApprove, onReject }: WhoIsOnDialogProps) => {
+// Manager+ — approve or reject anyone waiting on 'approval' joinPolicy,
+// plus any pending ownership claims. This is the other half of two
+// policies firestore.rules already enforces (self-create writes
+// status:'pending' for that policy; ownershipClaims writes are
+// Cloud-Function-only) but that nothing in the app previously acted
+// on — a pending user or a filed claim had no path to ever resolve.
+export const WhoIsOnDialog = ({
+  open, onClose, users, isManagerPlus, onApprove, onReject,
+  pendingOwnershipClaims, onApproveOwnershipClaim, onRejectOwnershipClaim,
+}: WhoIsOnDialogProps) => {
   // Filter for active users (clocked in).
   // Note: users with undefined status are treated as active for backward compatibility.
   const clockedInUsers = users.filter(u => u.status === 'active' || u.status === undefined);
@@ -56,6 +66,30 @@ export const WhoIsOnDialog = ({ open, onClose, users, isManagerPlus, onApprove, 
                     <div slot="end" className="flex gap-2">
                       <md-outlined-button onClick={() => onReject?.(u.id)}>Reject</md-outlined-button>
                       <md-filled-button onClick={() => onApprove?.(u.id)}>Approve</md-filled-button>
+                    </div>
+                  </md-list-item>
+                ))}
+              </md-list>
+            </div>
+          </div>
+        )}
+
+        {/* Section: Pending Ownership Claims (Manager+ only) */}
+        {isManagerPlus && pendingOwnershipClaims && pendingOwnershipClaims.length > 0 && (
+          <div>
+            <h3 className="text-blue-400 font-bold text-sm uppercase tracking-wide mb-2">
+              Ownership Claims ({pendingOwnershipClaims.length})
+            </h3>
+            <div className="border border-blue-900 rounded overflow-hidden">
+              <md-list>
+                {pendingOwnershipClaims.map(c => (
+                  <md-list-item key={c.id}>
+                    <div slot="headline" className="text-white">{c.claimantName || 'Unknown'}</div>
+                    {c.justification && <div slot="supporting-text" className="text-gray-400">{c.justification}</div>}
+                    <md-icon slot="start" className="text-blue-400">verified</md-icon>
+                    <div slot="end" className="flex gap-2">
+                      <md-outlined-button onClick={() => onRejectOwnershipClaim?.(c.id)}>Reject</md-outlined-button>
+                      <md-filled-button onClick={() => onApproveOwnershipClaim?.(c.id)}>Approve</md-filled-button>
                     </div>
                   </md-list-item>
                 ))}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,6 @@
 // Import the 'ButtonConfig' interface to type the default button structures.
 import { ButtonConfig } from './types';
 
-export const NTFY_DISPATCH_CONCURRENCY = 5;
-
 // Job titles a joining user can self-select. This is deliberately
 // NOT the privilege list — 'Owner' is auto-assigned to whoever
 // creates the bar and 'Manager' can only be granted by promotion, so

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -22,6 +22,10 @@ import {
 import { getMessaging, getToken, onMessage } from "firebase/messaging";
 // Import Firebase Storage for file uploads (e.g., bar logos).
 import { getStorage } from "firebase/storage";
+// Import Firebase Functions for calling the ownership-claim callables
+// (ownershipClaims writes go through Cloud Functions only — see
+// firestore.rules and functions/src/ownershipClaims.ts).
+import { getFunctions } from "firebase/functions";
 
 // Define the Firebase configuration object using environment variables.
 // These variables are injected by Vite at build time.
@@ -59,6 +63,10 @@ export const messaging = getMessaging(app);
 // Initialize and export the Firebase Storage service instance for
 // file uploads (bar logo uploads from ThemeEditor).
 export const storage = getStorage(app);
+
+// Initialize and export the Firebase Functions service instance for
+// calling onCall callables (ownership-claim filing/review).
+export const functions = getFunctions(app);
 
 // --- Auth Providers ---
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -21,9 +21,17 @@ export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isRegistering, setIsRegistering] = useState(false);
+  // True until onAuthStateChanged's first callback. Without this, a
+  // returning signed-in user briefly sees the login form (App.tsx's
+  // `!user` screen) on every cold start, since `user` starts out null
+  // regardless of whether a session is about to be restored.
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (u) => setUser(u));
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
     return () => unsubscribe();
   }, []);
 
@@ -51,6 +59,7 @@ export function useAuth() {
 
   return {
     user,
+    loading,
     authError,
     isRegistering,
     setIsRegistering,

--- a/src/hooks/useBarTheme.ts
+++ b/src/hooks/useBarTheme.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import type { BarTheme } from '../types';
 import { getContrastColor } from '../utils/color';
 
@@ -7,7 +7,10 @@ import { getContrastColor } from '../utils/color';
  * Removes custom properties when theme is undefined or bar is not premium.
  */
 export function useBarTheme(theme: BarTheme | undefined, isPremium: boolean): void {
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) applies the CSS variables
+  // synchronously before the browser paints, avoiding a one-frame
+  // flash of the previous/default colors on every theme change.
+  useLayoutEffect(() => {
     const root = document.documentElement;
 
     if (!isPremium || !theme) {

--- a/src/hooks/useRequestActions.ts
+++ b/src/hooks/useRequestActions.ts
@@ -4,42 +4,39 @@ import {
   addDoc,
   collection,
   deleteDoc,
+  deleteField,
   doc,
   serverTimestamp,
   updateDoc,
 } from 'firebase/firestore';
 import { db } from '../firebase';
-import { ROLE_NOTIFICATION_DEFAULTS, NTFY_DISPATCH_CONCURRENCY } from '../constants';
-import { pMap } from '../utils/async';
-import type { BarUser } from '../types';
 
 interface UseRequestActionsArgs {
   user: User | null;
   barId: string | null;
   displayName: string;
   userRole: string | null;
-  allUsers: BarUser[];
   getButtonIdForLabel: (label: string) => string | undefined;
 }
 
 // Owns the three request mutations:
-//   - submitRequest(label): writes to /requests, vibrates, fans out
-//     ntfy.sh notifications to every active member subscribed to this
-//     button. BREAK requests are sent to everyone regardless of prefs.
+//   - submitRequest(label): writes to /requests and vibrates for
+//     immediate haptic feedback. Delivery (FCM push + ntfy.sh) is
+//     handled server-side by the onRequestCreated Cloud Function,
+//     which fires on every new /requests doc — this used to fan out
+//     ntfy.sh calls from the client itself, which required every
+//     client to be able to read every bar member's ntfy topic (see
+//     firestore.rules' notes on the per-bar user doc) purely so it
+//     could compute who to notify. Moving it server-side closed that
+//     exposure and also means a request gets an instant native push
+//     instead of waiting for nag-bot's 5-minute cron.
 //   - claimRequest(reqId): marks a request as claimed.
 //   - cancelRequest(reqId): deletes a request the user created.
-//
-// ntfy fanout: the per-topic mapper catches its own errors so pMap
-// never rejects and one bad topic cannot abort the rest. We await
-// pMap so submitRequest only resolves once dispatch attempts are
-// complete — this is what gives the inactivity timer and UI a clean
-// "done" signal.
 export function useRequestActions({
   user,
   barId,
   displayName,
   userRole,
-  allUsers,
   getButtonIdForLabel,
 }: UseRequestActionsArgs) {
   const submitRequest = useCallback(async (label: string) => {
@@ -57,69 +54,13 @@ export function useRequestActions({
       status: 'pending',
       timestamp: serverTimestamp(),
       lastNotification: serverTimestamp(),
-      // Persisted so the (separate, Admin-SDK) nag-bot script can
-      // apply the same notificationPreferences filtering as this
-      // in-app fanout without re-deriving it from the bar's button
-      // config, which it has no access to.
+      // Persisted so onRequestCreated (server-side fanout) and
+      // nag-bot.js can apply the same notificationPreferences
+      // filtering without re-deriving it from the bar's button
+      // config, which neither has access to.
       ...(btnId ? { buttonId: btnId } : {}),
     });
-
-    const topics = new Set<string>();
-
-    allUsers.forEach(u => {
-      const isActive = u.status === 'active' || u.status === undefined;
-      if (!isActive || u.id === user.uid || !u.ntfyTopic) return;
-
-      let prefs = u.notificationPreferences;
-      if (!prefs && u.role) {
-        prefs = ROLE_NOTIFICATION_DEFAULTS[u.role] || [];
-      }
-
-      // BREAK requests always fan out to everyone. Exact resolved-id
-      // match only — a substring check on the label would let free
-      // text like "BREAKAGE AT WELL 3" mass-notify everyone regardless
-      // of preferences.
-      if (btnId === 'break') {
-        topics.add(u.ntfyTopic);
-        return;
-      }
-
-      // Free-text / unrecognized labels (custom requests, "(Ask Me)"
-      // auto-submits) have no btnId to check preferences against.
-      // activeRequests in App.tsx treats this the same way — shown to
-      // everyone as a safety default — so mirror that here instead of
-      // silently notifying nobody.
-      if (!btnId) {
-        topics.add(u.ntfyTopic);
-        return;
-      }
-
-      if (prefs && prefs.includes(btnId)) {
-        topics.add(u.ntfyTopic);
-      }
-    });
-
-    await pMap(
-      Array.from(topics),
-      async (topic) => {
-        try {
-          return await fetch(`https://ntfy.sh/${topic}`, {
-            method: 'POST',
-            body: `New Request: ${label} (by ${displayName})`,
-            headers: {
-              'Title': 'BarBacker Alert',
-              'Priority': 'high',
-              'Tags': 'bell,bar_chart',
-            },
-          });
-        } catch (err) {
-          console.error('Failed to send ntfy', err);
-          return undefined;
-        }
-      },
-      NTFY_DISPATCH_CONCURRENCY,
-    );
-  }, [user, barId, displayName, userRole, allUsers, getButtonIdForLabel]);
+  }, [user, barId, displayName, userRole, getButtonIdForLabel]);
 
   // Firestore serializes writes to a single document, and
   // firestore.rules requires resource.data.status == 'pending' for
@@ -142,9 +83,26 @@ export function useRequestActions({
     }
   }, [user, displayName]);
 
+  // Release a claim back to pending — the claimer got pulled away
+  // mid-task, or claimed the wrong one. firestore.rules only permits
+  // this transition for whoever currently holds the claim.
+  const unclaimRequest = useCallback(async (reqId: string) => {
+    try {
+      await updateDoc(doc(db, 'requests', reqId), {
+        status: 'pending',
+        claimedBy: deleteField(),
+        claimerName: deleteField(),
+        claimedAt: deleteField(),
+      });
+    } catch (e) {
+      console.error('Failed to unclaim request', e);
+      throw e;
+    }
+  }, []);
+
   const cancelRequest = useCallback(async (reqId: string) => {
     await deleteDoc(doc(db, 'requests', reqId));
   }, []);
 
-  return { submitRequest, claimRequest, cancelRequest };
+  return { submitRequest, claimRequest, unclaimRequest, cancelRequest };
 }

--- a/src/test/FirebasePersistence.test.ts
+++ b/src/test/FirebasePersistence.test.ts
@@ -46,6 +46,11 @@ vi.mock('firebase/storage', () => ({
   getStorage: vi.fn(() => ({})),
 }));
 
+// Mock firebase/functions (used for the ownership-claim callables)
+vi.mock('firebase/functions', () => ({
+  getFunctions: vi.fn(() => ({})),
+}));
+
 describe('Firebase Persistence', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/src/test/MultiBar.test.tsx
+++ b/src/test/MultiBar.test.tsx
@@ -37,7 +37,7 @@ vi.mock('firebase/auth', () => ({
 vi.mock('firebase/firestore', () => {
     return {
         getFirestore: vi.fn(),
-        collection: vi.fn(() => ({ type: 'collection' })),
+        collection: vi.fn((_db, path) => ({ type: 'collection', path })),
         doc: vi.fn((db, path, ...args) => {
             const fullPath = path + (args.length ? '/' + args.join('/') : '');
             return { type: 'doc', path: fullPath };
@@ -77,7 +77,17 @@ vi.mock('firebase/firestore', () => {
         arrayUnion: arrayUnionSpy,
         arrayRemove: arrayRemoveSpy,
         increment: vi.fn(),
-        getDocs: vi.fn(async () => {
+        getDocs: vi.fn(async (q: any) => {
+             // Only the useMyBars "bars" name lookup (collection(db, 'bars'))
+             // should resolve with a bar — anything else (e.g. App.tsx's
+             // per-bar invite check, collection(db, `bars/{barId}/invites`))
+             // must come back empty, or the invite-check effect treats this
+             // fixture's single fake doc as a real pending invite and never
+             // clears its "Checking for an invite..." screen.
+             const path = q?.args?.[0]?.path;
+             if (path !== 'bars') {
+                 return { forEach: () => {}, docs: [] };
+             }
              return {
                  forEach: (cb: any) => {
                      cb({ id: 'bar-1', data: () => ({ name: 'Bar One' }), exists: () => true });

--- a/src/test/firestore-rules.test.ts
+++ b/src/test/firestore-rules.test.ts
@@ -11,6 +11,7 @@ import {
   getDoc,
   updateDoc,
   deleteDoc,
+  deleteField,
   collection,
   addDoc,
 } from 'firebase/firestore';
@@ -234,6 +235,33 @@ describe('Firestore security rules', () => {
     it('allows a requester to delete (cancel) their own request', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(deleteDoc(doc(db, 'requests', 'r-a')));
+    });
+
+    it('lets the claimer release a claim back to pending (unclaim)', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), 'requests', 'r-a'), {
+          barId: BAR_A, label: 'ICE', requesterId: ALICE, status: 'claimed',
+          claimedBy: MANAGER, claimerName: 'M', timestamp: new Date(), claimedAt: new Date(),
+        });
+      });
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertSucceeds(updateDoc(doc(db, 'requests', 'r-a'), {
+        status: 'pending', claimedBy: deleteField(), claimerName: deleteField(), claimedAt: deleteField(),
+      }));
+    });
+
+    it('denies unclaiming a request someone else is holding', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), 'requests', 'r-a'), {
+          barId: BAR_A, label: 'ICE', requesterId: ALICE, status: 'claimed',
+          claimedBy: MANAGER, claimerName: 'M', timestamp: new Date(), claimedAt: new Date(),
+        });
+      });
+      // Alice has a role at bar A but never claimed this request.
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
+      await assertFails(updateDoc(doc(db, 'requests', 'r-a'), {
+        status: 'pending', claimedBy: deleteField(), claimerName: deleteField(), claimedAt: deleteField(),
+      }));
     });
 
     it('allows an admin to read across bars', async () => {

--- a/src/test/rules/bar.test.ts
+++ b/src/test/rules/bar.test.ts
@@ -64,6 +64,20 @@ describe("bar rules", () => {
     }));
   });
 
+  it("Staff cannot self-write ntfyTopic on the per-bar user doc", async () => {
+    // ntfyTopic used to be mirrored here so client-side fanout could
+    // read every member's topic — which is exactly what made it
+    // possible for any bar member to read (and keep, even after being
+    // kicked) a colleague's ntfy topic. Fanout is now server-side
+    // (onRequestCreated), reading the topic off the global,
+    // self-only users/{uid} doc instead — this field should no longer
+    // be writable (or meaningfully readable by peers) here at all.
+    const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+    await assertFails(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), {
+      ntfyTopic: "some-topic",
+    }));
+  });
+
   it("Staff cannot escalate role via combined-field self-write", async () => {
     const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
     // Attempt to set status:off_clock AND role:Manager in one update.

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,9 @@ export interface Request {
   buttonId?: string;
   // Optional: The name of the user who claimed the request.
   claimerName?: string;
+  // Optional: The uid of the user who claimed the request. Lets the
+  // claimer (and only the claimer) release it back to pending.
+  claimedBy?: string;
   // Optional: The timestamp of the last notification sent for this request (used for throttling).
   lastNotification?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
 }
@@ -158,8 +161,6 @@ export interface BarUser {
   email?: string;
   // Optional: List of button IDs the user wants to be notified about.
   notificationPreferences?: string[];
-  // Optional: The ntfy topic ID for iOS notifications.
-  ntfyTopic?: string;
   // Optional: Server timestamp of the user's most recent notice
   // post. Used by firestore.rules to enforce a 5s cooldown between
   // notice creates. Bumped atomically by saveNotice (batched write).


### PR DESCRIPTION
## Summary

Sixth round of glee-audit remediation, closing out the remaining "real gaps" plus deferred-by-design items #2 (client-cooperative notice rate-limit) and #3 (dead `invites`/`ownershipClaims` collections).

### Real gaps closed

- **Server-side notification fanout.** Request notifications (FCM + ntfy) now go out from a new `onRequestCreated` Cloud Function instead of the client. The old client-side fanout had to read every eligible member's `ntfyTopic` off the per-bar user doc — which is exactly what let any bar member read (and keep, even after being kicked) a colleague's ntfy topic. The function reads the topic off the self-only global `users/{uid}` doc via the Admin SDK instead, so no client needs to read a peer's topic at all. `ntfyTopic` is dropped from the per-bar doc's writable/readable fields in `firestore.rules`. Eligibility logic (role/preferences/off-clock/break-always-notifies/self-exclusion) is extracted into a pure, unit-tested `notifyEligibility.ts`.
- **Unclaim.** A "claimed" request can now be released back to "pending" by whoever holds the claim — a new precondition-gated `update` branch in `firestore.rules`, plus an "Unclaim" button in the Shift Log. Previously a stale or mistaken claim had no recovery path.
- **Stale request cleanup.** A new scheduled `cleanupStaleRequests` function deletes requests still `pending` after 12 hours.
- **Honest notification status badge.** `NotificationSettings` no longer hardcodes "Active" before the ntfy topic has even loaded — it now shows Loading/Blocked/Active based on real state.
- **Auth loading flag.** `useAuth` exposes `loading`, and `App.tsx` shows a spinner during initial auth resolution instead of flashing the signed-out state.
- **Theme FOUC fix.** `useBarTheme` switched from `useEffect` to `useLayoutEffect` to remove a one-frame flash of default colors on bar-theme change.

### Deferred-by-design items closed

- **Notice rate-limit was client-cooperative** — a hostile client could just skip bumping `lastNoticeAt` and post as fast as it wanted. Added an authoritative `onNoticeCreated` trigger that queries the author's actually-committed prior notices (which can't be spoofed by the client) and deletes the new notice if it violates the 5s window. Backed by a new `notices(authorId, timestamp)` composite index.
- **`invites`/`ownershipClaims` were dead** — rules existed but nothing ever consumed them. Added:
  - `onInviteConsumed`: grants a role and `joinedBars` membership when an invite is consumed, downgrading a claimed `Owner` role to `Manager`.
  - `fileOwnershipClaim` / `reviewOwnershipClaim`: callables letting a non-owner file an ownership claim and letting a Manager+/admin approve or reject it (approval transfers `bars/{barId}.ownerId` and demotes the previous owner).
  - Minimal client wiring to actually exercise both: an "Invite Staff" form in `BarManager`, an auto-consume-on-entry invite check in `App.tsx`, a "Claim Ownership" button, and an approve/reject list in `WhoIsOnDialog`.

### Verification

- Web build: passes
- jsdom test suite: 82/82 passing
- Functions build (`tsc`) + unit tests: 10/10 passing (covers `notifyEligibility`'s pure eligibility logic)
- Firestore rules emulator suite: 61/61 passing, including 3 new tests (unclaim success/denial, ntfyTopic self-write denial on the per-bar doc)

**Not verifiable in this sandbox:** the new Cloud Functions are type-checked and unit-tested where their logic is pure, but true end-to-end delivery (FCM push, ntfy push, invite consumption, ownership-claim approval) requires a real Firebase project deploy to confirm. Please verify those flows after merging and deploying.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Move request notification delivery, notice rate limiting, and invite/ownership workflows to server-side Cloud Functions while tightening related client behavior and rules.

New Features:
- Introduce Cloud Functions for request-created fanout (FCM and ntfy), notice creation rate limiting, stale request cleanup, invite consumption, and ownership claim filing/review.
- Add client support for staff invites and ownership claims, including invite-based auto-role assignment and manager review UI in WhoIsOnDialog.
- Allow request claim holders to unclaim requests, returning them to pending state from the UI.

Bug Fixes:
- Prevent clients from reading or writing peers’ ntfy topics in per-bar user docs by relying on global user docs and server-side fanout.
- Make notification status in NotificationSettings reflect real ntfy topic and browser permission state instead of hardcoded Active.
- Ensure returning authenticated users don’t briefly see the sign-in screen by adding an auth loading state and spinner.
- Eliminate theme flash-of-unstyled-content on bar theme changes by switching bar theme application to layout effect.

Enhancements:
- Simplify request submission responsibilities on the client to writing the request and vibrating, with eligibility logic extracted and unit-tested server-side.
- Refine Firestore security rules to support unclaim operations and enforce ntfyTopic write restrictions, with corresponding emulator tests.
- Improve invite flows so newly invited staff are automatically onboarded on bar entry without transient role selection flashes.

Tests:
- Update unit and integration tests for request actions, notification settings, Firestore rules, and Firebase persistence to cover new server-side behavior and UI states, including unclaim, notice cooldown, and ntfy status badges.