### PR TITLE
docs: start a future-feature list (Compose Multiplatform rewrite, Phases 2-4 pointer)

### DIFF
--- a/docs/plans/future-features.md
+++ b/docs/plans/future-features.md
@@ -1,0 +1,33 @@
+# Future Feature List
+
+Ideas raised but not scoped or scheduled. Not a commitment, not a plan —
+just a place to keep track so they don't get lost. Promote an entry to its
+own `docs/plans/<date>-<name>.md` design doc when it's actually picked up.
+
+## Compose Multiplatform rewrite
+
+Rewrite the client (currently React 19 + Vite + Capacitor, covering
+Android/iOS/web from one codebase) in Kotlin with Compose Multiplatform.
+
+Main tradeoff: CMP's Android/desktop story is mature, but iOS and
+web/Wasm support are comparatively young next to the current Capacitor +
+Firebase JS SDK setup, and none of the existing UI code carries over —
+it's a from-scratch client rewrite sitting on top of the same Firestore
+backend and Cloud Functions. Worth revisiting if native performance/UI
+becomes a real requirement, or if there's a language/tooling reason to
+move off the web stack.
+
+## Also already tracked, not yet built
+
+The four-phase plan in `2026-05-21-feature-set-purr-design.md` has Phase 1
+(hardening) effectively done as of the glee-audit rounds; Phases 2-4 are
+still fully unbuilt and each independent enough to pick up on its own:
+
+- **Phase 2** — real chat with pinned notices (replaces the 3-day rolling
+  notices marquee).
+- **Phase 3** — real POS integration (Square + Toast), OAuth + server-side
+  API calls.
+- **Phase 4** — two-way Google Calendar sync + inbound/outbound iCal.
+
+And, per that doc, the customer-facing ordering PWA remains its own
+separate brainstorm, not yet started.


### PR DESCRIPTION
## Summary

- Adds `docs/plans/future-features.md`, a lightweight running list for ideas that aren't scoped/scheduled yet.
- Records the Compose Multiplatform client-rewrite idea, with the main tradeoff (CMP's iOS/web-Wasm story is younger than the current Capacitor + Firebase JS SDK setup; none of the existing UI carries over).
- Points at Phases 2-4 of the existing `2026-05-21-feature-set-purr-design.md` (chat, POS, calendar), which remain fully unbuilt — Phase 1 is effectively done via the glee-audit rounds.

Docs-only change, no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Add a future-features tracking document outlining potential client rewrite and unbuilt roadmap phases.

Documentation:
- Introduce docs/plans/future-features.md as a lightweight list of unscheduled feature ideas and design directions.
- Document the Compose Multiplatform client rewrite concept and its high-level tradeoffs versus the current web-based stack.
- Reference the remaining unbuilt phases (chat, POS, calendar, ordering PWA) from the existing feature-set design as future work.