### PR TITLE
Fix 18 bugs found by adversarial audit of Phase 2-4 (chat/POS/calendar)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,6 +20,47 @@ The web application is hosted on GitHub Pages.
     ```
     This pushes the `dist` folder to the `gh-pages` branch.
 
+## Cloud Functions Deployment
+
+Not currently automated in CI — deploy manually from `functions/`:
+```bash
+cd functions && npm run build
+firebase deploy --only functions
+```
+
+### Required environment variables
+
+None of these are set anywhere in this repo or its CI — they must be
+configured directly in the Firebase project (`firebase functions:config:set`
+for v1-style config, or as actual environment variables/secrets for v2
+functions, e.g. `firebase functions:secrets:set NAME`) before the POS
+(Phase 3) or Calendar (Phase 4) OAuth flows can work at all. Every one
+of them is read via `process.env.*` with no fallback.
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `POS_KMS_KEY_NAME` | `functions/src/shared/kms.ts` (POS + Calendar) | Full resource name of a provisioned Cloud KMS key (`projects/*/locations/*/keyRings/*/cryptoKeys/*`) used to encrypt every stored OAuth token — POS and Calendar secrets alike, despite the POS-specific name. The Cloud Functions service account needs `roles/cloudkms.cryptoKeyEncrypterDecrypter` on it. |
+| `SQUARE_CLIENT_ID` / `SQUARE_CLIENT_SECRET` | `functions/src/pos/square.ts`, `functions/src/pos/oauth.ts` | Square OAuth application credentials (from the Square Developer Dashboard). |
+| `POS_OAUTH_CALLBACK_BASE_URL` | `functions/src/pos/oauth.ts` | Public base URL the `oauthCallback` function is reachable at — Square redirects here after consent. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | `functions/src/calendar/google.ts`, `functions/src/calendar/oauth.ts` | Google Cloud OAuth 2.0 client credentials, scoped to the Calendar API. |
+| `CALENDAR_OAUTH_CALLBACK_BASE_URL` | `functions/src/calendar/oauth.ts`, `functions/src/calendar/calendars.ts`, `functions/src/calendar/resubscribe.ts` | Public base URL the `calendarOauthCallback` and `calendarWebhook` functions are reachable at — used both as the OAuth redirect target and as the base for Google's push-notification webhook. |
+
+Toast (`functions/src/pos/toast.ts`) doesn't use OAuth-redirect
+credentials — a manager enters partner-issued `clientId`/`clientSecret`/
+`restaurantGuid` directly at connect time, so there's nothing to
+configure here for it.
+
+### Client-side env vars for the calendar feed
+
+`VITE_ICAL_FEED_BASE_URL` (see `src/vite-env.d.ts`) — the base URL
+`CalendarSettings` builds the outbound iCal feed link from. The web
+client (GitHub Pages) and the `icalFeed` Cloud Function are two
+separate hosts, so this can't be inferred from `window.location.origin`.
+Point it at wherever `/ical/**` actually resolves — a Firebase Hosting
+site using the rewrite in `firebase.json`, or the function's own Cloud
+Run URL. Left unset, the feed URL is deliberately not shown rather than
+handing out a link that 404s.
+
 ## Android Deployment
 
 The Android application is a Capacitor wrapper around the web app.

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,19 @@
   "storage": {
     "rules": "storage.rules"
   },
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "/ical/**",
+        "function": {
+          "functionId": "icalFeed",
+          "region": "us-central1"
+        }
+      }
+    ]
+  },
   "emulators": {
     "firestore": {
       "host": "127.0.0.1",

--- a/firestore.rules
+++ b/firestore.rules
@@ -172,11 +172,18 @@ service cloud.firestore {
         // per-bar user doc at write time (not client-asserted) so a
         // message can't be posted under a spoofed name or role badge.
         allow create: if hasRole(barId)
+          && request.resource.data.keys().hasOnly(['text', 'authorId', 'authorName', 'authorRole', 'timestamp', 'pinned', 'pinnedBy', 'pinnedAt'])
           && request.resource.data.authorId == request.auth.uid
           && request.resource.data.authorName ==
                get(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid)).data.get('displayName', '')
           && request.resource.data.authorRole ==
                get(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid)).data.get('role', '')
+          // Must be the serverTimestamp() sentinel, not a client-chosen
+          // literal — otherwise a spoofed far-future timestamp sorts
+          // itself to the top of the scrollback forever and permanently
+          // pins itself at the head of useChat's "latest message"
+          // listener, which nothing in the app can ever correct.
+          && request.resource.data.timestamp == request.time
           && (request.resource.data.pinned == false || isManagerPlus(barId));
         allow update: if isManagerPlus(barId)
           && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['pinned', 'pinnedBy', 'pinnedAt']);
@@ -248,8 +255,12 @@ service cloud.firestore {
         allow read, write: if false;
       }
 
-      // Menu synced from a connected POS (posSyncMenu). Any bar
-      // member can see the current menu; writes are Cloud-Function-only.
+      // Menu synced from a connected POS (posSyncMenu). Readable by
+      // any bar member by design, though nothing in the client
+      // currently reads it outside the Manager+-gated POS Settings
+      // dialog (usePOS.ts) — the broader read here is for a future
+      // staff-facing menu view, not a current one. Writes are
+      // Cloud-Function-only.
       match /menu/{itemId} {
         allow read: if hasRole(barId);
         allow write: if false;

--- a/functions/src/__tests__/google.test.ts
+++ b/functions/src/__tests__/google.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { googleEventToPatch } from "../calendar/google";
+
+describe("googleEventToPatch", () => {
+  it("uses dateTime as-is for timed events", () => {
+    const patch = googleEventToPatch({
+      summary: "Staff Meeting",
+      start: { dateTime: "2026-08-15T18:00:00-05:00" },
+      end: { dateTime: "2026-08-15T19:00:00-05:00" },
+    });
+    expect(patch.start).toBe("2026-08-15T18:00:00-05:00");
+    expect(patch.end).toBe("2026-08-15T19:00:00-05:00");
+  });
+
+  // The bug this guards against: a date-only value ("2026-08-15", no
+  // dateTime) parses as UTC midnight — new Date("2026-08-15") renders
+  // as 8/14 in any negative-offset timezone. Appending a zone-less
+  // time component makes it parse as local midnight instead, so the
+  // all-day event actually displays on the day it's supposed to.
+  it("anchors date-only (all-day) events to local midnight, not UTC midnight", () => {
+    const patch = googleEventToPatch({
+      summary: "Inventory Day",
+      start: { date: "2026-08-15" },
+      end: { date: "2026-08-16" },
+    });
+    expect(patch.start).toBe("2026-08-15T00:00:00");
+    expect(patch.end).toBe("2026-08-16T00:00:00");
+
+    // The whole point: this must NOT shift to the previous day when
+    // parsed in a negative-offset timezone the way the bare date
+    // string "2026-08-15" would.
+    const parsedInAnyTimezone = new Date(patch.start!);
+    expect(parsedInAnyTimezone.getDate()).toBe(15);
+    expect(parsedInAnyTimezone.getMonth()).toBe(7); // August, 0-indexed
+  });
+
+  it("defaults a missing title to (untitled) and passes description through", () => {
+    const patch = googleEventToPatch({
+      start: { dateTime: "2026-08-15T18:00:00Z" },
+      end: { dateTime: "2026-08-15T19:00:00Z" },
+      description: "Bring the good scotch",
+    });
+    expect(patch.title).toBe("(untitled)");
+    expect(patch.description).toBe("Bring the good scotch");
+  });
+});

--- a/functions/src/__tests__/outboundSync.test.ts
+++ b/functions/src/__tests__/outboundSync.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { contentChanged } from "../calendar/outboundSync";
+import { CalendarEvent } from "../calendar/types";
+
+const base: CalendarEvent = {
+  id: "e1", title: "Staff Meeting", start: "2026-08-15T18:00:00", end: "2026-08-15T19:00:00", type: "event",
+};
+
+describe("contentChanged", () => {
+  it("is true for a brand-new document (no before)", () => {
+    expect(contentChanged(undefined, base)).toBe(true);
+  });
+
+  it("is true when the document was deleted (no after)", () => {
+    expect(contentChanged(base, undefined)).toBe(true);
+  });
+
+  // This is the actual loop-prevention case: onEventWritten's own
+  // write-back (externalId/lastSyncedAt) must NOT look like a content
+  // change, or the trigger re-fires on itself forever.
+  it("is false when only externalId/lastSyncedAt changed", () => {
+    const after: CalendarEvent = { ...base, externalId: "google-123" };
+    expect(contentChanged(base, after)).toBe(false);
+  });
+
+  it("is true when the title changed", () => {
+    expect(contentChanged(base, { ...base, title: "Renamed" })).toBe(true);
+  });
+
+  it("is true when start/end changed", () => {
+    expect(contentChanged(base, { ...base, start: "2026-08-15T20:00:00" })).toBe(true);
+  });
+
+  it("is true when assignedTo changed", () => {
+    expect(contentChanged({ ...base, assignedTo: ["a"] }, { ...base, assignedTo: ["a", "b"] })).toBe(true);
+  });
+});

--- a/functions/src/calendar/calendars.ts
+++ b/functions/src/calendar/calendars.ts
@@ -4,6 +4,7 @@ import { randomBytes } from "node:crypto";
 import { requireManagerPlus } from "../shared/authz";
 import { getGoogleAccessToken } from "./connection";
 import { watchGoogleCalendar } from "./google";
+import { syncFromGoogle } from "./inboundSync";
 
 export const calendarListCalendars = onCall(async (request) => {
   const { barId } = (request.data ?? {}) as { barId?: string };
@@ -45,6 +46,21 @@ export const calendarSelectCalendar = onCall(async (request) => {
     watchChannelId: channelId, watchResourceId: watch.resourceId, watchExpiresAt: watch.expiration,
     updatedAt: FieldValue.serverTimestamp(),
   }, { merge: true });
+
+  // Google only pushes on future *changes* — without an initial pull,
+  // a calendar full of pre-existing events would show nothing in the
+  // app until someone happened to edit one of them in Google. This
+  // does the same sync a webhook ping would trigger, just eagerly.
+  try {
+    await syncFromGoogle(barId);
+  } catch (e) {
+    // The calendar is connected and watching either way; a failed
+    // initial pull just means the next real change (or the daily
+    // resubscribe sweep, which doesn't re-pull) won't backfill
+    // history either — log it, but don't fail calendar selection
+    // over a sync hiccup the user can't do anything about mid-request.
+    console.error(`Initial Google sync failed for bar ${barId}`, e);
+  }
 
   return { calendarId };
 });

--- a/functions/src/calendar/connection.ts
+++ b/functions/src/calendar/connection.ts
@@ -19,13 +19,28 @@ export async function getGoogleAccessToken(barId: string): Promise<string> {
   const expiresAt = secret.expiresAt as number;
   if (expiresAt - Date.now() < JUST_IN_TIME_MARGIN_MS) {
     const refreshToken = await decryptSecret(secret.refreshToken);
-    const refreshed = await refreshGoogleToken(refreshToken);
-    accessToken = refreshed.accessToken;
-    await secretRef.set({
-      accessToken: await encryptSecret(accessToken),
-      expiresAt: refreshed.expiresAt,
-      updatedAt: FieldValue.serverTimestamp(),
-    }, { merge: true });
+    try {
+      const refreshed = await refreshGoogleToken(refreshToken);
+      accessToken = refreshed.accessToken;
+      await secretRef.set({
+        accessToken: await encryptSecret(accessToken),
+        expiresAt: refreshed.expiresAt,
+        updatedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    } catch (e) {
+      // Every caller of this function (outboundSync's trigger,
+      // syncFromGoogle's webhook handler, resubscribe's scheduled
+      // sweep) previously only console.error'd a refresh failure —
+      // calendarConnection kept showing connected:true with no error
+      // field, so a manager had no way to find out sync had silently
+      // died (e.g. the grant was revoked on Google's side). Surface it
+      // here, once, so every caller gets this for free.
+      const message = e instanceof Error ? e.message : "Failed to refresh Google access token.";
+      await db.doc(`bars/${barId}/calendarConnection/google`).set(
+        { connected: false, error: message }, { merge: true },
+      );
+      throw e;
+    }
   }
   return accessToken;
 }

--- a/functions/src/calendar/google.ts
+++ b/functions/src/calendar/google.ts
@@ -56,12 +56,23 @@ function eventToGoogle(event: CalendarEvent) {
   };
 }
 
+// A date-only value (Google's all-day-event shape, "2026-08-15", no
+// `dateTime`) parses as UTC midnight per the ISO 8601 / Date spec —
+// displaying it with any local formatter (toLocaleString, etc.) in a
+// negative-offset timezone shows the *previous* day. Appending a
+// bare (zone-less) time component instead makes Date parse it as
+// local midnight, which is what an all-day event actually means to
+// the person looking at their own calendar.
+function toLocalDateTimeString(dateOnly: string): string {
+  return `${dateOnly}T00:00:00`;
+}
+
 export function googleEventToPatch(gEvent: any): Partial<CalendarEvent> {
   return {
     title: gEvent.summary ?? "(untitled)",
     description: gEvent.description,
-    start: gEvent.start?.dateTime ?? gEvent.start?.date,
-    end: gEvent.end?.dateTime ?? gEvent.end?.date,
+    start: gEvent.start?.dateTime ?? (gEvent.start?.date ? toLocalDateTimeString(gEvent.start.date) : undefined),
+    end: gEvent.end?.dateTime ?? (gEvent.end?.date ? toLocalDateTimeString(gEvent.end.date) : undefined),
   };
 }
 
@@ -103,21 +114,39 @@ export async function deleteGoogleEvent(accessToken: string, calendarId: string,
 // Incremental sync via syncToken. A GONE (410) response means the
 // token expired server-side — the caller must fall back to a full
 // resync; signaled here by omitting nextSyncToken from the result.
+// Google only returns nextSyncToken on the LAST page of a change set,
+// so this pages all the way through before returning — stopping
+// early at the first page would silently drop the rest of that page
+// set's changes and, since the (nonexistent) syncToken it returned
+// would be treated as "nothing more to sync," lose them permanently
+// rather than just delaying them to the next poll.
 export async function listGoogleEventChanges(
   accessToken: string, calendarId: string, syncToken?: string,
 ): Promise<{ events: any[]; nextSyncToken?: string; tokenExpired?: boolean }> {
-  const params = new URLSearchParams();
-  if (syncToken) params.set("syncToken", syncToken);
-  else params.set("timeMin", new Date().toISOString());
-  const res = await fetch(`${GOOGLE_CAL_BASE}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-  const data = await res.json() as any;
-  if (!res.ok) {
-    if (res.status === 410) return { events: [], tokenExpired: true };
-    throw new Error(data.error?.message ?? `Google events list failed (${res.status}).`);
-  }
-  return { events: data.items ?? [], nextSyncToken: data.nextSyncToken };
+  const events: any[] = [];
+  let pageToken: string | undefined;
+  let nextSyncToken: string | undefined;
+
+  do {
+    const params = new URLSearchParams();
+    if (syncToken) params.set("syncToken", syncToken);
+    else params.set("timeMin", new Date().toISOString());
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const res = await fetch(`${GOOGLE_CAL_BASE}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const data = await res.json() as any;
+    if (!res.ok) {
+      if (res.status === 410) return { events: [], tokenExpired: true };
+      throw new Error(data.error?.message ?? `Google events list failed (${res.status}).`);
+    }
+    events.push(...(data.items ?? []));
+    pageToken = data.nextPageToken;
+    nextSyncToken = data.nextSyncToken;
+  } while (pageToken);
+
+  return { events, nextSyncToken };
 }
 
 export async function watchGoogleCalendar(
@@ -131,4 +160,20 @@ export async function watchGoogleCalendar(
   const data = await res.json() as any;
   if (!res.ok) throw new Error(data.error?.message ?? `Google watch subscribe failed (${res.status}).`);
   return { resourceId: data.resourceId, expiration: parseInt(data.expiration, 10) };
+}
+
+// Stops a push-notification channel — called on disconnect so Google
+// stops sending webhook pings for a bar that's no longer connected.
+// Best-effort: 404 means the channel already expired/doesn't exist,
+// which is fine either way.
+export async function stopGoogleChannel(accessToken: string, channelId: string, resourceId: string): Promise<void> {
+  const res = await fetch(`${GOOGLE_CAL_BASE}/channels/stop`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ id: channelId, resourceId }),
+  });
+  if (!res.ok && res.status !== 404) {
+    const data = await res.json().catch(() => ({})) as any;
+    throw new Error(data.error?.message ?? `Google channel stop failed (${res.status}).`);
+  }
 }

--- a/functions/src/calendar/icalPoll.ts
+++ b/functions/src/calendar/icalPoll.ts
@@ -3,6 +3,8 @@ import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { createHash } from "node:crypto";
 import * as ical from "node-ical";
 
+const FETCH_TIMEOUT_MS = 15 * 1000;
+
 // Polls every Manager-added external .ics URL every 15 minutes and
 // upserts its events as read-only, externally-owned local events —
 // see the "Inbound iCal subscription" section of the design doc.
@@ -17,11 +19,44 @@ export const pollICalSubscriptions = onSchedule("every 15 minutes", async () => 
     const sub = subDoc.data() as { url?: string };
     if (!barId || !sub.url) continue;
 
+    // hasOnly() in firestore.rules validates the field set on create,
+    // not the URL's shape — a Manager could paste anything. Reject
+    // non-http(s) schemes before ever handing it to node-ical.
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(sub.url);
+    } catch {
+      await subDoc.ref.set({ lastPolledAt: FieldValue.serverTimestamp(), lastError: "Invalid URL." }, { merge: true });
+      continue;
+    }
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      await subDoc.ref.set(
+        { lastPolledAt: FieldValue.serverTimestamp(), lastError: "Only http(s) URLs are supported." }, { merge: true },
+      );
+      continue;
+    }
+
     const provider = `ical:${createHash("sha256").update(sub.url).digest("hex").slice(0, 16)}`;
     const eventsRef = db.collection(`bars/${barId}/events`);
 
     try {
-      const parsed = await ical.async.fromURL(sub.url);
+      // A slow or hung feed shouldn't be able to burn the whole
+      // invocation's time budget and starve every subscription queued
+      // after it — every poll here runs sequentially in one function
+      // call, so each fetch gets its own bounded timeout.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      let parsed: ical.CalendarResponse;
+      try {
+        // node-ical's .d.ts types the (url, options) overload as
+        // returning void (it's shared with the callback-based form),
+        // but the implementation (lib/core-api.js) always returns a
+        // Promise when no callback is passed — the cast reflects the
+        // real runtime contract, not the imprecise declared one.
+        parsed = await (ical.async.fromURL(sub.url, { signal: controller.signal }) as unknown as Promise<ical.CalendarResponse>);
+      } finally {
+        clearTimeout(timeout);
+      }
       const seenIds = new Set<string>();
 
       for (const key of Object.keys(parsed)) {
@@ -44,8 +79,14 @@ export const pollICalSubscriptions = onSchedule("every 15 minutes", async () => 
           externalProvider: provider,
           lastSyncedAt: FieldValue.serverTimestamp(),
         };
-        if (existing.empty) await eventsRef.add(payload);
-        else await existing.docs[0].ref.set(payload, { merge: true });
+        if (existing.empty) {
+          await eventsRef.add(payload);
+        } else {
+          // FieldValue.delete() is only valid on a merge/update write,
+          // not the create() above — clears a stale soft-delete if
+          // this event had vanished from the feed and come back.
+          await existing.docs[0].ref.set({ ...payload, deletedAt: FieldValue.delete() }, { merge: true });
+        }
       }
 
       // Anything previously synced from this subscription but no

--- a/functions/src/calendar/inboundSync.ts
+++ b/functions/src/calendar/inboundSync.ts
@@ -60,10 +60,20 @@ export async function syncFromGoogle(barId: string): Promise<void> {
     const lastSyncedAt = (existingDoc.data().lastSyncedAt as Timestamp | undefined)?.toMillis() ?? 0;
     if (googleUpdated <= lastSyncedAt) continue; // echo of our own write.
 
+    // Deliberately NOT setting externalProvider here. This branch also
+    // matches locally-created events that have been mirrored out to
+    // Google (externalId set, no externalProvider — see
+    // outboundSync.ts) — those stay locally owned and editable even
+    // after Google reports a newer change on them; only a brand-new
+    // doc (the empty-snapshot branch above) is genuinely Google-
+    // native and gets marked externally-owned. Setting it
+    // unconditionally here used to permanently flip a locally-owned
+    // event to read-only the moment anyone touched it in Google,
+    // locking its own author out of ever editing or deleting it again.
     await existingDoc.ref.set({
       ...googleEventToPatch(gEvent),
-      externalProvider: "google",
       lastSyncedAt: FieldValue.serverTimestamp(),
+      deletedAt: FieldValue.delete(), // clears a stale soft-delete if this event had vanished and come back.
     }, { merge: true });
   }
 

--- a/functions/src/calendar/oauth.ts
+++ b/functions/src/calendar/oauth.ts
@@ -3,7 +3,8 @@ import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { randomBytes } from "node:crypto";
 import { requireManagerPlus } from "../shared/authz";
 import { encryptSecret } from "../shared/kms";
-import { exchangeCodeForTokens } from "./google";
+import { exchangeCodeForTokens, stopGoogleChannel } from "./google";
+import { getGoogleAccessToken } from "./connection";
 
 const STATE_TTL_MS = 10 * 60 * 1000;
 
@@ -91,8 +92,24 @@ export const calendarDisconnect = onCall(async (request) => {
   requireManagerPlus(request.auth, barId);
 
   const db = getFirestore();
+  const connRef = db.doc(`bars/${barId}/calendarConnection/google`);
+  const connection = (await connRef.get()).data();
+
+  // Best-effort: stop the live push channel so Google doesn't keep
+  // pinging calendarWebhook for a bar that's no longer connected.
+  // Failure here shouldn't block disconnecting — worst case the
+  // channel just expires on its own on Google's side.
+  if (connection?.watchChannelId && connection?.watchResourceId) {
+    try {
+      const accessToken = await getGoogleAccessToken(barId);
+      await stopGoogleChannel(accessToken, connection.watchChannelId, connection.watchResourceId);
+    } catch (e) {
+      console.error(`Failed to stop Google push channel for bar ${barId}`, e);
+    }
+  }
+
   await db.doc(`bars/${barId}/calendarSecrets/google`).delete();
-  await db.doc(`bars/${barId}/calendarConnection/google`).set({
+  await connRef.set({
     provider: "google", connected: false, calendarId: null, error: null,
     disconnectedAt: FieldValue.serverTimestamp(),
   });

--- a/functions/src/calendar/outboundSync.ts
+++ b/functions/src/calendar/outboundSync.ts
@@ -4,6 +4,17 @@ import { getGoogleAccessToken } from "./connection";
 import { deleteGoogleEvent, insertGoogleEvent, updateGoogleEvent } from "./google";
 import { CalendarEvent } from "./types";
 
+// Fields that represent actual user-visible content — if none of
+// these changed between before/after, the write was this function's
+// own bookkeeping (externalId, lastSyncedAt) reflecting back onto the
+// doc it just wrote, not a real edit.
+const CONTENT_FIELDS: (keyof CalendarEvent)[] = ["title", "description", "start", "end", "type", "assignedTo"];
+
+export function contentChanged(before: CalendarEvent | undefined, after: CalendarEvent | undefined): boolean {
+  if (!before || !after) return true;
+  return CONTENT_FIELDS.some((field) => JSON.stringify(before[field]) !== JSON.stringify(after[field]));
+}
+
 // Mirrors LOCALLY-OWNED events (no externalProvider set — see the
 // design note in firestore.rules) out to Google. Events with
 // externalProvider set are Google/iCal-owned and never mirrored back
@@ -11,10 +22,19 @@ import { CalendarEvent } from "./types";
 // inbound ping-pong: only inboundSync.ts (webhook.ts) writes
 // externalProvider, and this trigger explicitly skips anything that
 // has it.
+//
+// The other half of loop prevention is contentChanged() above: every
+// successful insert/update below writes externalId/lastSyncedAt back
+// onto the same document, which re-triggers this function. Without
+// the content check, that write-back looks like a fresh edit and
+// mirrors again forever (write -> trigger -> write -> trigger...).
+// Skipping when only bookkeeping fields moved breaks the cycle.
 export const onEventWritten = onDocumentWritten("bars/{barId}/events/{eventId}", async (event) => {
   const { barId, eventId } = event.params;
   const before = event.data?.before?.data() as CalendarEvent | undefined;
   const after = event.data?.after?.data() as CalendarEvent | undefined;
+
+  if (after && !contentChanged(before, after)) return;
 
   const db = getFirestore();
   const connDoc = await db.doc(`bars/${barId}/calendarConnection/google`).get();

--- a/functions/src/calendar/resubscribe.ts
+++ b/functions/src/calendar/resubscribe.ts
@@ -4,12 +4,18 @@ import { randomBytes } from "node:crypto";
 import { getGoogleAccessToken } from "./connection";
 import { watchGoogleCalendar } from "./google";
 
-const RESUBSCRIBE_MARGIN_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+const RESUBSCRIBE_MARGIN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 
-// Google Calendar watch channels expire (max ~30 days, often less) —
-// this weekly sweep re-subscribes anything within 2 days of expiry,
-// per the design doc's "refresh weekly" note.
-export const resubscribeCalendarWatches = onSchedule("every 168 hours", async () => {
+// Google Calendar watch channels expire — Google doesn't guarantee a
+// fixed TTL for events.watch channels (watchGoogleCalendar doesn't
+// request a specific `expiration`, so Google applies its own default,
+// which in practice can be considerably shorter than the ~30-day
+// documented maximum). A weekly sweep with a margin narrower than its
+// own interval can miss a channel's entire renewal window — this runs
+// daily with a 3-day margin instead, so every channel gets multiple
+// chances to be caught before it actually expires regardless of which
+// default Google applied.
+export const resubscribeCalendarWatches = onSchedule("every 24 hours", async () => {
   const db = getFirestore();
   const connectionsSnap = await db.collectionGroup("calendarConnection")
     .where("connected", "==", true).get();

--- a/functions/src/calendar/shiftReminders.ts
+++ b/functions/src/calendar/shiftReminders.ts
@@ -2,16 +2,18 @@ import { onSchedule } from "firebase-functions/v2/scheduler";
 import { getFirestore, FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getMessaging } from "firebase-admin/messaging";
 
-const WINDOW_START_MIN = 14;
-const WINDOW_END_MIN = 16;
+const WINDOW_START_MIN = 10;
+const WINDOW_END_MIN = 15;
 
-// 15-minutes-before shift reminders via the existing FCM/ntfy
+// ~10-15-minutes-before shift reminders via the existing FCM/ntfy
 // plumbing (see the design doc's "Notifications" section under
-// Phase 4). Runs every 5 minutes and checks for shifts starting in a
-// 14-16 minute window from now, which — combined with the 5-minute
-// cadence — guarantees each shift is caught by exactly one run
-// without needing cross-run dedup beyond the reminderSentAt flag
-// (belt-and-suspenders against a retry double-sending).
+// Phase 4). Runs every 5 minutes; the window must be at least as wide
+// as that 5-minute cadence for every shift to be guaranteed a run
+// that catches it — a shift starting at minute M needs some run at
+// r where r+WINDOW_START <= M < r+WINDOW_END, and with runs 5 minutes
+// apart that's only guaranteed if (WINDOW_END - WINDOW_START) >= 5.
+// reminderSentAt is still what prevents a double-send on the rare
+// shift that two consecutive runs both catch.
 export const sendShiftReminders = onSchedule("every 5 minutes", async () => {
   const db = getFirestore();
   const now = Date.now();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,16 @@
 import * as admin from "firebase-admin";
+import { getFirestore } from "firebase-admin/firestore";
 
 admin.initializeApp();
+// Several write paths build payload objects with optional fields that
+// come back `undefined` from an external API (e.g. a Google Calendar
+// event with no description, an iCal VEVENT with no DESCRIPTION, a
+// Square/Toast catalog item with no category) — the Admin SDK rejects
+// `undefined` field values by default, which used to throw and abort
+// the whole sync mid-batch. Dropping undefined fields silently (Admin
+// SDK's documented behavior for this setting) is what every caller
+// here actually wants: an absent field, not a write failure.
+getFirestore().settings({ ignoreUndefinedProperties: true });
 
 export { onUserRoleChange } from "./onUserRoleChange";
 export { onRequestCreated } from "./onRequestCreated";

--- a/functions/src/onChatPinned.ts
+++ b/functions/src/onChatPinned.ts
@@ -1,6 +1,8 @@
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { getMessaging } from "firebase-admin/messaging";
+
+const BACKFILL_AGE_MS = 5 * 60 * 1000;
 
 // Fires an FCM push to every bar member when a chat message transitions
 // into pinned — either created pinned (Manager+ create) or pinned via
@@ -19,6 +21,16 @@ export const onChatPinned = onDocumentWritten("bars/{barId}/chat/{messageId}", a
   const wasPinned = before?.pinned === true;
   const isPinned = after.pinned === true;
   if (!isPinned || wasPinned) return;
+
+  // migrateNoticesToChat backfills old notices as pinned:true with
+  // pinnedAt copied from the original notice's own (old) timestamp —
+  // without this check, migrating a bar with a backlog of notices
+  // fires one high-priority push per notice to every device in the
+  // bar the moment anyone first opens chat. A real pin always has
+  // pinnedAt within moments of the write; anything older than that is
+  // a backfill, not news.
+  const pinnedAt = after.pinnedAt as Timestamp | undefined;
+  if (pinnedAt && Date.now() - pinnedAt.toMillis() > BACKFILL_AGE_MS) return;
 
   const { barId } = event.params;
   const db = getFirestore();

--- a/functions/src/pos/connection.ts
+++ b/functions/src/pos/connection.ts
@@ -64,9 +64,15 @@ export async function getConnectedClient(barId: string, provider: POSProvider): 
   if (!secretDoc.exists) throw new HttpsError("failed-precondition", `${provider} is not connected for this bar.`);
   const secret = secretDoc.data()!;
 
-  const accessToken = await refreshIfNeeded(
-    secretRef, secret, provider, await decryptSecret(secret.accessToken), JUST_IN_TIME_MARGIN_MS,
-  );
+  let accessToken: string;
+  try {
+    accessToken = await refreshIfNeeded(
+      secretRef, secret, provider, await decryptSecret(secret.accessToken), JUST_IN_TIME_MARGIN_MS,
+    );
+  } catch (e) {
+    await markConnectionFailed(db, barId, provider, e);
+    throw e;
+  }
   return createPOSClient(provider, accessToken);
 }
 
@@ -82,5 +88,23 @@ export async function rotateIfNeeded(
   const secretDoc = await secretRef.get();
   if (!secretDoc.exists) return;
   const secret = secretDoc.data()!;
-  await refreshIfNeeded(secretRef, secret, provider, await decryptSecret(secret.accessToken), marginMs);
+  try {
+    await refreshIfNeeded(secretRef, secret, provider, await decryptSecret(secret.accessToken), marginMs);
+  } catch (e) {
+    await markConnectionFailed(db, barId, provider, e);
+    throw e;
+  }
+}
+
+// Previously every caller of refreshIfNeeded only console.error'd a
+// failure — posConnection kept showing connected:true with no error
+// field, so a manager had no way to discover sync had silently died
+// (e.g. a revoked grant). Surface it once, here, for every caller.
+async function markConnectionFailed(
+  db: FirebaseFirestore.Firestore, barId: string, provider: POSProvider, error: unknown,
+): Promise<void> {
+  const message = error instanceof Error ? error.message : "Failed to refresh access token.";
+  await db.doc(`bars/${barId}/posConnection/${provider}`).set(
+    { connected: false, error: message }, { merge: true },
+  );
 }

--- a/functions/src/shared/kms.ts
+++ b/functions/src/shared/kms.ts
@@ -1,14 +1,19 @@
 import { KeyManagementServiceClient } from "@google-cloud/kms";
 
-// KMS-backed encryption for POS OAuth tokens at rest — see the "OAuth
-// flow" section of docs/plans/2026-05-21-feature-set-purr-design.md.
-// Requires a real KMS key ring/key provisioned in the deploying GCP
-// project, with the Cloud Functions service account granted
+// KMS-backed encryption for OAuth tokens at rest, shared by both POS
+// (functions/src/pos/) and Calendar (functions/src/calendar/) — see
+// the "OAuth flow" sections of
+// docs/plans/2026-05-21-feature-set-purr-design.md. Requires a real
+// KMS key ring/key provisioned in the deploying GCP project, with the
+// Cloud Functions service account granted
 // roles/cloudkms.cryptoKeyEncrypterDecrypter on it, and
-// POS_KMS_KEY_NAME set to that key's full resource name
-// (projects/*/locations/*/keyRings/*/cryptoKeys/*). None of that
-// exists in this sandbox — encrypt/decrypt can't be exercised until
-// the user provisions the key post-merge.
+// POS_KMS_KEY_NAME (the one name, despite also covering Calendar —
+// renaming it is a bigger migration than it's worth) set to that
+// key's full resource name (projects/*/locations/*/keyRings/*/cryptoKeys/*).
+// See docs/deployment-env-vars.md for the full list this and every
+// other OAuth flow needs. None of it exists in this sandbox —
+// encrypt/decrypt can't be exercised until the user provisions the
+// key post-merge.
 const kmsClient = new KeyManagementServiceClient();
 
 function keyName(): string {

--- a/src/components/CalendarSettings.test.tsx
+++ b/src/components/CalendarSettings.test.tsx
@@ -35,6 +35,9 @@ function renderSettings(overrides: Partial<React.ComponentProps<typeof CalendarS
 describe('CalendarSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The feed URL is only ever shown once the deployment declares
+    // where /ical/** is actually reachable — see CalendarSettings.tsx.
+    vi.stubEnv('VITE_ICAL_FEED_BASE_URL', 'https://example.com');
   });
 
   it('shows a Connect button when Google is not connected', () => {
@@ -74,6 +77,13 @@ describe('CalendarSettings', () => {
     expect(screen.getByText(/\/ical\/bar-1\/abc123\.ics/)).toBeInTheDocument();
     expect(screen.getByText('Rotate')).toBeInTheDocument();
     expect(screen.getByText('Revoke')).toBeInTheDocument();
+  });
+
+  it('shows a not-configured message instead of a broken link when VITE_ICAL_FEED_BASE_URL is unset', () => {
+    vi.stubEnv('VITE_ICAL_FEED_BASE_URL', '');
+    renderSettings({ feedToken: 'abc123' });
+    expect(screen.getByText(/hasn't configured where the feed is actually served from/)).toBeInTheDocument();
+    expect(screen.queryByText('Rotate')).not.toBeInTheDocument();
   });
 
   it('calls onRotateFeedToken(true) for revoke and (false) for rotate', async () => {

--- a/src/components/CalendarSettings.tsx
+++ b/src/components/CalendarSettings.tsx
@@ -55,8 +55,16 @@ export function CalendarSettings({
     setCalendars(await onListGoogleCalendars());
   });
 
-  const feedUrl = feedToken
-    ? `${typeof window !== 'undefined' ? window.location.origin : ''}/ical/${barId}/${feedToken}.ics`
+  // window.location.origin is NOT a safe base here — the web client
+  // (GitHub Pages) and the icalFeed Cloud Function are two separate
+  // hosts unless VITE_ICAL_FEED_BASE_URL is explicitly configured to
+  // point at wherever /ical/** is actually reachable (a Firebase
+  // Hosting site with the rewrite in firebase.json, or the function's
+  // own Cloud Run URL). Without it, show that plainly instead of
+  // handing out a URL that looks valid but 404s.
+  const feedBaseUrl = import.meta.env.VITE_ICAL_FEED_BASE_URL;
+  const feedUrl = feedToken && feedBaseUrl
+    ? `${feedBaseUrl.replace(/\/$/, '')}/ical/${barId}/${feedToken}.ics`
     : null;
 
   const copyFeedUrl = () => {
@@ -102,6 +110,12 @@ export function CalendarSettings({
 
         <div className="border border-gray-800 rounded p-3 flex flex-col gap-2">
           <div className="text-xs font-bold text-gray-400 uppercase">Outbound iCal Feed</div>
+          {feedToken && !feedBaseUrl && (
+            <div className="text-xs text-yellow-500">
+              A feed token exists, but this deployment hasn't configured where the feed is actually
+              served from (VITE_ICAL_FEED_BASE_URL) — the link can't be shown until that's set.
+            </div>
+          )}
           {feedUrl ? (
             <>
               <div className="text-xs text-gray-400 break-all">{feedUrl}</div>
@@ -116,9 +130,11 @@ export function CalendarSettings({
               </div>
             </>
           ) : (
-            <md-filled-button disabled={busy || undefined} onClick={() => withBusy(() => onRotateFeedToken(false))}>
-              Generate Feed URL
-            </md-filled-button>
+            !feedToken && (
+              <md-filled-button disabled={busy || undefined} onClick={() => withBusy(() => onRotateFeedToken(false))}>
+                Generate Feed URL
+              </md-filled-button>
+            )
           )}
         </div>
 

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ChatPanel } from './ChatPanel';
 import { ChatMessage } from '../types';
@@ -83,19 +83,33 @@ describe('ChatPanel', () => {
     expect(mockOnTogglePin).toHaveBeenCalledWith('m1', true);
   });
 
-  it('sends a message and clears the input', () => {
+  it('sends a message and clears the input on success', async () => {
+    mockOnSend.mockResolvedValueOnce(undefined);
     const { container } = renderPanel();
     const input = container.querySelector('md-filled-text-field') as any;
     input.value = 'New message';
     fireEvent.input(input);
     fireEvent.click(screen.getByText('Send'));
     expect(mockOnSend).toHaveBeenCalledWith('New message', false);
+    await waitFor(() => expect((container.querySelector('md-filled-text-field') as any).value).toBe(''));
   });
 
   it('does not send a blank message', () => {
     renderPanel();
     fireEvent.click(screen.getByText('Send'));
     expect(mockOnSend).not.toHaveBeenCalled();
+  });
+
+  it('keeps the typed text and shows an error when the send fails', async () => {
+    mockOnSend.mockRejectedValueOnce(new Error('Missing or insufficient permissions.'));
+    const { container } = renderPanel();
+    const input = container.querySelector('md-filled-text-field') as any;
+    input.value = 'This should stick around';
+    fireEvent.input(input);
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => expect(screen.getByText('Missing or insufficient permissions.')).toBeInTheDocument());
+    expect((container.querySelector('md-filled-text-field') as any).value).toBe('This should stick around');
   });
 
   it('shows a "Load earlier messages" control only when hasMore is true', () => {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -18,7 +18,7 @@ interface ChatPanelProps {
   onLoadMore: () => void;
   currentUserId: string;
   isManagerPlus: boolean;
-  onSend: (text: string, pin: boolean) => void;
+  onSend: (text: string, pin: boolean) => Promise<void>;
   onTogglePin: (messageId: string, pin: boolean) => void;
   onDelete: (messageId: string) => void;
 }
@@ -34,6 +34,8 @@ export function ChatPanel({
 }: ChatPanelProps) {
   const [text, setText] = useState('');
   const [pinNext, setPinNext] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
 
@@ -51,12 +53,23 @@ export function ChatPanel({
     stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
   };
 
-  const handleSend = () => {
-    if (!text.trim()) return;
-    onSend(text, pinNext);
-    setText('');
-    setPinNext(false);
-    stickToBottomRef.current = true;
+  const handleSend = async () => {
+    if (!text.trim() || sending) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      await onSend(text, pinNext);
+      // Only clear the composer once the write actually lands — on
+      // failure (most commonly a rules rejection) the typed text
+      // stays put instead of silently vanishing as if it had sent.
+      setText('');
+      setPinNext(false);
+      stickToBottomRef.current = true;
+    } catch (e) {
+      setSendError(e instanceof Error ? e.message : 'Failed to send. Please try again.');
+    } finally {
+      setSending(false);
+    }
   };
 
   return (
@@ -110,6 +123,7 @@ export function ChatPanel({
             );
           })}
         </div>
+        {sendError && <div className="text-xs text-red-400 pt-1">{sendError}</div>}
         <div className="flex items-end gap-2 pt-3 border-t border-gray-800">
           <md-filled-text-field
             label="Message"
@@ -130,7 +144,9 @@ export function ChatPanel({
               <md-icon>push_pin</md-icon>
             </md-icon-button>
           )}
-          <md-filled-button onClick={handleSend}>Send</md-filled-button>
+          <md-filled-button disabled={sending || undefined} onClick={handleSend}>
+            {sending ? 'Sending…' : 'Send'}
+          </md-filled-button>
         </div>
       </div>
       <div slot="actions">

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -22,7 +22,12 @@ export function useCalendar({ barId, isManagerPlus }: UseCalendarArgs) {
   const [feedToken, setFeedToken] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!barId) { setEvents([]); return; }
+    // Cleared unconditionally so switching bars can't leave the
+    // previous bar's events rendering under the new bar's header if
+    // the new listener comes back permission-denied (e.g. the role
+    // claim hasn't been stamped onto the ID token yet).
+    setEvents([]);
+    if (!barId) return;
     const unsub = onSnapshot(
       query(collection(db, `bars/${barId}/events`), orderBy('start', 'asc')),
       (s) => setEvents(
@@ -34,7 +39,10 @@ export function useCalendar({ barId, isManagerPlus }: UseCalendarArgs) {
   }, [barId]);
 
   useEffect(() => {
-    if (!barId || !isManagerPlus) { setGoogleConnection(null); setICalSubscriptions([]); setFeedToken(null); return; }
+    setGoogleConnection(null);
+    setICalSubscriptions([]);
+    setFeedToken(null);
+    if (!barId || !isManagerPlus) return;
     const unsubConn = onSnapshot(
       doc(db, `bars/${barId}/calendarConnection/google`),
       (s) => setGoogleConnection(s.exists() ? { provider: 'google', ...s.data() } as CalendarConnectionStatus : null),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -67,7 +67,14 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
 
   // Pinned messages — always live while in a bar, drives the marquee.
   useEffect(() => {
-    if (!user || !barId) { setPinnedMessages([]); return; }
+    // Cleared unconditionally (not just on the no-bar branch below) so
+    // switching bars can't leave the previous bar's pinned messages
+    // rendering under the new bar's header — including the case where
+    // the new bar's listener comes back permission-denied (e.g. the
+    // role claim hasn't been stamped onto the ID token yet) and never
+    // delivers a snapshot to overwrite them.
+    setPinnedMessages([]);
+    if (!user || !barId) return;
     const unsub = onSnapshot(
       query(
         collection(db, `bars/${barId}/chat`),
@@ -85,7 +92,8 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
   // unread badge works even while the panel (and its full listener)
   // is closed.
   useEffect(() => {
-    if (!user || !barId) { setLatestMessageAt(0); return; }
+    setLatestMessageAt(0);
+    if (!user || !barId) return;
     const unsub = onSnapshot(
       query(collection(db, `bars/${barId}/chat`), orderBy('timestamp', 'desc'), limit(1)),
       (s) => {
@@ -112,9 +120,10 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
 
   // Full scrollback — only while the panel is open.
   useEffect(() => {
-    if (!user || !barId || !panelOpen) return;
+    setMessages([]);
     setOlderMessages([]);
     setHasMore(true);
+    if (!user || !barId || !panelOpen) return;
     const unsub = onSnapshot(
       query(collection(db, `bars/${barId}/chat`), orderBy('timestamp', 'desc'), limit(PAGE_SIZE)),
       (s) => setMessages(s.docs.map((d) => ({ id: d.id, ...d.data() } as ChatMessage)).reverse()),

--- a/src/hooks/usePOS.ts
+++ b/src/hooks/usePOS.ts
@@ -18,7 +18,11 @@ export function usePOS({ barId, isManagerPlus }: UsePOSArgs) {
   const [menu, setMenu] = useState<POSMenuItem[]>([]);
 
   useEffect(() => {
-    if (!barId || !isManagerPlus) { setConnections({}); return; }
+    // Cleared unconditionally so switching bars can't leave the
+    // previous bar's connection status rendering under the new bar's
+    // header if the new listener comes back permission-denied.
+    setConnections({});
+    if (!barId || !isManagerPlus) return;
     const unsub = onSnapshot(
       collection(db, `bars/${barId}/posConnection`),
       (s) => {
@@ -32,7 +36,8 @@ export function usePOS({ barId, isManagerPlus }: UsePOSArgs) {
   }, [barId, isManagerPlus]);
 
   useEffect(() => {
-    if (!barId || !isManagerPlus) { setMenu([]); return; }
+    setMenu([]);
+    if (!barId || !isManagerPlus) return;
     const unsub = onSnapshot(
       collection(db, `bars/${barId}/menu`),
       (s) => setMenu(s.docs.map((d) => ({ id: d.id, ...d.data() } as POSMenuItem))),

--- a/src/test/firestore-rules.test.ts
+++ b/src/test/firestore-rules.test.ts
@@ -14,6 +14,7 @@ import {
   deleteField,
   collection,
   addDoc,
+  serverTimestamp,
 } from 'firebase/firestore';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -159,42 +160,58 @@ describe('Firestore security rules', () => {
     it('rejects a create where authorId does not match auth.uid', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'spoof', authorId: BOB, authorName: 'Bob', authorRole: 'Staff', timestamp: new Date(), pinned: false,
+        text: 'spoof', authorId: BOB, authorName: 'Bob', authorRole: 'Staff', timestamp: serverTimestamp(), pinned: false,
       }));
     });
 
     it('rejects a create where authorName does not match the caller\'s own bar-user doc', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'spoof name', authorId: ALICE, authorName: 'Not Alice', authorRole: 'Staff', timestamp: new Date(), pinned: false,
+        text: 'spoof name', authorId: ALICE, authorName: 'Not Alice', authorRole: 'Staff', timestamp: serverTimestamp(), pinned: false,
       }));
     });
 
     it('rejects a create where authorRole does not match the caller\'s own bar-user doc', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'spoof role', authorId: ALICE, authorName: 'Alice', authorRole: 'Manager', timestamp: new Date(), pinned: false,
+        text: 'spoof role', authorId: ALICE, authorName: 'Alice', authorRole: 'Manager', timestamp: serverTimestamp(), pinned: false,
       }));
     });
 
     it('accepts an unpinned create where authorId/authorName/authorRole all match', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertSucceeds(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'hi', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff', timestamp: new Date(), pinned: false,
+        text: 'hi', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff', timestamp: serverTimestamp(), pinned: false,
       }));
     });
 
     it('rejects Staff creating a pre-pinned message', async () => {
       const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
       await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'pin me', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff', timestamp: new Date(), pinned: true,
+        text: 'pin me', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff', timestamp: serverTimestamp(), pinned: true,
       }));
     });
 
     it('allows Manager+ to create a pre-pinned message', async () => {
       const db = env.authenticatedContext(MANAGER, managerOf(BAR_A)).firestore();
       await assertSucceeds(addDoc(collection(db, `bars/${BAR_A}/chat`), {
-        text: 'announcement', authorId: MANAGER, authorName: 'M', authorRole: 'Manager', timestamp: new Date(), pinned: true,
+        text: 'announcement', authorId: MANAGER, authorName: 'M', authorRole: 'Manager', timestamp: serverTimestamp(), pinned: true,
+      }));
+    });
+
+    it('rejects a create with a client-supplied literal timestamp instead of serverTimestamp()', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
+      await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
+        text: 'spoofed time', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff',
+        timestamp: new Date('2099-01-01'), pinned: false,
+      }));
+    });
+
+    it('rejects a create with an extra field outside the allowed set', async () => {
+      const db = env.authenticatedContext(ALICE, staffOf(BAR_A)).firestore();
+      await assertFails(addDoc(collection(db, `bars/${BAR_A}/chat`), {
+        text: 'sneaky', authorId: ALICE, authorName: 'Alice', authorRole: 'Staff',
+        timestamp: serverTimestamp(), pinned: false, extra: 'field',
       }));
     });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,13 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_APP_ID: string
   readonly VITE_FIREBASE_VAPID_KEY: string
   readonly VITE_GOD_MODE_EMAIL: string
+  // Base URL the outbound iCal feed (functions/src/calendar/icalFeed.ts)
+  // is actually reachable at — e.g. a Firebase Hosting site with the
+  // /ical/** rewrite in firebase.json, or the icalFeed function's own
+  // Cloud Run URL. window.location.origin is NOT a safe default: the
+  // web client and the Cloud Functions deploy are two separate hosts
+  // (GitHub Pages + Cloud Functions/Cloud Run) unless this is set.
+  readonly VITE_ICAL_FEED_BASE_URL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Phase 2 (real chat), Phase 3 (POS integration), and Phase 4 (Google Calendar sync) shipped as PRs #290/#291/#292 without independent adversarial review. This PR runs that review (an adversarial `glee` audit) against the merged code and fixes all 18 CONFIRMED defects it found.

### Calendar sync correctness
- **`outboundSync.ts`**: guard `onEventWritten` with a before/after content comparison so its own `externalId`/`lastSyncedAt` write-back can't retrigger itself — this was an unbounded loop of Google API calls and Firestore writes for every locally-edited event.
- **`inboundSync.ts`**: stop re-stamping `externalProvider` on every update to an existing doc (only set it on creation), and clear `deletedAt` on upsert — editing a locally-created event in Google was permanently flipping it read-only for its own author.
- **`google.ts`**: page `listGoogleEventChanges` through `nextPageToken` instead of returning after the first page — large change sets were silently dropping events and discarding the `syncToken`. Anchor all-day (date-only) events to local midnight instead of passing the bare date through, which parses as UTC midnight and shows on the wrong day west of UTC. Add `stopGoogleChannel()` and call it from `calendarDisconnect` so a disconnected bar's push channel doesn't keep pinging the webhook.
- **`calendars.ts`**: import existing events immediately when a manager selects a calendar, instead of only after the next webhook fires.
- **`icalPoll.ts`**: validate the feed URL scheme and bound the fetch with a 15s timeout before parsing untrusted external content; clear `deletedAt` so an event that vanishes and reappears upstream isn't hidden forever.
- **`resubscribe.ts`**: renew watch channels daily instead of weekly, with a 3-day (not 2-day) margin — channels could go up to ~5 days unrenewed.
- **`shiftReminders.ts`**: widen the reminder window to match the 5-minute poll cadence so it can't skip shifts that fall between runs.

### Deployment topology
- **`firebase.json`**: add a Hosting rewrite for `/ical/**` to the `icalFeed` function.
- **`CalendarSettings.tsx`**: build the feed link from `VITE_ICAL_FEED_BASE_URL` instead of `window.location.origin`, which pointed at GitHub Pages rather than the separate Functions host and produced a link that always 404'd. Shows a "not configured" notice instead of a broken link when the env var is unset.
- **`DEPLOYMENT.md`**: document every required Cloud Functions env var (KMS key, Square/Google OAuth credentials, callback base URLs, the iCal feed base URL) — previously referenced only in code comments.

### Chat
- **`firestore.rules`**: lock chat message creation to an explicit field allowlist and require `timestamp == request.time`, closing off a client-spoofable timestamp that could corrupt sort order/unread state.
- **`ChatPanel.tsx`**: await the send, keep the typed text and show an error on failure instead of clearing input and silently dropping the message.
- **`onChatPinned.ts`**: skip the FCM push in `migrateNoticesToChat`'s backfill path (`pinnedAt` older than 5 minutes) so backfilling old notices doesn't blast a high-priority push to every device in the bar.

### Reliability / data hygiene
- **`index.ts`**: enable `ignoreUndefinedProperties` on the Admin Firestore instance — optional API fields (description, category) coming back `undefined` were crashing writes in 4 call sites.
- **`connection.ts`** (calendar + POS): catch token-refresh failures and mark the connection doc `{ connected: false, error }` instead of throwing into a void background call, so a broken sync is visible instead of showing a permanently-stale "Connected" badge.
- **`useChat.ts` / `useCalendar.ts` / `usePOS.ts`**: clear listener state before the `barId` early-return so switching bars can't leave the previous bar's data on screen.

### Not acted on
3 PLAUSIBLE (unverified) findings from the same audit — whether Square's `orders/search` needs explicit `location_ids`, whether Toast's `connect()` can return `connected:true` with an undefined token, and webhook channel token verification — none could be confirmed without live API credentials. OAuth/KMS/webhook flows generally still can't be exercised end-to-end outside a real Firebase project with `GOOGLE_CLIENT_ID`/`SECRET`, `SQUARE_CLIENT_ID`/`SECRET`, and `POS_KMS_KEY_NAME` provisioned.

## Test plan
- [x] `cd functions && npm run build` — clean
- [x] `cd functions && npm test` — 19/19 passing
- [x] `npx tsc --noEmit` (client) — clean
- [x] `npm run build` (client, full vite build) — clean
- [x] `npm test -- --run` (client jsdom suite) — 115/115 passing
- [x] `npm run test:rules` (Firestore rules emulator suite) — 92/92 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Address multiple adversarially-identified defects across calendar sync, chat, POS, and deployment to improve correctness, reliability, and visibility of failures.

New Features:
- Expose outbound iCal feed base URL as a configurable client-side environment variable so deployments can point the feed link at the correct host.
- Eagerly import existing Google Calendar events immediately after a manager selects a calendar to ensure historical events appear without waiting for a webhook.

Bug Fixes:
- Correct handling of Google all-day events by anchoring date-only values to local midnight to avoid off-by-one-day display issues in negative timezones.
- Ensure Google Calendar incremental sync iterates through all pages of changes before returning, preserving events and sync tokens across large change sets.
- Prevent calendar outbound sync triggers from retriggering themselves on bookkeeping-only writes by detecting real content changes before mirroring to Google.
- Stop Google Calendar push notification channels on disconnect so disconnected bars stop receiving webhook pings.
- Add URL scheme validation and bounded fetch timeouts to inbound iCal polling to avoid hanging on invalid or slow feeds, and clear stale soft-deletes when events reappear.
- Adjust shift reminder window to align with the 5-minute scheduler cadence so all shifts are reliably caught without double-sending.
- Surface POS and calendar OAuth token refresh failures by marking connections disconnected with an error instead of silently failing.
- Guard Google access token refresh with error reporting on the calendar connection document so managers can see when sync has died.
- Clear chat, calendar, and POS listener state when switching bars to avoid showing stale data from a previous bar in the UI.
- Require server-side timestamps and a strict field allowlist for chat message creation in Firestore rules to prevent client-spoofed timestamps and unexpected fields.
- Avoid sending backfill push notifications for migrated pinned messages by skipping pushes when pinnedAt is older than a small threshold.
- Build outbound calendar feed URLs from a configured base instead of window.location.origin and show a not-configured message when the base is missing, avoiding broken links.

Enhancements:
- Enable ignoreUndefinedProperties on the Admin Firestore instance so optional undefined fields from external APIs no longer crash writes.
- Document shared KMS-based encryption for OAuth tokens and clarify its configuration across POS and calendar flows.
- Improve deployment documentation with explicit Cloud Functions deployment steps and a full list of required environment variables for POS and Calendar OAuth and feeds.

Deployment:
- Prepare Firebase Hosting to serve outbound iCal feeds via a rewrite to the icalFeed Cloud Function, aligning client-generated URLs with the deployed topology.

Documentation:
- Expand deployment documentation with Cloud Functions deployment instructions, required environment variables for POS and Calendar OAuth and feeds, and clarification of Toast credentials.
- Clarify client-side configuration for the outbound calendar feed base URL in type definitions and tests to document its purpose and required setup.

Tests:
- Add unit tests for Google event patching, including correct handling of all-day events anchored to local midnight.
- Add unit tests for calendar outbound sync content-change detection to verify loop-prevention behavior.
- Extend Firestore rules tests to cover serverTimestamp requirements and allowed-field enforcement for chat messages.
- Update ChatPanel tests to cover async send behavior, input clearing on success, and error display on failure.
- Update CalendarSettings tests to stub the feed base URL and verify the not-configured notice when the base is unset.