### PR TITLE
Phase 3: POS integration — Square (real) + Toast (real) + 8 stubs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -229,6 +229,38 @@ service cloud.firestore {
                        (isAuthed() && resource.data.claimantId == request.auth.uid);
         allow write: if false;
       }
+
+      // POS integration (Phase 3 — see
+      // docs/plans/2026-05-21-feature-set-purr-design.md). Connection
+      // *status* (connected/merchantId/lastSyncedAt/error — never a
+      // token) is Manager+-readable so POS Settings can show it;
+      // writes are Cloud-Function-only (posConnectToast, oauthCallback,
+      // posDisconnect, posSyncMenu). The actual encrypted tokens live
+      // in posSecrets, a separate collection with no client access at
+      // all — splitting them out means a client read of posConnection
+      // can never leak a credential, since Firestore rules can't do
+      // field-level read redaction within a single document.
+      match /posConnection/{provider} {
+        allow read: if isManagerPlus(barId);
+        allow write: if false;
+      }
+      match /posSecrets/{provider} {
+        allow read, write: if false;
+      }
+
+      // Menu synced from a connected POS (posSyncMenu). Any bar
+      // member can see the current menu; writes are Cloud-Function-only.
+      match /menu/{itemId} {
+        allow read: if hasRole(barId);
+        allow write: if false;
+      }
+    }
+
+    // Ephemeral OAuth state tokens for the POS connect flow (Square) —
+    // see posGetAuthorizeUrl/oauthCallback in functions/src/pos/oauth.ts.
+    // Cloud-Function-only; short-lived and deleted by oauthCallback.
+    match /posOAuthStates/{state} {
+      allow read, write: if false;
     }
 
     // Requests — top-level collection, scoped by barId field.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "barbacker-functions",
       "dependencies": {
+        "@google-cloud/kms": "^6.0.0",
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^6.0.0"
       },
@@ -160,6 +161,205 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/kms": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-6.0.0.tgz",
+      "integrity": "sha512-tDSTv9gdd0Kd0knCiSftIaCHFYEolj2P2ZKRayhZx5mR558fjnVQgwWDGIh+pBMOatCrLqb20XON3rGB5fm5Ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/gcp-metadata": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/google-auth-library": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/google-gax": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.0.2.tgz",
+      "integrity": "sha512-9O+aJyiZrGcEggeG9FoA1R3HRQEUi32ydPSvE42lFbh+D8KwQS57CgMsZ0JPpGCM1LFwEWe+yr2h/53xmgHnQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^11.0.0",
+        "google-logging-utils": "^2.0.0",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^4.0.0",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@google-cloud/kms/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/proto3-json-serializer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-4.0.2.tgz",
+      "integrity": "sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/retry-request": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+      "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/teeny-request": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+      "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -226,7 +426,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -240,7 +439,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -285,7 +483,6 @@
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -1026,7 +1223,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1036,7 +1232,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1046,7 +1241,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1118,15 +1312,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -1214,7 +1406,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -1229,7 +1420,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1241,8 +1431,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1317,6 +1506,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1384,7 +1582,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -1411,8 +1608,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1428,7 +1624,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1491,7 +1686,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1591,8 +1785,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -1678,6 +1871,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/finalhandler": {
@@ -1771,6 +1987,18 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1857,7 +2085,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2118,7 +2345,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -2132,7 +2358,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2149,8 +2374,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -2184,7 +2408,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2216,7 +2439,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -2579,8 +2801,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -2772,6 +2993,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2816,7 +3057,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2861,7 +3101,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3062,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3077,7 +3315,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3359,7 +3596,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -3368,15 +3604,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -3386,7 +3620,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3401,7 +3634,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3426,8 +3658,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",
@@ -3610,8 +3841,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3812,6 +4042,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3875,7 +4114,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3892,8 +4130,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",
@@ -3916,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -3932,7 +4168,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -3951,7 +4186,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,9 @@
   "name": "barbacker-functions",
   "private": true,
   "main": "lib/index.js",
-  "engines": { "node": "20" },
+  "engines": {
+    "node": "20"
+  },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
@@ -11,13 +13,14 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@google-cloud/kms": "^6.0.0",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
+    "@types/node": "^20.10.0",
     "typescript": "^5.4.0",
-    "vitest": "^4.0.16",
-    "@types/node": "^20.10.0"
+    "vitest": "^4.0.16"
   },
   "overrides": {
     "uuid": "^11.1.1"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,3 +9,6 @@ export { onInviteConsumed } from "./onInviteConsumed";
 export { fileOwnershipClaim, reviewOwnershipClaim } from "./ownershipClaims";
 export { migrateNoticesToChat } from "./migrateNoticesToChat";
 export { onChatPinned } from "./onChatPinned";
+export { posGetAuthorizeUrl, oauthCallback, posConnectToast, posDisconnect } from "./pos/oauth";
+export { posSyncMenu, posGetOrders, posGetSales } from "./pos/callables";
+export { rotatePOSTokens } from "./pos/rotateTokens";

--- a/functions/src/pos/authz.ts
+++ b/functions/src/pos/authz.ts
@@ -1,0 +1,11 @@
+import { HttpsError } from "firebase-functions/v2/https";
+
+export function requireManagerPlus(auth: { token: Record<string, unknown> } | undefined, barId: string) {
+  if (!auth) throw new HttpsError("unauthenticated", "Must be signed in.");
+  const barsClaims = (auth.token.bars as Record<string, string> | undefined) ?? {};
+  const isAdmin = auth.token.admin === true;
+  const role = barsClaims[barId];
+  if (!isAdmin && role !== "Manager" && role !== "Owner") {
+    throw new HttpsError("permission-denied", "Only a Manager or Owner of this bar can manage POS settings.");
+  }
+}

--- a/functions/src/pos/callables.ts
+++ b/functions/src/pos/callables.ts
@@ -1,0 +1,60 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { requireManagerPlus } from "./authz";
+import { getConnectedClient } from "./connection";
+import { POSProvider } from "./types";
+
+function parseArgs(data: unknown): { barId: string; provider: POSProvider } {
+  const { barId, provider } = (data ?? {}) as { barId?: string; provider?: string };
+  if (!barId || !provider) throw new HttpsError("invalid-argument", "barId and provider are required.");
+  return { barId, provider: provider as POSProvider };
+}
+
+// Menu sync as a smoke test — see "What Phase 3 ships" in the design
+// doc. Synced items land in bars/{barId}/menu/{itemId}, readable by
+// any bar member (Manager+ triggers the sync, everyone can see it).
+export const posSyncMenu = onCall(async (request) => {
+  const { barId, provider } = parseArgs(request.data);
+  requireManagerPlus(request.auth, barId);
+
+  const client = await getConnectedClient(barId, provider);
+  const items = await client.syncMenu();
+
+  const db = getFirestore();
+  const batches: Promise<FirebaseFirestore.WriteResult[]>[] = [];
+  for (let i = 0; i < items.length; i += 400) {
+    const batch = db.batch();
+    for (const item of items.slice(i, i + 400)) {
+      batch.set(db.doc(`bars/${barId}/menu/${item.id}`), { ...item, provider, syncedAt: FieldValue.serverTimestamp() });
+    }
+    batches.push(batch.commit());
+  }
+  await Promise.all(batches);
+
+  await db.doc(`bars/${barId}/posConnection/${provider}`).set(
+    { lastSyncedAt: FieldValue.serverTimestamp(), lastSyncedCount: items.length }, { merge: true },
+  );
+
+  return { count: items.length };
+});
+
+export const posGetOrders = onCall(async (request) => {
+  const { barId, provider } = parseArgs(request.data);
+  requireManagerPlus(request.auth, barId);
+  const { since } = (request.data ?? {}) as { since?: string };
+
+  const client = await getConnectedClient(barId, provider);
+  const orders = await client.getOrders(since ? { since: new Date(since) } : undefined);
+  return { orders };
+});
+
+export const posGetSales = onCall(async (request) => {
+  const { barId, provider } = parseArgs(request.data);
+  requireManagerPlus(request.auth, barId);
+  const { start, end } = (request.data ?? {}) as { start?: string; end?: string };
+  if (!start || !end) throw new HttpsError("invalid-argument", "start and end are required.");
+
+  const client = await getConnectedClient(barId, provider);
+  const summary = await client.getSales(new Date(start), new Date(end));
+  return summary;
+});

--- a/functions/src/pos/connection.ts
+++ b/functions/src/pos/connection.ts
@@ -1,0 +1,86 @@
+import { HttpsError } from "firebase-functions/v2/https";
+import { getFirestore, FieldValue, DocumentReference, DocumentData } from "firebase-admin/firestore";
+import { decryptSecret, encryptSecret } from "./kms";
+import { createPOSClient } from "./factory";
+import { POSClient, POSProvider } from "./types";
+
+const JUST_IN_TIME_MARGIN_MS = 5 * 60 * 1000;
+
+// Refreshes (Square) or reissues (Toast) the stored access token if
+// it's within `marginMs` of expiry, persisting the new token back to
+// `secretRef`. Returns the (possibly refreshed) plaintext access
+// token. Shared by getConnectedClient's just-in-time refresh and
+// rotateTokens.ts's proactive hourly sweep — they just call this with
+// different margins.
+async function refreshIfNeeded(
+  secretRef: DocumentReference<DocumentData>,
+  secret: DocumentData,
+  provider: POSProvider,
+  currentAccessToken: string,
+  marginMs: number,
+): Promise<string> {
+  const expiresAt = secret.expiresAt as number | null;
+  if (expiresAt == null || expiresAt - Date.now() >= marginMs) return currentAccessToken;
+
+  if (provider === "toast") {
+    // Toast reissues rather than refreshes — see toast.ts.
+    const clientId = secret.clientId as string;
+    const clientSecret = await decryptSecret(secret.clientSecret);
+    const restaurantGuid = secret.restaurantGuid as string;
+    const client = createPOSClient(provider);
+    const result = await client.connect({ clientId, clientSecret, restaurantGuid });
+    if (!result.connected) throw new HttpsError("failed-precondition", result.error ?? "Failed to reconnect to Toast.");
+    await secretRef.set({
+      accessToken: await encryptSecret(result.accessToken!),
+      expiresAt: result.expiresAt ?? null,
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return result.accessToken!;
+  }
+
+  if (!secret.refreshToken) return currentAccessToken;
+  const refreshToken = await decryptSecret(secret.refreshToken);
+  const client = createPOSClient(provider);
+  if (!client.refreshAccessToken) throw new HttpsError("internal", `${provider} does not support token refresh.`);
+  const refreshed = await client.refreshAccessToken(refreshToken);
+  await secretRef.set({
+    accessToken: await encryptSecret(refreshed.accessToken),
+    refreshToken: await encryptSecret(refreshed.refreshToken),
+    expiresAt: refreshed.expiresAt,
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true });
+  return refreshed.accessToken;
+}
+
+// Loads a bar's stored, decrypted POS connection and returns a
+// ready-to-use client, transparently refreshing the access token
+// first if it's within 5 minutes of expiry — the just-in-time
+// backstop for a call that lands in the gap between rotateTokens.ts's
+// hourly proactive sweep (24h margin).
+export async function getConnectedClient(barId: string, provider: POSProvider): Promise<POSClient> {
+  const db = getFirestore();
+  const secretRef = db.doc(`bars/${barId}/posSecrets/${provider}`);
+  const secretDoc = await secretRef.get();
+  if (!secretDoc.exists) throw new HttpsError("failed-precondition", `${provider} is not connected for this bar.`);
+  const secret = secretDoc.data()!;
+
+  const accessToken = await refreshIfNeeded(
+    secretRef, secret, provider, await decryptSecret(secret.accessToken), JUST_IN_TIME_MARGIN_MS,
+  );
+  return createPOSClient(provider, accessToken);
+}
+
+// Proactive rotation, called by rotateTokens.ts's hourly schedule —
+// same refresh logic, just with a much wider (24h) margin so tokens
+// get rotated well before they'd ever force a just-in-time refresh
+// mid-request.
+export async function rotateIfNeeded(
+  barId: string, provider: POSProvider, marginMs: number,
+): Promise<void> {
+  const db = getFirestore();
+  const secretRef = db.doc(`bars/${barId}/posSecrets/${provider}`);
+  const secretDoc = await secretRef.get();
+  if (!secretDoc.exists) return;
+  const secret = secretDoc.data()!;
+  await refreshIfNeeded(secretRef, secret, provider, await decryptSecret(secret.accessToken), marginMs);
+}

--- a/functions/src/pos/factory.ts
+++ b/functions/src/pos/factory.ts
@@ -1,0 +1,12 @@
+import { POSClient, POSProvider } from "./types";
+import { SquarePOSClient } from "./square";
+import { ToastPOSClient } from "./toast";
+import { STUB_POS_CLIENTS } from "./stubs";
+
+export function createPOSClient(provider: POSProvider, accessToken?: string): POSClient {
+  switch (provider) {
+    case "square": return new SquarePOSClient(accessToken);
+    case "toast": return new ToastPOSClient(accessToken);
+    default: return new STUB_POS_CLIENTS[provider](accessToken);
+  }
+}

--- a/functions/src/pos/kms.ts
+++ b/functions/src/pos/kms.ts
@@ -1,0 +1,30 @@
+import { KeyManagementServiceClient } from "@google-cloud/kms";
+
+// KMS-backed encryption for POS OAuth tokens at rest — see the "OAuth
+// flow" section of docs/plans/2026-05-21-feature-set-purr-design.md.
+// Requires a real KMS key ring/key provisioned in the deploying GCP
+// project, with the Cloud Functions service account granted
+// roles/cloudkms.cryptoKeyEncrypterDecrypter on it, and
+// POS_KMS_KEY_NAME set to that key's full resource name
+// (projects/*/locations/*/keyRings/*/cryptoKeys/*). None of that
+// exists in this sandbox — encrypt/decrypt can't be exercised until
+// the user provisions the key post-merge.
+const kmsClient = new KeyManagementServiceClient();
+
+function keyName(): string {
+  const name = process.env.POS_KMS_KEY_NAME;
+  if (!name) throw new Error("POS_KMS_KEY_NAME is not configured.");
+  return name;
+}
+
+export async function encryptSecret(plaintext: string): Promise<string> {
+  const [result] = await kmsClient.encrypt({ name: keyName(), plaintext: Buffer.from(plaintext, "utf8") });
+  if (!result.ciphertext) throw new Error("KMS encrypt returned no ciphertext.");
+  return Buffer.from(result.ciphertext as Uint8Array).toString("base64");
+}
+
+export async function decryptSecret(ciphertextB64: string): Promise<string> {
+  const [result] = await kmsClient.decrypt({ name: keyName(), ciphertext: Buffer.from(ciphertextB64, "base64") });
+  if (!result.plaintext) throw new Error("KMS decrypt returned no plaintext.");
+  return Buffer.from(result.plaintext as Uint8Array).toString("utf8");
+}

--- a/functions/src/pos/oauth.ts
+++ b/functions/src/pos/oauth.ts
@@ -1,0 +1,141 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { onRequest } from "firebase-functions/v2/https";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { randomBytes } from "node:crypto";
+import { SquarePOSClient } from "./square";
+import { ToastPOSClient } from "./toast";
+import { encryptSecret } from "./kms";
+import { requireManagerPlus } from "./authz";
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+// Step 1 of the Square connect flow (see the design doc's "OAuth
+// flow" section) — Manager+ requests a redirect URL, we mint a
+// short-lived opaque state token tying that request back to this bar,
+// and the client sends the browser there. oauthCallback (below) is
+// step 3; Square's consent screen is step 2, entirely outside our
+// control. Square is the only provider using this redirect flow —
+// Toast connects via posConnectToast (client-credentials, no
+// user-facing consent screen — see toast.ts's caveat comment).
+export const posGetAuthorizeUrl = onCall(async (request) => {
+  const { barId } = (request.data ?? {}) as { barId?: string };
+  if (!barId) throw new HttpsError("invalid-argument", "barId is required.");
+  requireManagerPlus(request.auth, barId);
+
+  const clientId = process.env.SQUARE_CLIENT_ID;
+  const callbackBase = process.env.POS_OAUTH_CALLBACK_BASE_URL;
+  if (!clientId || !callbackBase) {
+    throw new HttpsError("failed-precondition", "Square OAuth is not configured on the server.");
+  }
+
+  const state = randomBytes(24).toString("hex");
+  await getFirestore().doc(`posOAuthStates/${state}`).set({
+    barId, provider: "square", createdAt: FieldValue.serverTimestamp(),
+  });
+
+  const scope = ["ITEMS_READ", "ORDERS_READ", "MERCHANT_PROFILE_READ"].join("+");
+  const redirectUri = encodeURIComponent(`${callbackBase}/oauthCallback`);
+  const authorizeUrl =
+    `https://connect.squareup.com/oauth2/authorize?client_id=${clientId}` +
+    `&scope=${scope}&session=false&state=${state}&redirect_uri=${redirectUri}`;
+
+  return { authorizeUrl };
+});
+
+// Step 3 — Square redirects the manager's browser here with ?code&state
+// after they approve the consent screen. Plain onRequest (not onCall)
+// because this is a browser navigation, not an authenticated API call
+// from our own client.
+export const oauthCallback = onRequest(async (req, res) => {
+  const provider = "square"; // only Square uses the redirect flow currently.
+  const code = req.query.code as string | undefined;
+  const state = req.query.state as string | undefined;
+  if (!code || !state) {
+    res.status(400).send("Missing code or state.");
+    return;
+  }
+
+  const db = getFirestore();
+  const stateRef = db.doc(`posOAuthStates/${state}`);
+  const stateDoc = await stateRef.get();
+  if (!stateDoc.exists) {
+    res.status(400).send("Invalid or expired connection request. Please try connecting again.");
+    return;
+  }
+  const { barId, createdAt } = stateDoc.data() as { barId: string; provider: string; createdAt: FirebaseFirestore.Timestamp };
+  await stateRef.delete();
+  if (Date.now() - createdAt.toMillis() > STATE_TTL_MS) {
+    res.status(400).send("This connection request expired. Please try connecting again.");
+    return;
+  }
+
+  const client = new SquarePOSClient();
+  const result = await client.connect({ code });
+  if (!result.connected) {
+    res.status(400).send(`Failed to connect: ${result.error ?? "unknown error"}`);
+    return;
+  }
+
+  const encryptedAccessToken = await encryptSecret(result.accessToken!);
+  const encryptedRefreshToken = result.refreshToken ? await encryptSecret(result.refreshToken) : null;
+
+  await db.doc(`bars/${barId}/posSecrets/${provider}`).set({
+    accessToken: encryptedAccessToken,
+    refreshToken: encryptedRefreshToken,
+    expiresAt: result.expiresAt ?? null,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  await db.doc(`bars/${barId}/posConnection/${provider}`).set({
+    provider, connected: true, merchantId: result.merchantId,
+    connectedAt: FieldValue.serverTimestamp(), error: null,
+  });
+
+  res.status(200).send("<html><body>Square connected. You can close this tab and return to BarBacker.</body></html>");
+});
+
+// Toast has no user-facing consent screen (see toast.ts) — the
+// manager enters partner-issued credentials directly.
+export const posConnectToast = onCall(async (request) => {
+  const { barId, clientId, clientSecret, restaurantGuid } =
+    (request.data ?? {}) as { barId?: string; clientId?: string; clientSecret?: string; restaurantGuid?: string };
+  if (!barId || !clientId || !clientSecret || !restaurantGuid) {
+    throw new HttpsError("invalid-argument", "barId, clientId, clientSecret, and restaurantGuid are all required.");
+  }
+  requireManagerPlus(request.auth, barId);
+
+  const client = new ToastPOSClient();
+  const result = await client.connect({ clientId, clientSecret, restaurantGuid });
+  const db = getFirestore();
+  if (!result.connected) {
+    await db.doc(`bars/${barId}/posConnection/toast`).set({
+      provider: "toast", connected: false, merchantId: "", error: result.error ?? "Failed to connect.",
+    });
+    throw new HttpsError("failed-precondition", result.error ?? "Failed to connect to Toast.");
+  }
+
+  await db.doc(`bars/${barId}/posSecrets/toast`).set({
+    clientId, clientSecret: await encryptSecret(clientSecret), restaurantGuid,
+    accessToken: await encryptSecret(result.accessToken!),
+    expiresAt: result.expiresAt ?? null,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  await db.doc(`bars/${barId}/posConnection/toast`).set({
+    provider: "toast", connected: true, merchantId: result.merchantId,
+    connectedAt: FieldValue.serverTimestamp(), error: null,
+  });
+
+  return { connected: true };
+});
+
+export const posDisconnect = onCall(async (request) => {
+  const { barId, provider } = (request.data ?? {}) as { barId?: string; provider?: string };
+  if (!barId || !provider) throw new HttpsError("invalid-argument", "barId and provider are required.");
+  requireManagerPlus(request.auth, barId);
+
+  const db = getFirestore();
+  await db.doc(`bars/${barId}/posSecrets/${provider}`).delete();
+  await db.doc(`bars/${barId}/posConnection/${provider}`).set({
+    provider, connected: false, merchantId: "", error: null, disconnectedAt: FieldValue.serverTimestamp(),
+  });
+  return { disconnected: true };
+});

--- a/functions/src/pos/rotateTokens.ts
+++ b/functions/src/pos/rotateTokens.ts
@@ -1,0 +1,28 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { getFirestore } from "firebase-admin/firestore";
+import { rotateIfNeeded } from "./connection";
+import { POSProvider } from "./types";
+
+const PROACTIVE_MARGIN_MS = 24 * 60 * 60 * 1000;
+
+// Hourly proactive rotation for anything within 24h of expiry — see
+// the "OAuth flow" section of
+// docs/plans/2026-05-21-feature-set-purr-design.md. Requires a
+// Firestore composite/collection-group index on posSecrets (none
+// needed here beyond the default collection-group scan since there's
+// no additional filter/order).
+export const rotatePOSTokens = onSchedule("every 60 minutes", async () => {
+  const db = getFirestore();
+  const secretsSnap = await db.collectionGroup("posSecrets").get();
+
+  for (const doc of secretsSnap.docs) {
+    const barId = doc.ref.parent.parent?.id;
+    const provider = doc.id as POSProvider;
+    if (!barId) continue;
+    try {
+      await rotateIfNeeded(barId, provider, PROACTIVE_MARGIN_MS);
+    } catch (e) {
+      console.error(`Failed to rotate POS token for bar ${barId} provider ${provider}`, e);
+    }
+  }
+});

--- a/functions/src/pos/square.ts
+++ b/functions/src/pos/square.ts
@@ -1,0 +1,140 @@
+import { BasePOSClient, MenuItem, Order, POSConnectResult, POSCredentials, POSTokenRefreshResult, SalesSummary } from "./types";
+
+const SQUARE_API_BASE = "https://connect.squareup.com";
+const SQUARE_VERSION = "2024-10-17";
+
+function centsFromMoney(money: { amount?: string | number } | undefined): number {
+  if (!money?.amount) return 0;
+  return typeof money.amount === "string" ? parseInt(money.amount, 10) : money.amount;
+}
+
+// Square's OAuth + REST API — well-documented public API, high
+// confidence on these endpoint shapes. See
+// https://developer.squareup.com/docs/oauth-api/overview and
+// https://developer.squareup.com/reference/square for the source of
+// truth; this should be sanity-checked against current docs before
+// relying on it in production, since API versions do shift.
+export class SquarePOSClient extends BasePOSClient {
+  async connect(creds: POSCredentials): Promise<POSConnectResult> {
+    if (!creds.code) return { connected: false, merchantId: "", error: "Missing authorization code." };
+    const clientId = process.env.SQUARE_CLIENT_ID;
+    const clientSecret = process.env.SQUARE_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+      return { connected: false, merchantId: "", error: "Square OAuth is not configured (SQUARE_CLIENT_ID/SECRET)." };
+    }
+    const res = await fetch(`${SQUARE_API_BASE}/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Square-Version": SQUARE_VERSION },
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code: creds.code, grant_type: "authorization_code" }),
+    });
+    const data = await res.json() as any;
+    if (!res.ok) return { connected: false, merchantId: "", error: data?.message ?? `Square token exchange failed (${res.status}).` };
+    this.accessToken = data.access_token;
+    return {
+      connected: true,
+      merchantId: data.merchant_id,
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: data.expires_at ? new Date(data.expires_at).getTime() : undefined,
+    };
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<POSTokenRefreshResult> {
+    const clientId = process.env.SQUARE_CLIENT_ID;
+    const clientSecret = process.env.SQUARE_CLIENT_SECRET;
+    if (!clientId || !clientSecret) throw new Error("Square OAuth is not configured.");
+    const res = await fetch(`${SQUARE_API_BASE}/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Square-Version": SQUARE_VERSION },
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, refresh_token: refreshToken, grant_type: "refresh_token" }),
+    });
+    const data = await res.json() as any;
+    if (!res.ok) throw new Error(data?.message ?? `Square token refresh failed (${res.status}).`);
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: data.expires_at ? new Date(data.expires_at).getTime() : Date.now() + 24 * 60 * 60 * 1000,
+    };
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.accessToken) return;
+    const clientId = process.env.SQUARE_CLIENT_ID;
+    const clientSecret = process.env.SQUARE_CLIENT_SECRET;
+    await fetch(`${SQUARE_API_BASE}/oauth2/revoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Square-Version": SQUARE_VERSION,
+        "Authorization": `Client ${clientSecret}`,
+      },
+      body: JSON.stringify({ client_id: clientId, access_token: this.accessToken }),
+    }).catch((e) => console.error("Square token revoke failed", e));
+  }
+
+  private authHeaders(): Record<string, string> {
+    if (!this.accessToken) throw new Error("Not connected.");
+    return {
+      "Authorization": `Bearer ${this.accessToken}`,
+      "Square-Version": SQUARE_VERSION,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async syncMenu(): Promise<MenuItem[]> {
+    const res = await fetch(`${SQUARE_API_BASE}/v2/catalog/list?types=ITEM`, { headers: this.authHeaders() });
+    const data = await res.json() as any;
+    if (!res.ok) throw new Error(data?.errors?.[0]?.detail ?? `Square catalog list failed (${res.status}).`);
+    const objects: any[] = data.objects ?? [];
+    const items: MenuItem[] = [];
+    for (const obj of objects) {
+      const itemData = obj.item_data;
+      if (!itemData) continue;
+      for (const variation of itemData.variations ?? []) {
+        items.push({
+          id: variation.id,
+          name: itemData.name + (itemData.variations.length > 1 ? ` (${variation.item_variation_data?.name ?? ""})` : ""),
+          price: centsFromMoney(variation.item_variation_data?.price_money),
+          category: itemData.category_id,
+        });
+      }
+    }
+    return items;
+  }
+
+  async getOrders(opts?: { since?: Date }): Promise<Order[]> {
+    const res = await fetch(`${SQUARE_API_BASE}/v2/orders/search`, {
+      method: "POST",
+      headers: this.authHeaders(),
+      body: JSON.stringify({
+        query: opts?.since ? { filter: { date_time_filter: { created_at: { start_at: opts.since.toISOString() } } } } : undefined,
+      }),
+    });
+    const data = await res.json() as any;
+    if (!res.ok) throw new Error(data?.errors?.[0]?.detail ?? `Square order search failed (${res.status}).`);
+    return (data.orders ?? []).map((o: any) => ({
+      id: o.id,
+      createdAt: o.created_at,
+      total: centsFromMoney(o.total_money),
+      items: (o.line_items ?? []).map((li: any) => ({
+        name: li.name,
+        quantity: parseInt(li.quantity, 10) || 1,
+        price: centsFromMoney(li.total_money),
+      })),
+    }));
+  }
+
+  async getSales(start: Date, end: Date): Promise<SalesSummary> {
+    const orders = await this.getOrders({ since: start });
+    const inRange = orders.filter((o) => {
+      const t = new Date(o.createdAt).getTime();
+      return t >= start.getTime() && t <= end.getTime();
+    });
+    return {
+      grossCents: inRange.reduce((sum, o) => sum + o.total, 0),
+      orderCount: inRange.length,
+      start: start.toISOString(),
+      end: end.toISOString(),
+    };
+  }
+}

--- a/functions/src/pos/stubs.ts
+++ b/functions/src/pos/stubs.ts
@@ -1,0 +1,26 @@
+import { NotImplementedPOSClient, POSProvider } from "./types";
+
+// Scaffolding for the eight providers not yet implemented — kept as
+// real classes (rather than deleted) so a future implementation only
+// has to fill in the body and flip POS_PROVIDER_STATUS, per the
+// "Adapter inventory" section of
+// docs/plans/2026-05-21-feature-set-purr-design.md.
+export class CloverPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("clover", accessToken); } }
+export class LightspeedPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("lightspeed", accessToken); } }
+export class SpotOnPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("spoton", accessToken); } }
+export class TouchBistroPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("touchbistro", accessToken); } }
+export class RevelPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("revel", accessToken); } }
+export class LavuPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("lavu", accessToken); } }
+export class TalechPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("talech", accessToken); } }
+export class AlohaPOSClient extends NotImplementedPOSClient { constructor(accessToken?: string) { super("aloha", accessToken); } }
+
+export const STUB_POS_CLIENTS: Record<Exclude<POSProvider, "square" | "toast">, new (accessToken?: string) => NotImplementedPOSClient> = {
+  clover: CloverPOSClient,
+  lightspeed: LightspeedPOSClient,
+  spoton: SpotOnPOSClient,
+  touchbistro: TouchBistroPOSClient,
+  revel: RevelPOSClient,
+  lavu: LavuPOSClient,
+  talech: TalechPOSClient,
+  aloha: AlohaPOSClient,
+};

--- a/functions/src/pos/toast.ts
+++ b/functions/src/pos/toast.ts
@@ -1,0 +1,125 @@
+import { BasePOSClient, MenuItem, Order, POSConnectResult, POSCredentials, POSTokenRefreshResult, SalesSummary } from "./types";
+
+const TOAST_API_BASE = "https://ws-api.toasttab.com";
+
+// LOWER CONFIDENCE THAN square.ts — READ BEFORE RELYING ON THIS.
+//
+// Toast's real integration model does not match the uniform "OAuth
+// consent redirect" flow the rest of Phase 3 assumes (see the design
+// doc's "OAuth flow" section): Toast issues partner API credentials
+// (client id/secret + a per-restaurant GUID) after a manual partner
+// approval process, and authentication is client-credentials, not a
+// user-facing authorization-code redirect. There is no
+// "https://.../oauth2/authorize?..." URL for a restaurant manager to
+// click through the way there is for Square.
+//
+// connect() here therefore takes clientId/clientSecret/restaurantGuid
+// (via POSCredentials) rather than an authorization `code`, and the
+// POS Settings UI's "Connect" flow for Toast should collect those
+// fields directly instead of doing an OAuth redirect. Endpoint paths
+// below (/authentication/v1/authentication/login, /orders/v2/orders,
+// /menus/v2/menus) reflect Toast's publicly documented partner API
+// shape as of this writing, but Toast's API is partner-gated and
+// versioned — verify against the actual current docs (available only
+// after partner approval) before deploying, and expect to adjust
+// field names/paths.
+export class ToastPOSClient extends BasePOSClient {
+  private restaurantGuid?: string;
+
+  async connect(creds: POSCredentials): Promise<POSConnectResult> {
+    if (!creds.clientId || !creds.clientSecret || !creds.restaurantGuid) {
+      return { connected: false, merchantId: "", error: "Missing clientId/clientSecret/restaurantGuid." };
+    }
+    this.restaurantGuid = creds.restaurantGuid;
+    const res = await fetch(`${TOAST_API_BASE}/authentication/v1/authentication/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientId: creds.clientId, clientSecret: creds.clientSecret, userAccessType: "TOAST_MACHINE_CLIENT" }),
+    });
+    const data = await res.json() as any;
+    if (!res.ok) return { connected: false, merchantId: "", error: data?.message ?? `Toast auth failed (${res.status}).` };
+    this.accessToken = data.token?.accessToken;
+    const expiresIn = data.token?.expiresIn ?? 3600;
+    return {
+      connected: true,
+      merchantId: creds.restaurantGuid,
+      accessToken: this.accessToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+    };
+  }
+
+  // Toast's client-credentials tokens are reissued via connect(), not
+  // refreshed via a refresh_token grant — rotateTokens.ts calls
+  // connect() again with the stored client credentials rather than
+  // this method for Toast. Present for POSClient interface
+  // conformance only.
+  async refreshAccessToken(): Promise<POSTokenRefreshResult> {
+    throw new Error("Toast tokens are reissued via connect(), not refreshed — see comment above.");
+  }
+
+  async disconnect(): Promise<void> {
+    this.accessToken = undefined;
+    this.restaurantGuid = undefined;
+  }
+
+  private authHeaders(): Record<string, string> {
+    if (!this.accessToken || !this.restaurantGuid) throw new Error("Not connected.");
+    return {
+      "Authorization": `Bearer ${this.accessToken}`,
+      "Toast-Restaurant-External-ID": this.restaurantGuid,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async syncMenu(): Promise<MenuItem[]> {
+    const res = await fetch(`${TOAST_API_BASE}/menus/v2/menus`, { headers: this.authHeaders() });
+    const data = await res.json() as any;
+    if (!res.ok) throw new Error(data?.message ?? `Toast menu fetch failed (${res.status}).`);
+    const items: MenuItem[] = [];
+    for (const menu of Array.isArray(data) ? data : []) {
+      for (const group of menu.menuGroups ?? []) {
+        for (const item of group.menuItems ?? []) {
+          items.push({
+            id: item.guid,
+            name: item.name,
+            price: Math.round((item.price ?? 0) * 100),
+            category: group.name,
+          });
+        }
+      }
+    }
+    return items;
+  }
+
+  async getOrders(opts?: { since?: Date }): Promise<Order[]> {
+    const params = new URLSearchParams();
+    if (opts?.since) params.set("startDate", opts.since.toISOString());
+    const res = await fetch(`${TOAST_API_BASE}/orders/v2/orders?${params.toString()}`, { headers: this.authHeaders() });
+    const data = await res.json() as any;
+    if (!res.ok) throw new Error(data?.message ?? `Toast orders fetch failed (${res.status}).`);
+    return (Array.isArray(data) ? data : []).map((o: any) => ({
+      id: o.guid,
+      createdAt: o.openedDate,
+      total: Math.round((o.totalAmount ?? 0) * 100),
+      items: (o.checks ?? []).flatMap((c: any) => (c.selections ?? []).map((s: any) => ({
+        name: s.displayName,
+        quantity: s.quantity ?? 1,
+        price: Math.round((s.price ?? 0) * 100),
+      }))),
+    }));
+  }
+
+  async getSales(start: Date, end: Date): Promise<SalesSummary> {
+    const orders = await this.getOrders({ since: start });
+    const inRange = orders.filter((o) => {
+      const t = new Date(o.createdAt).getTime();
+      return t >= start.getTime() && t <= end.getTime();
+    });
+    return {
+      grossCents: inRange.reduce((sum, o) => sum + o.total, 0),
+      orderCount: inRange.length,
+      start: start.toISOString(),
+      end: end.toISOString(),
+    };
+  }
+}

--- a/functions/src/pos/types.ts
+++ b/functions/src/pos/types.ts
@@ -1,0 +1,113 @@
+// POS integration types — Phase 3 of
+// docs/plans/2026-05-21-feature-set-purr-design.md. All POS API calls
+// happen server-side (Cloud Functions only); the browser never sees
+// provider tokens. See callables.ts for the client-facing surface.
+
+export type POSProvider =
+  | "square" | "toast"
+  | "clover" | "lightspeed" | "spoton" | "touchbistro"
+  | "revel" | "lavu" | "talech" | "aloha";
+
+// Square and Toast are the only real implementations; the rest are
+// scaffolding files conforming to this interface, kept for future
+// implementations rather than deleted (see the "Adapter inventory"
+// section of the design doc). Their status here is what the client's
+// provider picker enables/disables — see src/constants.ts's
+// POS_PROVIDER_STATUS, which must be kept in sync with this list.
+export const AVAILABLE_POS_PROVIDERS: POSProvider[] = ["square", "toast"];
+
+export interface MenuItem {
+  id: string;
+  name: string;
+  price: number; // integer cents
+  category?: string;
+  modifiers?: { name: string; price: number }[];
+}
+
+export interface OrderLineItem {
+  name: string;
+  quantity: number;
+  price: number; // integer cents
+}
+
+export interface Order {
+  id: string;
+  createdAt: string; // ISO 8601
+  total: number; // integer cents
+  items: OrderLineItem[];
+}
+
+export interface SalesSummary {
+  grossCents: number;
+  orderCount: number;
+  start: string; // ISO 8601
+  end: string; // ISO 8601
+}
+
+// Credentials handed to connect(). Shape varies by provider's auth
+// model — Square uses an OAuth authorization code; Toast's real API
+// uses client-credentials (see toast.ts's caveat comment) rather than
+// a user-facing consent redirect, so `code` is Square-specific and
+// `clientSecret`/`restaurantGuid` are Toast-specific. A given
+// adapter only reads the fields its own connect() understands.
+export interface POSCredentials {
+  code?: string;
+  clientId?: string;
+  clientSecret?: string;
+  restaurantGuid?: string;
+}
+
+export interface POSConnectResult {
+  connected: boolean;
+  merchantId: string;
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number; // epoch millis
+  error?: string;
+}
+
+export interface POSTokenRefreshResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number; // epoch millis
+}
+
+export interface POSClient {
+  connect(creds: POSCredentials): Promise<POSConnectResult>;
+  disconnect(): Promise<void>;
+  syncMenu(): Promise<MenuItem[]>;
+  getOrders(opts?: { since?: Date }): Promise<Order[]>;
+  getSales(start: Date, end: Date): Promise<SalesSummary>;
+  // Only implemented by providers whose tokens expire (Square, Toast
+  // client-credentials). Absent on providers with non-expiring or
+  // not-yet-implemented auth.
+  refreshAccessToken?(refreshToken: string): Promise<POSTokenRefreshResult>;
+}
+
+export abstract class BasePOSClient implements POSClient {
+  protected accessToken?: string;
+  constructor(accessToken?: string) {
+    this.accessToken = accessToken;
+  }
+  abstract connect(creds: POSCredentials): Promise<POSConnectResult>;
+  abstract disconnect(): Promise<void>;
+  abstract syncMenu(): Promise<MenuItem[]>;
+  abstract getOrders(opts?: { since?: Date }): Promise<Order[]>;
+  abstract getSales(start: Date, end: Date): Promise<SalesSummary>;
+}
+
+export class NotImplementedPOSClient extends BasePOSClient {
+  constructor(private readonly provider: POSProvider, accessToken?: string) {
+    super(accessToken);
+  }
+  private unsupported(): never {
+    throw new Error(`${this.provider} is not yet implemented — see POS_PROVIDER_STATUS.`);
+  }
+  async connect(): Promise<POSConnectResult> {
+    return { connected: false, merchantId: "", error: `${this.provider} is not yet implemented.` };
+  }
+  async disconnect(): Promise<void> { this.unsupported(); }
+  async syncMenu(): Promise<MenuItem[]> { this.unsupported(); }
+  async getOrders(): Promise<Order[]> { this.unsupported(); }
+  async getSales(): Promise<SalesSummary> { this.unsupported(); }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import { useInactivityAutoSubmit } from './hooks/useInactivityAutoSubmit';
 import { useAuth } from './hooks/useAuth';
 import { usePushNotifications } from './hooks/usePushNotifications';
 import { useChat } from './hooks/useChat';
+import { usePOS } from './hooks/usePOS';
 import { useDragAndDrop } from './hooks/useDragAndDrop';
 import { useRequestActions } from './hooks/useRequestActions';
 
@@ -84,6 +85,7 @@ import ThemeEditor from './components/ThemeEditor';
 import InputDialog from './components/InputDialog';
 import { WhoIsOnDialog } from './components/WhoIsOnDialog';
 import { ChatPanel } from './components/ChatPanel';
+import { POSSettings } from './components/POSSettings';
 import { SortableButton } from './components/SortableButton';
 import { MdDialog } from './components/MdDialog';
 // Import dnd-kit for drag-and-drop functionality.
@@ -390,6 +392,7 @@ function App() {
   const [eightySixEntries, setEightySixEntries] = useState<EightySixEntry[]>([]);
   const [showEightySixDialog, setShowEightySixDialog] = useState(false);
   const [showThemeEditor, setShowThemeEditor] = useState(false);
+  const [showPOSSettings, setShowPOSSettings] = useState(false);
 
   // Joined bars + their display names + the account-level ntfy topic
   // — all driven by the global users/{uid} document.
@@ -744,6 +747,13 @@ function App() {
     togglePin: toggleChatPin,
     deleteMessage: deleteChatMessage,
   } = useChat({ user, barId, displayName, userRole, panelOpen: showChatPanel });
+
+  // POS integration (Phase 3). See docs/plans/2026-05-21-feature-set-purr-design.md.
+  const {
+    connections: posConnections, menu: posMenu,
+    connectSquare: posConnectSquare, connectToast: posConnectToast,
+    disconnect: posDisconnect, syncMenu: posSyncMenu, getSales: posGetSales,
+  } = usePOS({ barId, isManagerPlus });
 
   // Determine children for dynamic buttons (ICE, BEER, etc.).
   const getDynamicChildren = (btn: ButtonConfig): ButtonConfig[] => {
@@ -1445,6 +1455,18 @@ function App() {
         onDelete={deleteChatMessage}
       />
 
+      <POSSettings
+        open={showPOSSettings}
+        onClose={() => setShowPOSSettings(false)}
+        connections={posConnections}
+        menu={posMenu}
+        onConnectSquare={posConnectSquare}
+        onConnectToast={posConnectToast}
+        onDisconnect={posDisconnect}
+        onSyncMenu={posSyncMenu}
+        onGetSales={posGetSales}
+      />
+
       <InputDialog
         open={inputDialog.open}
         mode={inputDialog.type}
@@ -1601,6 +1623,12 @@ function App() {
                           <md-menu-item onClick={() => setShowThemeEditor(true)}>
                               <md-icon slot="start">palette</md-icon>
                               <div slot="headline">Customize Theme</div>
+                          </md-menu-item>
+                        )}
+                        {isPremium && isManagerPlus && (
+                          <md-menu-item onClick={() => setShowPOSSettings(true)}>
+                              <md-icon slot="start">point_of_sale</md-icon>
+                              <div slot="headline">POS Integration</div>
                           </md-menu-item>
                         )}
                         <md-menu-item onClick={handleShare}>

--- a/src/components/POSSettings.test.tsx
+++ b/src/components/POSSettings.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POSSettings } from './POSSettings';
+import { POSConnectionStatus, POSMenuItem } from '../types';
+
+const mockOnClose = vi.fn();
+const mockOnConnectSquare = vi.fn(() => Promise.resolve());
+const mockOnConnectToast = vi.fn(() => Promise.resolve());
+const mockOnDisconnect = vi.fn(() => Promise.resolve());
+const mockOnSyncMenu = vi.fn(() => Promise.resolve({ data: { count: 3 } }));
+const mockOnGetSales = vi.fn(() => Promise.resolve({ grossCents: 12345, orderCount: 7 }));
+
+function renderSettings(connections: Record<string, POSConnectionStatus> = {}, menu: POSMenuItem[] = []) {
+  return render(
+    <POSSettings
+      open={true}
+      onClose={mockOnClose}
+      connections={connections}
+      menu={menu}
+      onConnectSquare={mockOnConnectSquare}
+      onConnectToast={mockOnConnectToast}
+      onDisconnect={mockOnDisconnect}
+      onSyncMenu={mockOnSyncMenu}
+      onGetSales={mockOnGetSales}
+    />
+  );
+}
+
+describe('POSSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders available providers as actionable and the rest as coming soon', () => {
+    renderSettings();
+    expect(screen.getByText('Square')).toBeInTheDocument();
+    expect(screen.getByText('Toast')).toBeInTheDocument();
+    expect(screen.getByText('Connect Square')).toBeInTheDocument();
+    expect(screen.getAllByText(/coming soon/i).length).toBe(8);
+  });
+
+  it('calls onConnectSquare when Connect Square is clicked', async () => {
+    renderSettings();
+    fireEvent.click(screen.getByText('Connect Square'));
+    await waitFor(() => expect(mockOnConnectSquare).toHaveBeenCalled());
+  });
+
+  it('shows the Toast credential form and only enables Connect once all fields are filled', async () => {
+    const { container } = renderSettings();
+    await waitFor(() => expect(screen.getByText('Connect Toast')).toHaveAttribute('disabled'));
+
+    const fields = Array.from(container.querySelectorAll('md-filled-text-field')) as any[];
+    const clientIdField = fields.find((f) => f.label === 'Client ID');
+    const clientSecretField = fields.find((f) => f.label === 'Client Secret');
+    const guidField = fields.find((f) => f.label === 'Restaurant GUID');
+
+    clientIdField.value = 'id-1'; fireEvent.input(clientIdField);
+    clientSecretField.value = 'secret-1'; fireEvent.input(clientSecretField);
+    guidField.value = 'guid-1'; fireEvent.input(guidField);
+
+    await waitFor(() => expect(screen.getByText('Connect Toast')).not.toHaveAttribute('disabled'));
+  });
+
+  it('submits the Toast form values on connect', async () => {
+    const { container } = renderSettings();
+    const fields = Array.from(container.querySelectorAll('md-filled-text-field')) as any[];
+    fields.find((f) => f.label === 'Client ID')!.value = 'id-1';
+    fireEvent.input(fields.find((f) => f.label === 'Client ID')!);
+    fields.find((f) => f.label === 'Client Secret')!.value = 'secret-1';
+    fireEvent.input(fields.find((f) => f.label === 'Client Secret')!);
+    fields.find((f) => f.label === 'Restaurant GUID')!.value = 'guid-1';
+    fireEvent.input(fields.find((f) => f.label === 'Restaurant GUID')!);
+
+    fireEvent.click(screen.getByText('Connect Toast'));
+    await waitFor(() => expect(mockOnConnectToast).toHaveBeenCalledWith('id-1', 'secret-1', 'guid-1'));
+  });
+
+  it('shows connected status and sync/insights/disconnect actions for a connected provider', () => {
+    renderSettings({ square: { provider: 'square', connected: true, merchantId: 'merch-1' } });
+    expect(screen.getByText(/Connected — merch-1/)).toBeInTheDocument();
+    expect(screen.getByText('Sync Menu')).toBeInTheDocument();
+    expect(screen.getByText('View 7-Day Insights')).toBeInTheDocument();
+    expect(screen.getByText('Disconnect')).toBeInTheDocument();
+  });
+
+  it('shows a connection error when present', () => {
+    renderSettings({ square: { provider: 'square', connected: false, error: 'Token exchange failed.' } });
+    expect(screen.getByText('Token exchange failed.')).toBeInTheDocument();
+  });
+
+  it('calls onDisconnect for the right provider', async () => {
+    renderSettings({ square: { provider: 'square', connected: true, merchantId: 'merch-1' } });
+    fireEvent.click(screen.getByText('Disconnect'));
+    await waitFor(() => expect(mockOnDisconnect).toHaveBeenCalledWith('square'));
+  });
+
+  it('displays sales insights after fetching them', async () => {
+    renderSettings({ square: { provider: 'square', connected: true, merchantId: 'merch-1' } });
+    fireEvent.click(screen.getByText('View 7-Day Insights'));
+    await waitFor(() => expect(screen.getByText(/123.45/)).toBeInTheDocument());
+    expect(screen.getByText(/7 orders/)).toBeInTheDocument();
+  });
+});

--- a/src/components/POSSettings.tsx
+++ b/src/components/POSSettings.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import '@material/web/dialog/dialog.js';
+import '@material/web/button/text-button.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/textfield/filled-text-field.js';
+import '@material/web/icon/icon.js';
+import { POS_PROVIDERS, POS_PROVIDER_STATUS } from '../constants';
+import { POSConnectionStatus, POSMenuItem } from '../types';
+import { MdDialog } from './MdDialog';
+
+interface POSSettingsProps {
+  open: boolean;
+  onClose: () => void;
+  connections: Record<string, POSConnectionStatus>;
+  menu: POSMenuItem[];
+  onConnectSquare: () => Promise<void>;
+  onConnectToast: (clientId: string, clientSecret: string, restaurantGuid: string) => Promise<void>;
+  onDisconnect: (provider: string) => Promise<void>;
+  onSyncMenu: (provider: string) => Promise<unknown>;
+  onGetSales: (provider: string, start: Date, end: Date) => Promise<{ grossCents: number; orderCount: number } | null>;
+}
+
+// POS Settings dialog — Phase 3 of
+// docs/plans/2026-05-21-feature-set-purr-design.md. Only Square and
+// Toast are wired up; the rest render disabled per
+// POS_PROVIDER_STATUS. All actual API traffic happens server-side —
+// this component only calls the three callables + reads the two
+// Firestore collections passed in via usePOS.
+export function POSSettings({
+  open, onClose, connections, menu, onConnectSquare, onConnectToast, onDisconnect, onSyncMenu, onGetSales,
+}: POSSettingsProps) {
+  const [toastForm, setToastForm] = useState({ clientId: '', clientSecret: '', restaurantGuid: '' });
+  const [busyProvider, setBusyProvider] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [insights, setInsights] = useState<{ grossCents: number; orderCount: number } | null>(null);
+
+  const withBusy = async (provider: string, fn: () => Promise<void>) => {
+    setBusyProvider(provider);
+    setStatusMessage(null);
+    try {
+      await fn();
+    } catch (e) {
+      setStatusMessage(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      setBusyProvider(null);
+    }
+  };
+
+  const handleSync = (provider: string) => withBusy(provider, async () => {
+    const result = await onSyncMenu(provider) as { data?: { count: number } } | undefined;
+    setStatusMessage(`Synced ${result?.data?.count ?? 0} items.`);
+  });
+
+  const handleInsights = (provider: string) => withBusy(provider, async () => {
+    const end = new Date();
+    const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const sales = await onGetSales(provider, start, end);
+    setInsights(sales);
+  });
+
+  return (
+    <MdDialog open={open} onClose={onClose}>
+      <div slot="headline">POS Integration</div>
+      <div slot="content" className="flex flex-col gap-3 min-w-[320px]">
+        {POS_PROVIDERS.map((provider) => {
+          const status = POS_PROVIDER_STATUS[provider.id];
+          const connection = connections[provider.id];
+          const isConnected = connection?.connected;
+          const isBusy = busyProvider === provider.id;
+
+          if (status === 'coming_soon') {
+            return (
+              <div key={provider.id} className="flex items-center justify-between p-2 rounded bg-gray-900 opacity-60">
+                <span className="text-gray-400">{provider.label}</span>
+                <span className="text-xs text-gray-500">Coming soon — not yet available</span>
+              </div>
+            );
+          }
+
+          return (
+            <div key={provider.id} className="border border-gray-800 rounded p-3 flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-white font-medium">{provider.label}</span>
+                {isConnected
+                  ? <span className="text-xs text-green-400">✓ Connected{connection.merchantId ? ` — ${connection.merchantId}` : ''}</span>
+                  : <span className="text-xs text-gray-500">Not connected</span>}
+              </div>
+              {connection?.error && <div className="text-xs text-red-400">{connection.error}</div>}
+
+              {!isConnected && provider.id === 'square' && (
+                <md-filled-button disabled={isBusy || undefined} onClick={() => withBusy('square', onConnectSquare)}>
+                  Connect Square
+                </md-filled-button>
+              )}
+
+              {!isConnected && provider.id === 'toast' && (
+                <div className="flex flex-col gap-2">
+                  <md-filled-text-field label="Client ID" value={toastForm.clientId}
+                    onInput={(e: any) => setToastForm((f) => ({ ...f, clientId: e.target.value }))} />
+                  <md-filled-text-field label="Client Secret" type="password" value={toastForm.clientSecret}
+                    onInput={(e: any) => setToastForm((f) => ({ ...f, clientSecret: e.target.value }))} />
+                  <md-filled-text-field label="Restaurant GUID" value={toastForm.restaurantGuid}
+                    onInput={(e: any) => setToastForm((f) => ({ ...f, restaurantGuid: e.target.value }))} />
+                  <md-filled-button
+                    disabled={isBusy || !toastForm.clientId || !toastForm.clientSecret || !toastForm.restaurantGuid || undefined}
+                    onClick={() => withBusy('toast', () => onConnectToast(toastForm.clientId, toastForm.clientSecret, toastForm.restaurantGuid))}
+                  >
+                    Connect Toast
+                  </md-filled-button>
+                </div>
+              )}
+
+              {isConnected && (
+                <div className="flex gap-2 flex-wrap items-center">
+                  <md-outlined-button disabled={isBusy || undefined} onClick={() => handleSync(provider.id)}>
+                    Sync Menu
+                  </md-outlined-button>
+                  <md-outlined-button disabled={isBusy || undefined} onClick={() => handleInsights(provider.id)}>
+                    View 7-Day Insights
+                  </md-outlined-button>
+                  <md-text-button disabled={isBusy || undefined} onClick={() => withBusy(provider.id, () => onDisconnect(provider.id))}>
+                    Disconnect
+                  </md-text-button>
+                </div>
+              )}
+              {isConnected && connection.lastSyncedAt && (
+                <div className="text-xs text-gray-500">
+                  ✓ Connected — synced {connection.lastSyncedCount ?? menu.filter((m) => m.provider === provider.id).length} items
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {insights && (
+          <div className="border border-blue-900 rounded p-3 text-sm text-blue-300">
+            Last 7 days: ${(insights.grossCents / 100).toFixed(2)} gross, {insights.orderCount} orders.
+          </div>
+        )}
+        {statusMessage && <div className="text-xs text-gray-400">{statusMessage}</div>}
+      </div>
+      <div slot="actions">
+        <md-text-button onClick={onClose}>Close</md-text-button>
+      </div>
+    </MdDialog>
+  );
+}
+
+export default POSSettings;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,3 +109,36 @@ export const ROLE_NOTIFICATION_DEFAULTS: Record<string, string[]> = {
   'Security': ['security', 'manager', 'break']
 };
 
+// POS provider picker honesty (Phase 3 — see
+// docs/plans/2026-05-21-feature-set-purr-design.md). Only 'available'
+// providers are selectable in POSSettings; the rest render disabled
+// with a "Coming soon" label. Flipping a provider to real support is
+// a one-line change here once its Cloud Function adapter is built —
+// see functions/src/pos/stubs.ts for the scaffolding those adapters
+// already conform to.
+export const POS_PROVIDERS: { id: string; label: string }[] = [
+  { id: 'square', label: 'Square' },
+  { id: 'toast', label: 'Toast' },
+  { id: 'clover', label: 'Clover' },
+  { id: 'lightspeed', label: 'Lightspeed' },
+  { id: 'spoton', label: 'SpotOn' },
+  { id: 'touchbistro', label: 'TouchBistro' },
+  { id: 'revel', label: 'Revel' },
+  { id: 'lavu', label: 'Lavu' },
+  { id: 'talech', label: 'Talech' },
+  { id: 'aloha', label: 'Aloha' },
+];
+
+export const POS_PROVIDER_STATUS: Record<string, 'available' | 'coming_soon'> = {
+  square: 'available',
+  toast: 'available',
+  clover: 'coming_soon',
+  lightspeed: 'coming_soon',
+  spoton: 'coming_soon',
+  touchbistro: 'coming_soon',
+  revel: 'coming_soon',
+  lavu: 'coming_soon',
+  talech: 'coming_soon',
+  aloha: 'coming_soon',
+};
+

--- a/src/hooks/usePOS.ts
+++ b/src/hooks/usePOS.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db, functions } from '../firebase';
+import { POSConnectionStatus, POSMenuItem } from '../types';
+
+interface UsePOSArgs {
+  barId: string | null;
+  isManagerPlus: boolean;
+}
+
+// POS integration data + actions (Phase 3). All API calls happen
+// server-side (see functions/src/pos/) — this hook only talks to
+// Firestore (connection status + synced menu, both read-only here)
+// and the three callables that drive the connect/sync flow.
+export function usePOS({ barId, isManagerPlus }: UsePOSArgs) {
+  const [connections, setConnections] = useState<Record<string, POSConnectionStatus>>({});
+  const [menu, setMenu] = useState<POSMenuItem[]>([]);
+
+  useEffect(() => {
+    if (!barId || !isManagerPlus) { setConnections({}); return; }
+    const unsub = onSnapshot(
+      collection(db, `bars/${barId}/posConnection`),
+      (s) => {
+        const next: Record<string, POSConnectionStatus> = {};
+        s.docs.forEach((d) => { next[d.id] = { provider: d.id, ...d.data() } as POSConnectionStatus; });
+        setConnections(next);
+      },
+      (err) => console.error('POS connection listener failed', err),
+    );
+    return unsub;
+  }, [barId, isManagerPlus]);
+
+  useEffect(() => {
+    if (!barId || !isManagerPlus) { setMenu([]); return; }
+    const unsub = onSnapshot(
+      collection(db, `bars/${barId}/menu`),
+      (s) => setMenu(s.docs.map((d) => ({ id: d.id, ...d.data() } as POSMenuItem))),
+      (err) => console.error('POS menu listener failed', err),
+    );
+    return unsub;
+  }, [barId, isManagerPlus]);
+
+  const connectSquare = useCallback(async () => {
+    if (!barId) return;
+    const result = await httpsCallable(functions, 'posGetAuthorizeUrl')({ barId });
+    const { authorizeUrl } = result.data as { authorizeUrl: string };
+    window.location.href = authorizeUrl;
+  }, [barId]);
+
+  const connectToast = useCallback(async (clientId: string, clientSecret: string, restaurantGuid: string) => {
+    if (!barId) return;
+    await httpsCallable(functions, 'posConnectToast')({ barId, clientId, clientSecret, restaurantGuid });
+  }, [barId]);
+
+  const disconnect = useCallback(async (provider: string) => {
+    if (!barId) return;
+    await httpsCallable(functions, 'posDisconnect')({ barId, provider });
+  }, [barId]);
+
+  const syncMenu = useCallback(async (provider: string) => {
+    if (!barId) return;
+    return httpsCallable(functions, 'posSyncMenu')({ barId, provider });
+  }, [barId]);
+
+  const getSales = useCallback(async (provider: string, start: Date, end: Date) => {
+    if (!barId) return null;
+    const result = await httpsCallable(functions, 'posGetSales')({
+      barId, provider, start: start.toISOString(), end: end.toISOString(),
+    });
+    return result.data as { grossCents: number; orderCount: number };
+  }, [barId]);
+
+  return { connections, menu, connectSquare, connectToast, disconnect, syncMenu, getSales };
+}

--- a/src/test/firestore-rules.test.ts
+++ b/src/test/firestore-rules.test.ts
@@ -241,6 +241,60 @@ describe('Firestore security rules', () => {
     });
   });
 
+  describe('bars/{barId}/posConnection, posSecrets, menu (Phase 3)', () => {
+    beforeEach(async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), `bars/${BAR_A}/posConnection`, 'square'),
+          { provider: 'square', connected: true, merchantId: 'merch-1' });
+        await setDoc(doc(ctx.firestore(), `bars/${BAR_A}/posSecrets`, 'square'),
+          { accessToken: 'encrypted-blob' });
+        await setDoc(doc(ctx.firestore(), `bars/${BAR_A}/menu`, 'item-1'),
+          { name: 'Well Whiskey', price: 800, provider: 'square' });
+      });
+    });
+
+    it('allows Manager+ to read posConnection status', async () => {
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertSucceeds(getDoc(doc(db, `bars/${BAR_A}/posConnection`, 'square')));
+    });
+
+    it('denies Staff from reading posConnection status', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
+      await assertFails(getDoc(doc(db, `bars/${BAR_A}/posConnection`, 'square')));
+    });
+
+    it('denies any client write to posConnection, even by Manager+', async () => {
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertFails(setDoc(doc(db, `bars/${BAR_A}/posConnection`, 'square'),
+        { provider: 'square', connected: true, merchantId: 'attacker' }));
+    });
+
+    it('denies any client read or write of posSecrets, even by Manager+', async () => {
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertFails(getDoc(doc(db, `bars/${BAR_A}/posSecrets`, 'square')));
+      await assertFails(setDoc(doc(db, `bars/${BAR_A}/posSecrets`, 'square'), { accessToken: 'stolen' }));
+    });
+
+    it('allows any bar member to read the synced menu', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
+      await assertSucceeds(getDoc(doc(db, `bars/${BAR_A}/menu`, 'item-1')));
+    });
+
+    it('denies any client write to the menu, even by Manager+', async () => {
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertFails(setDoc(doc(db, `bars/${BAR_A}/menu`, 'item-1'),
+        { name: 'Free Drinks', price: 0, provider: 'square' }));
+    });
+
+    it('denies any client access to posOAuthStates', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), 'posOAuthStates', 'state-1'), { barId: BAR_A, provider: 'square' });
+      });
+      const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
+      await assertFails(getDoc(doc(db, 'posOAuthStates', 'state-1')));
+    });
+  });
+
   describe('requests/{requestId}', () => {
     beforeEach(async () => {
       await env.withSecurityRulesDisabled(async (ctx) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,3 +239,26 @@ export interface OwnershipClaim {
   status: 'pending' | 'approved' | 'rejected';
   createdAt: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
 }
+
+// POS integration (Phase 3). Client-visible status only — the actual
+// OAuth tokens live server-side (bars/{barId}/posSecrets), never
+// readable from the client. See functions/src/pos/.
+export interface POSConnectionStatus {
+  provider: string;
+  connected: boolean;
+  merchantId?: string;
+  error?: string | null;
+  connectedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+  lastSyncedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+  lastSyncedCount?: number;
+}
+
+// A menu item synced in from a connected POS via posSyncMenu.
+export interface POSMenuItem {
+  id: string;
+  name: string;
+  price: number; // integer cents
+  category?: string;
+  provider: string;
+  syncedAt?: import('firebase/firestore').FieldValue | import('firebase/firestore').Timestamp;
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of `docs/plans/2026-05-21-feature-set-purr-design.md`. **Stacked on #290 (Phase 2)** — this branch was cut from `claude/phase-2-chat` since both touch `App.tsx`/`firestore.rules`; merge/rebase order is #290 then this one. The diff below is Phase 3 only (compare against `claude/phase-2-chat`, not `main`).

Square and Toast get real OAuth + API implementations; the other eight providers (Clover, Lightspeed, SpotOn, TouchBistro, Revel, Lavu, Talech, Aloha) stay as scaffolding classes conforming to the same `POSClient` interface, gated "coming soon" in the picker rather than built or deleted.

### Server side (`functions/src/pos/`)

- **`POSClient` interface** + `MenuItem`/`Order`/`SalesSummary` types shared by every adapter.
- **`SquarePOSClient`** — real OAuth (authorization-code) + REST API (catalog list, order search) against Square's well-documented public API. High confidence.
- **`ToastPOSClient`** — **lower confidence, flagged prominently in `toast.ts`**. Toast's real integration model is client-credentials (clientId/clientSecret/restaurantGuid), not a user-facing OAuth redirect the way Square is — the design doc assumed a uniform redirect flow that doesn't actually match Toast. This adapter's `connect()` takes credentials directly instead. Endpoint paths reflect Toast's publicly documented partner API as of this writing, but that API is partner-gated and versioned — verify against real docs once partner approval is in hand.
- **KMS-encrypted token storage** (`kms.ts`) — requires a real KMS key provisioned in the deploying GCP project (`POS_KMS_KEY_NAME`) and the Functions service account granted encrypter/decrypter on it.
- **OAuth flow**: `posGetAuthorizeUrl` (Manager+ callable, mints a short-lived state token) → Square's consent screen → `oauthCallback` (plain `onRequest`, since it's a browser redirect) → exchanges the code, encrypts and stores tokens. Toast connects directly via `posConnectToast` (no redirect). `posDisconnect` clears everything.
- **`posSyncMenu`/`posGetOrders`/`posGetSales`** — role-gated callables; auto-refresh/reissue the access token if within 5 minutes of expiry. `posSyncMenu` writes into `bars/{barId}/menu` as a smoke test. `rotatePOSTokens` is the proactive hourly counterpart (24h margin), sharing the refresh logic.

### Rules

`posConnection` (status only — Manager+ readable) is a **separate** collection from `posSecrets` (the actual encrypted tokens, Cloud-Function-only, zero client access) specifically so a status read can never leak a credential — Firestore rules can't redact individual fields within one document. `menu` is bar-member-readable, Cloud-Function-write-only. `posOAuthStates` is Cloud-Function-only.

### Client

- **`usePOS`** — connection + menu listeners (Manager+ only), and callable wrappers.
- **`POSSettings`** — dialog listing all ten providers; Square/Toast actionable, the rest disabled "Coming soon". Square connects via redirect; Toast via a direct credentials form. Connected providers get Sync Menu, 7-day insights, and Disconnect.
- Wired into the toolbar menu as "POS Integration", gated the same way "Customize Theme" already is.

### Verification

- Web build: passes · jsdom: 100/100 (8 new `POSSettings` tests) · functions build + unit tests: 10/10 · Firestore rules emulator suite: 76/76 (7 new POS permission-matrix tests)

**Cannot be verified end-to-end in this sandbox:** real OAuth token exchange (needs a Square developer app + `SQUARE_CLIENT_ID`/`SECRET`, and Toast partner approval), KMS encryption (needs a provisioned key), and the actual Square/Toast API response shapes against live data. Square should be close to correct; **Toast is an explicit best-effort scaffold — read the caveat comment at the top of `toast.ts` before deploying it as-is.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Integrate Phase 3 POS support, adding secure server-side Square and Toast connections with menu/sales sync and exposing manager-only POS controls in the client UI.

New Features:
- Add POS provider catalog and availability flags for Square, Toast, and eight additional stubbed providers, driving the manager-facing POS settings UI.
- Introduce manager-only POSSettings dialog and usePOS hook to manage POS connections, synced menus, and 7-day sales insights from the client toolbar.
- Implement server-side POS adapters for Square and Toast, enabling real OAuth/client-credential connections, menu sync, order retrieval, and sales summaries via callable Cloud Functions.

Enhancements:
- Store POS OAuth credentials in dedicated Firestore collections with KMS-backed encryption and token rotation, separating connection status from secrets for safer access patterns.
- Add shared POS type definitions and factory/stub infrastructure to standardize current and future POS provider integrations.
- Extend Firestore security rules and tests to cover POS connection, secrets, menu, and OAuth state collections with appropriate role-based access control.

Build:
- Update Functions dependencies to include Google Cloud KMS and TypeScript node types to support encrypted secret handling in POS integrations.

Tests:
- Add POSSettings component tests covering provider availability, connection flows, error display, and sales insight rendering.
- Extend Firestore rules tests with POS-related permission matrix cases for posConnection, posSecrets, menu, and posOAuthStates collections.