### PR TITLE
Security/reliability hardening: fixes from 6-area adversarial audit

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -118,6 +118,7 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}
+          VITE_ICAL_FEED_BASE_URL: ${{ secrets.VITE_ICAL_FEED_BASE_URL }}
         run: npm run build
 
       - name: Sync Capacitor

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       issues: write
@@ -26,13 +27,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Inject ARCore API Key
-        env:
-          ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
-        run: |
-          # Inject ARCore API Key into local.properties for build.gradle.kts to pick up
-          echo "ARCORE_API_KEY=$ARCORE_API_KEY" >> local.properties
 
       - name: Generate Keystore from Secrets
         env:
@@ -69,8 +63,21 @@ jobs:
 
             # Clean up temporary files
             rm private_key.pem certificate_chain.crt keystore.p12
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # A push-to-main build is the one that gets published (see
+            # the RELEASE STEPS below) — silently falling back to a
+            # fresh debug keystore here means the APK is signed with a
+            # DIFFERENT key than whatever the previous release used
+            # (each CI run's default debug keystore is regenerated,
+            # not reused), which makes every existing installed copy
+            # fail INSTALL_FAILED_UPDATE_INCOMPATIBLE on the next
+            # update with no warning to anyone. A missing keystore
+            # secret on a release build must fail the build, not
+            # silently ship an unusable release.
+            echo "::error::KEYSTORE_PRIVATE is not set. Refusing to publish a release build signed with an ephemeral debug keystore — every existing install would fail to update. Set the KEYSTORE_* secrets, or don't push to main."
+            exit 1
           else
-            echo "Warning: KEYSTORE_PRIVATE secret is missing. Skipping custom keystore generation."
+            echo "Warning: KEYSTORE_PRIVATE secret is missing. Skipping custom keystore generation (fine for a non-release PR/branch build)."
           fi
 
       - name: Setup Node.js
@@ -130,6 +137,37 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x android/gradlew
 
+      - name: Compute Version
+        # Run BEFORE the Gradle build (not just before the release
+        # step, as this used to be computed) so the version actually
+        # baked into versionCode/versionName by android/app/build.gradle
+        # (see its defaultConfig block) is the same one used for the
+        # release artifact's filename/tag below — previously
+        # versionBuild was passed as a Gradle property but nothing in
+        # build.gradle ever read it, so every APK ever built reported
+        # versionCode 1 / versionName "1.0" regardless of which commit
+        # built it.
+        id: version
+        run: |
+          export BUILD_NUMBER=$(git rev-list --count HEAD)
+          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2)
+          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2)
+
+          # Calculate Patch version programmatically based on commits since Minor update
+          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
+          if [ -n "$MINOR_COMMIT" ]; then
+            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
+          else
+            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
+          fi
+
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
+          echo "VERSION_MAJOR=$MAJOR" >> $GITHUB_ENV
+          echo "VERSION_MINOR=$MINOR" >> $GITHUB_ENV
+          echo "VERSION_PATCH=$PATCH" >> $GITHUB_ENV
+          echo "VERSION_NAME=$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER" >> $GITHUB_ENV
+          echo "TAG_NAME=latest-debug-v${MAJOR}.${MINOR}" >> $GITHUB_ENV
+
       - name: Build with Gradle
         id: gradle-build
         env:
@@ -138,12 +176,12 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           set +e
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
+          VERSION_PROPS="-PversionMajor=$VERSION_MAJOR -PversionMinor=$VERSION_MINOR -PversionPatch=$VERSION_PATCH -PversionBuild=$BUILD_NUMBER"
+
           # Build the APK
           if [ -f "android/app/keystore.jks" ]; then
             echo "Building with custom keystore..."
-            ./android/gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache \
+            ./android/gradlew assembleDebug $VERSION_PROPS --build-cache \
               -Pandroid.injected.signing.store.file=$(pwd)/android/app/keystore.jks \
               -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
               -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
@@ -151,7 +189,7 @@ jobs:
               -p android > build.log 2>&1
           else
             echo "Building with default debug keystore..."
-            ./android/gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache -p android > build.log 2>&1
+            ./android/gradlew assembleDebug $VERSION_PROPS --build-cache -p android > build.log 2>&1
           fi
           
           EXIT_CODE=$?
@@ -199,30 +237,24 @@ jobs:
             }
 
       # ------------------------------------------------------------------
-      # RELEASE STEPS (Only run on PUSH, not Pull Requests)
+      # RELEASE STEPS — only for a push to main. Previously this was
+      # gated on `github.event_name == 'push'` alone, with no ref
+      # check — since the top-level trigger is `push: branches: ["**"]`
+      # (every branch, for the build+test signal), that meant pushing
+      # ANY branch — including an in-progress feature branch — force-
+      # moved the public "Latest Debug Build" release tag and
+      # overwrote its APK with whatever that branch's unreviewed
+      # commit produced.
       # ------------------------------------------------------------------
       - name: Prepare Release Variables
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: release_vars
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
-          # Extract version info from properties file
-          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2)
-          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2)
+          # VERSION_NAME/TAG_NAME come from the "Compute Version" step
+          # above (run before the Gradle build itself, so the version
+          # baked into the APK's versionCode/versionName matches what
+          # this step names the release artifact as).
 
-          # Calculate Patch version programmatically based on commits since Minor update
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
-          fi
-
-          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
-          
-          TAG_NAME="latest-debug-v${MAJOR}.${MINOR}"
-          
           # Dynamic App Name from settings.gradle
           if [ -f "android/settings.gradle.kts" ]; then
              APP_NAME=$(grep 'rootProject.name' android/settings.gradle.kts | sed -E "s/.*=.*[\"'](.*)[\"']/\1/")
@@ -231,31 +263,24 @@ jobs:
           else
              APP_NAME="App"
           fi
-          
+
           # Locate built APK
           APK_ORIGINAL=$(find android/app/build/outputs/apk/debug -name "*.apk" | head -n 1)
-          
+
           if [ -z "$APK_ORIGINAL" ]; then
              echo "Error: No APK found to release!"
              exit 1
           fi
 
           TARGET_NAME="${APP_NAME}-${VERSION_NAME}-debug.apk"
-          
+
           # Rename for release
           mv "$APK_ORIGINAL" "$TARGET_NAME"
-          
-          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+
           echo "APK_FILE=$TARGET_NAME" >> $GITHUB_ENV
-          
-          # Package Build Tools (Optional)
-          mkdir -p build_tools_package/tools build_tools_package/native
-          [ -d "app/src/main/assets/tools" ] && cp -r app/src/main/assets/tools/* build_tools_package/tools/ || true
-          [ -d "app/src/main/jniLibs/arm64-v8a" ] && cp -r app/src/main/jniLibs/arm64-v8a/* build_tools_package/native/ || true
-          cd build_tools_package && zip -r ../build-tools.zip . && cd ..
 
       - name: Publish Release
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -266,14 +291,9 @@ jobs:
           git tag -fa $TAG_NAME -m "Latest Debug Build"
           git push origin $TAG_NAME --force
 
-          BUILD_TOOLS="build-tools.zip"
-
           # Check if release exists
           if gh release view $TAG_NAME > /dev/null 2>&1; then
              echo "Updating existing release..."
-
-             # Clean up ONLY the build-tools asset to avoid conflicts
-             gh release delete-asset "$TAG_NAME" "$BUILD_TOOLS" -y || true
 
              gh release edit $TAG_NAME --prerelease \
                --title "Latest Debug Build ($TAG_NAME)" \
@@ -282,14 +302,10 @@ jobs:
 
              # Clobber ensures that if we re-run the workflow on the exact same commit, it replaces the APK instead of failing.
              gh release upload $TAG_NAME "$APK_FILE" --clobber
-             [ -f "$BUILD_TOOLS" ] && gh release upload $TAG_NAME "$BUILD_TOOLS" --clobber
           else
              echo "Creating new release..."
              gh release create $TAG_NAME "$APK_FILE" --prerelease \
                --title "Latest Debug Build ($TAG_NAME)" \
                --notes "Auto-build from commit $GITHUB_SHA" \
                --target $GITHUB_SHA
-             [ -f "$BUILD_TOOLS" ] && gh release upload $TAG_NAME "$BUILD_TOOLS" --clobber
           fi
-
-# Verified setup_libs.sh is not present

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   clear-cache:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Clear caches

--- a/.github/workflows/deduplicate.yml
+++ b/.github/workflows/deduplicate.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deduplicate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +33,36 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.create({
+            // This runs daily — without a dedupe check, an ongoing
+            // failure (expired secret, persistent bug) files a fresh
+            // duplicate issue every single day it stays broken. Reuse
+            // an existing open one instead, matching nag.yml's fix
+            // for the identical failure-reporting pattern.
+            const title = `Workflow Failed: ${context.workflow}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Workflow Failed: ${context.workflow}`,
-              body: `The workflow failed. See logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              assignees: ['Jules']
-            })
+              state: 'open',
+              labels: 'workflow-failure',
+            });
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The workflow failed. See logs: ${runUrl}`,
+                labels: ['workflow-failure'],
+                assignees: ['Jules'],
+              });
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,9 +21,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install
+        # npm ci (not npm install) so a package.json/package-lock.json
+        # drift fails the build loudly instead of npm silently
+        # rewriting the lockfile in-runner and shipping whatever
+        # dependency tree that produced.
+        run: npm ci
 
       - name: Build
         env:
@@ -33,6 +39,13 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}
+          # Not actually sensitive (see docs/DEPLOYMENT.md) — a repo
+          # secret is used here only for consistency with the VITE_
+          # vars above. Previously unset in every CI build, which
+          # meant the outbound iCal feed link was never shown in any
+          # deployed build regardless of whether it was configured
+          # server-side.
+          VITE_ICAL_FEED_BASE_URL: ${{ secrets.VITE_ICAL_FEED_BASE_URL }}
         run: npm run build
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/enrich-bars.yml
+++ b/.github/workflows/enrich-bars.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -34,10 +35,36 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.create({
+            // Runs every 6 hours (4x/day) — without a dedupe check, an
+            // ongoing failure (expired secret, persistent bug) files 4
+            // duplicate issues per day it stays broken. Reuse an
+            // existing open one instead, matching nag.yml's fix for
+            // the identical failure-reporting pattern.
+            const title = `Workflow Failed: ${context.workflow}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Workflow Failed: ${context.workflow}`,
-              body: `The workflow failed. See logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              assignees: ['Jules']
-            })
+              state: 'open',
+              labels: 'workflow-failure',
+            });
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The workflow failed. See logs: ${runUrl}`,
+                labels: ['workflow-failure'],
+                assignees: ['Jules'],
+              });
+            }

--- a/.github/workflows/jules-branch-handler.yml
+++ b/.github/workflows/jules-branch-handler.yml
@@ -5,11 +5,23 @@ on:
 
 jobs:
   manage_branch:
+    # SECURITY: issue_comment always runs in the base-repo context
+    # with full secrets access, even for a comment on a PR opened
+    # from a fork — unlike pull_request, there is no fork/base split
+    # here. Without an author_association check, ANY GitHub user could
+    # comment "@google-labs-jules" on any open PR (including a
+    # malicious fork's own PR) and hand this job's JULES_API_KEY/
+    # GH_TOKEN to an autonomous agent explicitly instructed to merge
+    # into the default branch. author_association is populated by
+    # GitHub itself from the commenter's actual repo permissions, not
+    # anything the commenter controls, so this can't be spoofed the
+    # way a body/actor-name check could be.
     if: |
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@google-labs-jules')) &&
       github.actor != 'google-labs-jules[bot]' && github.actor != 'google-labs-jules' &&
       github.actor != 'github-actions[bot]' && github.actor != 'github-actions' &&
-      !endsWith(github.actor, '[bot]')
+      !endsWith(github.actor, '[bot]') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/jules-branch-handler.yml
+++ b/.github/workflows/jules-branch-handler.yml
@@ -23,6 +23,7 @@ jobs:
       !endsWith(github.actor, '[bot]') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/jules-issue-handler.yml
+++ b/.github/workflows/jules-issue-handler.yml
@@ -20,6 +20,7 @@ jobs:
       !endsWith(github.actor, '[bot]') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/jules-issue-handler.yml
+++ b/.github/workflows/jules-issue-handler.yml
@@ -5,10 +5,20 @@ on:
 
 jobs:
   handle_issue:
+    # SECURITY: this workflow feeds the issue title/body directly into
+    # an autonomous coding agent's prompt (see below) and grants it
+    # issues:write. Without an author_association check, literally
+    # anyone who can open an issue on this public repo could steer
+    # that agent via prompt injection in the issue body — and, chained
+    # with jules-branch-handler.yml's merge-on-comment flow, turn that
+    # into an unauthorized merge to main. author_association reflects
+    # the issue author's actual repo permissions as GitHub itself
+    # computed them, not anything the author controls.
     if: |
       github.actor != 'google-labs-jules[bot]' && github.actor != 'google-labs-jules' &&
       github.actor != 'github-actions[bot]' && github.actor != 'github-actions' &&
-      !endsWith(github.actor, '[bot]')
+      !endsWith(github.actor, '[bot]') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nag.yml
+++ b/.github/workflows/nag.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   harass_users:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/rules-tests.yml
+++ b/.github/workflows/rules-tests.yml
@@ -1,4 +1,4 @@
-name: Firestore Rules Tests
+name: Rules and Functions Tests
 
 on:
   push:
@@ -12,6 +12,7 @@ permissions:
 jobs:
   rules:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -49,26 +50,31 @@ jobs:
       - name: Pre-download Firestore emulator JAR
         run: firebase setup:emulators:firestore
 
-      - name: Start Firestore emulator
-        # Background the emulator and wait for the port to open so we
-        # can see startup output in its own log file if it dies.
+      - name: Start Firestore + Storage emulators
+        # Background the emulators and wait for both ports to open so
+        # we can see startup output in its own log file if either
+        # dies. Storage is included alongside Firestore because
+        # src/test/storage-rules.test.ts needs it — storage.rules had
+        # a syntax error that silently made the whole file
+        # unenforceable for months, undetected precisely because no
+        # CI job had ever loaded it.
         shell: bash
         run: |
-          firebase emulators:start --only firestore --project barbacker-rules-test \
+          firebase emulators:start --only firestore,storage --project barbacker-rules-test \
             > emulator.log 2>&1 &
           echo $! > emulator.pid
           for i in $(seq 1 60); do
-            if (echo > /dev/tcp/127.0.0.1/8080) 2>/dev/null; then
-              echo "emulator up after ${i}s"
+            if (echo > /dev/tcp/127.0.0.1/8080) 2>/dev/null && (echo > /dev/tcp/127.0.0.1/9199) 2>/dev/null; then
+              echo "emulators up after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "emulator did not come up; tail of emulator.log:"
+          echo "emulators did not come up; tail of emulator.log:"
           tail -200 emulator.log
           exit 1
 
-      - name: Run Firestore rules tests
+      - name: Run Firestore + Storage rules tests
         run: npx vitest --run --config vitest.rules.config.ts
 
       - name: Stop emulator
@@ -80,3 +86,32 @@ jobs:
           fi
           echo "--- emulator.log tail ---"
           tail -200 emulator.log || true
+
+  # Nothing in CI previously built or tested functions/ at all — a
+  # type error or a broken test there could reach main green and only
+  # surface when someone ran a manual deploy. This doesn't need the
+  # emulators the `rules` job above does; it just needs the package to
+  # actually compile and its own unit tests to actually pass.
+  functions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check + build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,19 @@ android {
         applicationId "com.HereLiesAz.BarBacker"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        // build-mobile.yml's "Compute Version" step passes these as
+        // -P properties (versionBuild = total commit count, a
+        // monotonically increasing integer valid as versionCode).
+        // Previously these were hardcoded to 1/"1.0" — the workflow
+        // computed a real version but nothing here ever read it, so
+        // every APK ever built, regardless of commit, reported the
+        // same versionCode/versionName. Falls back to 1/"1.0-dev" for
+        // a plain local `./gradlew assembleDebug` with no properties
+        // passed, so local development builds still work.
+        versionCode project.hasProperty('versionBuild') ? (project.property('versionBuild') as Integer) : 1
+        versionName project.hasProperty('versionBuild')
+            ? "${project.property('versionMajor')}.${project.property('versionMinor')}.${project.property('versionPatch')}.${project.property('versionBuild')}"
+            : "1.0-dev"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,12 +4,18 @@ const config: CapacitorConfig = {
   appId: 'com.HereLiesAz.BarBacker',
   appName: 'barbacker',
   webDir: 'dist',
-  server: {
-    // Note: import.meta.env is Vite specific and may fail in Capacitor CLI context if not transpiled.
-    // Falling back to process.env or hardcoded for the config file.
-    url: 'https://hereliesaz.github.io/BarBacker/',
-    allowNavigation: ['hereliesaz.github.io']
-  }
+  // No `server.url` — that setting tells the WebView to navigate to a
+  // REMOTE origin at runtime instead of loading the bundled `webDir`
+  // assets, which is exactly what it was doing here (pointed at the
+  // GitHub Pages site). That made every APK content-identical
+  // regardless of which commit built it — `npx cap sync android`
+  // (build-mobile.yml) copied dist/ into the project for nothing,
+  // since it was never actually loaded — required network
+  // connectivity just to open the app at all (defeating the PWA
+  // offline-caching work), and meant a bad gh-pages deploy could
+  // break every already-installed APK instantly with no way to roll
+  // back independently of the web deploy. The app now loads its own
+  // bundled assets like a normal Capacitor app.
 };
 
 export default config;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -93,6 +93,25 @@ them in the browser. That first fetch needs outbound network access;
 everything after is served from cache. No env vars or server
 provisioning are required for this feature.
 
+## GitHub Actions CI secrets
+
+Every one of these is a repo secret (Settings → Secrets and variables
+→ Actions), consumed by the workflows in `.github/workflows/`. None
+of this was documented anywhere before — the table below is the full
+set as of this writing; re-grep `secrets\.[A-Z_0-9]*` across
+`.github/workflows/` if it's been a while, since nothing enforces this
+staying in sync.
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_STORAGE_BUCKET`, `VITE_FIREBASE_MESSAGING_SENDER_ID`, `VITE_FIREBASE_APP_ID`, `VITE_FIREBASE_VAPID_KEY` | `deploy.yml`, `build-mobile.yml` | Same Firebase Web SDK config used client-side (see `src/firebase.ts`) — injected as build-time env vars for both the web deploy and the Android web-asset build. |
+| `VITE_ICAL_FEED_BASE_URL` | `deploy.yml`, `build-mobile.yml` | See "Client-side env vars for the calendar feed" above. Not actually sensitive; kept as a secret only for consistency with the `VITE_FIREBASE_*` vars next to it. |
+| `KEYSTORE_PRIVATE`, `KEYSTORE_CHAIN`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` | `build-mobile.yml` | Android app-signing identity — a private key + certificate chain (PEM), reassembled into a JKS keystore at build time, plus the store/key passwords and alias. `KEY_PASSWORD` must equal `KEYSTORE_PASSWORD` — the keystore-generation step never sets a distinct key password, so the two secrets have to hold the same value despite being named separately. |
+| `FIREBASE_SERVICE_ACCOUNT` | `nag.yml`, `deduplicate.yml`, `enrich-bars.yml` | A full service-account JSON key (Admin SDK credential) for the scheduled maintenance scripts (`scripts/nag-bot.js`, `scripts/deduplicate.js`, `scripts/enrich-bars.js`) — a different credential mechanism than `set-admin-claim.js`'s `GOOGLE_APPLICATION_CREDENTIALS` (see docs/SCRIPTS.md). |
+| `JULES_API_KEY` | `jules-branch-handler.yml`, `jules-issue-handler.yml` | API key for the Jules autonomous coding agent (`google-labs-code/jules-action`). Both workflows are gated to repo owner/member/collaborator-authored comments and issues — see the SECURITY comments in those files. |
+| `GH_TOKEN` | `jules-branch-handler.yml` | A personal-access-token-scoped token distinct from the auto-provided `GITHUB_TOKEN`, used because Jules needs to merge PRs — `GITHUB_TOKEN` alone can be insufficient for that depending on branch protection settings. Broader-scoped than `GITHUB_TOKEN`; treat as sensitive as any other repo-write credential. |
+| `GITHUB_TOKEN` | `deploy.yml`, `build-mobile.yml`, `jules-issue-handler.yml` (via `secrets.GITHUB_TOKEN`, not listed above where it's `github-token:`) | Auto-provided by GitHub Actions per run — not something to set manually. |
+
 ## Android Deployment
 
 The Android application is a Capacitor wrapper around the web app.
@@ -103,7 +122,15 @@ The Android application is a Capacitor wrapper around the web app.
 *   Keystore file (for signing)
 
 ### Build Process (CI/CD)
-The `.github/workflows/build-mobile.yml` workflow handles this automatically on tag push or manual trigger.
+The `.github/workflows/build-mobile.yml` workflow runs on every push
+to any branch (for build/test signal on every commit) and on
+`workflow_dispatch` — there is no tag-based trigger at all. It
+computes its own version (`major.minor.patch.build`, from
+`version.properties` + commit count) and publishes that as a
+prerelease under a floating `latest-debug-v<major>.<minor>` tag it
+creates/force-moves itself, but ONLY when the push is to `main` and
+the build succeeded — every other branch just builds and tests
+without touching the public release.
 
 1.  **Environment Setup**: Installs Node, Java 21.
 2.  **Web Build**: Runs `npm run build`.
@@ -118,8 +145,10 @@ The `.github/workflows/build-mobile.yml` workflow handles this automatically on 
     ```bash
     cd android && ./gradlew assembleDebug
     ```
-6.  **Signing**: Signs the APK if a keystore is provided.
-7.  **Release**: Uploads the APK to GitHub Releases.
+6.  **Signing**: Signs the APK if `KEYSTORE_PRIVATE` is set — required
+    (the build fails otherwise) on a push to `main`, since that's the
+    build that gets published; optional elsewhere.
+7.  **Release**: On a successful push-to-`main` build only, uploads the APK to GitHub Releases.
 
 ### Manual Local Build
 1.  Ensure `dist/` is up to date: `npm run build`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,16 @@
 
 ## Web Deployment (GitHub Pages)
 
-The web application is hosted on GitHub Pages.
+The web application is hosted on GitHub Pages, deployed automatically
+by `.github/workflows/deploy.yml` on every push to `main` (via
+`peaceiris/actions-gh-pages`). The `npm run deploy` command below is
+the same thing run by hand — use it only for an out-of-band deploy,
+not as the normal path, and only with every `VITE_FIREBASE_*` env var
+set locally first (see "Required environment variables" below):
+`scripts/generate-sw.js` silently falls back to placeholder
+credentials for any that are missing, so a build without them
+succeeds but ships a service worker that can never receive push
+notifications.
 
 1.  **Build**:
     ```bash
@@ -20,13 +29,24 @@ The web application is hosted on GitHub Pages.
     ```
     This pushes the `dist` folder to the `gh-pages` branch.
 
-## Cloud Functions Deployment
+## Cloud Functions, Firestore Rules, and Storage Rules Deployment
 
-Not currently automated in CI — deploy manually from `functions/`:
+Not currently automated in CI — deploy manually. `firebase deploy`
+with no `--only` flag deploys functions, Firestore rules/indexes, and
+Storage rules together and is the simplest way to avoid the three
+drifting out of sync (e.g. shipping a Cloud Function that depends on a
+rules change without the rules change itself, which is exactly what
+would have happened deploying the bottle-scanner feature under the
+command this doc used to list here):
 ```bash
-cd functions && npm run build
-firebase deploy --only functions
+cd functions && npm run build && cd ..
+firebase deploy --only functions,firestore:rules,firestore:indexes,storage
 ```
+`firebase deploy --only functions` alone (the old instruction here)
+deploys functions ONLY — it does not touch `firestore.rules`,
+`firestore.indexes.json`, or `storage.rules`, even though all three
+are wired into `firebase.json` and any of them can change alongside
+a functions change.
 
 ### Required environment variables
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -25,3 +25,13 @@ The `scripts/` directory contains Node.js scripts used for build automation and 
 
 ## `debug-test.cjs`
 *   **Purpose**: A CommonJS script for testing the debugging utilities in a standalone node environment.
+
+## `set-admin-claim.js`
+*   **Purpose**: Grants or revokes the `admin: true` Firebase custom claim on a user — this is the ONLY way to create an admin. `firestore.rules` and `storage.rules` both gate moderation/bypass behavior on this claim (`isAdmin()`); a fresh Firebase project has zero admins until this script is run once against it.
+*   **Requires**: `GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account JSON key with the Firebase Admin role — a different credential mechanism than the `FIREBASE_SERVICE_ACCOUNT` JSON-in-a-secret used by the scheduled workflows (nag/deduplicate/enrich-bars) below. Run this locally, not in CI.
+*   **Usage**:
+    ```bash
+    node scripts/set-admin-claim.js --email owner@example.com
+    node scripts/set-admin-claim.js --uid abc123 --revoke
+    ```
+    The target user must sign out and back in (or wait up to an hour) for the claim to appear in their ID token.

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,20 @@
 {
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log",
+        "*.local"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ],
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
@@ -20,9 +36,17 @@
     ]
   },
   "emulators": {
+    "functions": {
+      "host": "127.0.0.1",
+      "port": 5001
+    },
     "firestore": {
       "host": "127.0.0.1",
       "port": 8080
+    },
+    "storage": {
+      "host": "127.0.0.1",
+      "port": 9199
     },
     "hub": {
       "host": "127.0.0.1",

--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,19 @@ service cloud.firestore {
         : '';
     }
 
+    // NOTE — accepted staleness window: every check below reads the
+    // ID token's cached `bars` claim, not a live per-bar membership
+    // doc. A kicked or demoted user's existing token keeps its old
+    // claim (and thus old access) until it's next refreshed —
+    // Firebase ID tokens refresh automatically roughly hourly, but
+    // there's no server-side push to invalidate one early. App.tsx
+    // already force-refreshes on the *grant* direction (joining/
+    // promotion take effect immediately); there is no equivalent for
+    // the *revoke* direction without moving authorization off custom
+    // claims entirely (e.g. a live doc read per request), which is a
+    // bigger change than this pass makes. This is the standard
+    // tradeoff of Firebase's custom-claims model, not unique to this
+    // app — see https://firebase.google.com/docs/auth/admin/custom-claims.
     function hasRole(barId) { return isAdmin() || roleIn(barId) != ''; }
     function isManagerPlus(barId) {
       return isAdmin() || roleIn(barId) in ['Manager', 'Owner'];
@@ -29,9 +42,18 @@ service cloud.firestore {
       return isAdmin() || roleIn(barId) == 'Owner';
     }
 
-    // Global /users/{userId} — self-only.
+    // Global /users/{userId} — self-only. `joinedBars` is capped —
+    // onUserRoleChange (Cloud Function) does an unbounded read per
+    // entry in this array on every write to this user's per-bar role
+    // doc, so an unbounded self-writable array here is a billing/cost
+    // amplification vector (write junk ids once, then any ordinary
+    // per-bar write, like a `lastSeen` heartbeat, triggers a fan-out
+    // read of all of them). 50 is far beyond any real person's bar
+    // count.
     match /users/{userId} {
-      allow read, write: if isAuthed() && request.auth.uid == userId;
+      allow read, delete: if isAuthed() && request.auth.uid == userId;
+      allow create, update: if isAuthed() && request.auth.uid == userId &&
+        (!('joinedBars' in request.resource.data) || request.resource.data.joinedBars.size() <= 50);
     }
 
     // Bar documents.
@@ -56,8 +78,17 @@ service cloud.firestore {
       // null == null holds, leaving it unset, and a Manager+ update
       // that tries to introduce/change ownerId is still rejected
       // since only one side would be non-null.
+      //
+      // `subscription` is protected the same way. Nothing in
+      // functions/ writes it today (billing isn't implemented — see
+      // the design doc's Task H1, never built), which means there is
+      // currently NO legitimate write path for it at all; leaving it
+      // unprotected let any Manager flip their own free bar to
+      // 'premium' and unlock every gated feature (theme, POS,
+      // calendar, private 86'd entries, bottle scanner) for free.
       allow update: if isManagerPlus(barId) &&
-        request.resource.data.get('ownerId', null) == resource.data.get('ownerId', null);
+        request.resource.data.get('ownerId', null) == resource.data.get('ownerId', null) &&
+        request.resource.data.get('subscription', null) == resource.data.get('subscription', null);
       // Any bar member (not just Manager+) may bump buttonUsage —
       // it's just per-button tap counts driving sort order, not
       // privileged config, and restricting it to Manager+ meant every
@@ -111,22 +142,30 @@ service cloud.firestore {
         // may only toggle between 'active' and 'off_clock' — this
         // lets a user clock in and back out on their own without
         // being able to self-approve out of 'pending'/'rejected'.
-        // ntfyTopic deliberately is NOT writable here (or readable —
-        // see the `read` rule above, which still exposes this whole
-        // doc to any hasRole() peer): it used to be mirrored onto this
-        // doc so client-side fanout could read every member's topic to
-        // compute who to notify, which is exactly what made it
-        // possible for any bar member to read (and keep, even after
-        // being kicked) a colleague's ntfy topic. Fanout is now
-        // server-side (onRequestCreated Cloud Function, Admin SDK),
-        // which reads the topic off the global users/{uid} doc instead
-        // — self-only, see that match block above.
+        // Both halves of the toggle require the OTHER state as the
+        // starting point (active->off_clock and off_clock->active
+        // only) — previously the off_clock transition was allowed
+        // from any starting status with no check on resource.data.status
+        // at all, so a self-created 'pending' (or Manager-'rejected')
+        // doc could self-write to 'off_clock' and then, via the other
+        // clause below, straight to 'active' — a two-write bypass of
+        // the entire approval join policy. ntfyTopic deliberately is
+        // NOT writable here (or readable — see the `read` rule above,
+        // which still exposes this whole doc to any hasRole() peer):
+        // it used to be mirrored onto this doc so client-side fanout
+        // could read every member's topic to compute who to notify,
+        // which is exactly what made it possible for any bar member
+        // to read (and keep, even after being kicked) a colleague's
+        // ntfy topic. Fanout is now server-side (onRequestCreated
+        // Cloud Function, Admin SDK), which reads the topic off the
+        // global users/{uid} doc instead — self-only, see that match
+        // block above.
         allow write: if isAuthed() && request.auth.uid == userId &&
           request.resource.data.diff(resource.data).affectedKeys()
             .hasOnly(['displayName', 'lastSeen', 'notificationPreferences',
                       'email', 'status', 'jobTitle']) &&
           (!('status' in request.resource.data.diff(resource.data).affectedKeys()) ||
-           request.resource.data.status == 'off_clock' ||
+           (request.resource.data.status == 'off_clock' && resource.data.status == 'active') ||
            (request.resource.data.status == 'active' && resource.data.status == 'off_clock'));
 
         // Managers can flip pending → active, set role/jobTitle for
@@ -202,7 +241,18 @@ service cloud.firestore {
         // moderator-only notes about patrons. The UI also hides the
         // "private" toggle when isPremium is false, but the rules
         // are the authority. Admins (isAdmin) bypass via isManagerPlus.
+        //
+        // submittedBy/submitterName are bound to the caller's own uid
+        // and their own per-bar displayName (not client-asserted) —
+        // previously either could be set to anything, so a Manager
+        // could forge the bar's moderation log to attribute a ban to
+        // a colleague (or the Owner) instead of themselves.
         allow create: if isManagerPlus(barId)
+          && request.resource.data.keys().hasOnly(['patronName', 'submittedBy', 'submitterName', 'visibility', 'reason', 'timestamp'])
+          && request.resource.data.submittedBy == request.auth.uid
+          && request.resource.data.submitterName ==
+               get(/databases/$(database)/documents/bars/$(barId)/users/$(request.auth.uid)).data.get('displayName', '')
+          && request.resource.data.timestamp == request.time
           && (request.resource.data.visibility == 'public'
               || (request.resource.data.visibility == 'private'
                   && (isAdmin()
@@ -223,8 +273,20 @@ service cloud.firestore {
                        (isAuthed() && request.auth.token.email_verified == true &&
                         resource.data.email == request.auth.token.email);
         allow create: if isManagerPlus(barId);
+        // Consumption must be a one-way false -> true transition by
+        // the invitee themselves. Previously `consumed` had no
+        // constraint on its prior value and `consumedBy` was never
+        // checked against the caller at all — an invitee could flip
+        // consumed back to false and reconsume the same invite
+        // indefinitely with an attacker-chosen consumedBy uid, and
+        // onInviteConsumed (Cloud Function) grants that invite's role
+        // to whichever uid the write named, e.g. the bar's Owner.
         allow update: if isAuthed() && request.auth.token.email_verified == true &&
                         resource.data.email == request.auth.token.email &&
+                        resource.data.consumed == false &&
+                        request.resource.data.consumed == true &&
+                        request.resource.data.consumedBy == request.auth.uid &&
+                        request.resource.data.consumedAt == request.time &&
                         request.resource.data.diff(resource.data).affectedKeys()
                           .hasOnly(['consumed', 'consumedBy', 'consumedAt']);
         allow delete: if isManagerPlus(barId);
@@ -334,10 +396,37 @@ service cloud.firestore {
     // Requests — top-level collection, scoped by barId field.
     match /requests/{requestId} {
       allow read: if isAuthed() && hasRole(resource.data.barId);
+      // requesterName/requesterRole are bound to the caller's own
+      // per-bar user doc (like chat's authorName/authorRole) rather
+      // than trusted as client-asserted strings — previously a
+      // member could forge either (e.g. requesterName: "Eve (Owner)")
+      // and have it broadcast verbatim through onRequestCreated's
+      // FCM/ntfy push to the whole bar. timestamp/lastNotification
+      // must be the serverTimestamp() sentinel so a client can't pin
+      // a forged request atop the feed with a future date, or force
+      // an immediate nag-bot re-notify with a stale one. The field
+      // allowlist and photoUrl type check close off arbitrary extra
+      // fields — photoUrl in particular is rendered as a raw
+      // `<img src>` on every other member's device (see App.tsx),
+      // so an unconstrained string there was an open tracking-pixel/
+      // IP-collection vector.
       allow create: if isAuthed()
         && hasRole(request.resource.data.barId)
         && request.resource.data.requesterId == request.auth.uid
-        && request.resource.data.status == 'pending';
+        && request.resource.data.status == 'pending'
+        && request.resource.data.keys().hasOnly([
+             'barId', 'label', 'requesterId', 'requesterName', 'requesterRole',
+             'status', 'timestamp', 'lastNotification', 'buttonId', 'photoUrl'
+           ])
+        && request.resource.data.label is string
+        && request.resource.data.label.size() > 0 && request.resource.data.label.size() <= 500
+        && request.resource.data.requesterName ==
+             get(/databases/$(database)/documents/bars/$(request.resource.data.barId)/users/$(request.auth.uid)).data.get('displayName', '')
+        && request.resource.data.requesterRole ==
+             get(/databases/$(database)/documents/bars/$(request.resource.data.barId)/users/$(request.auth.uid)).data.get('role', '')
+        && request.resource.data.timestamp == request.time
+        && request.resource.data.lastNotification == request.time
+        && (!('photoUrl' in request.resource.data) || request.resource.data.photoUrl is string);
       // The only client-side update is claiming: pending -> claimed,
       // touching only the claim fields, with barId/requesterId/label
       // immutable so a member of one bar can't rewrite a request into

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
-    "deploy": "firebase deploy --only functions",
+    "deploy": "firebase deploy --only functions,firestore:rules,firestore:indexes,storage",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {

--- a/functions/src/__tests__/notifyEligibility.test.ts
+++ b/functions/src/__tests__/notifyEligibility.test.ts
@@ -36,4 +36,14 @@ describe("shouldNotifyMember", () => {
     expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "active", jobTitle: "Server" }, "me")).toBe(false);
     expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "active", jobTitle: "Bartender" }, "me")).toBe(true);
   });
+
+  // Regression: onInviteConsumed.ts sets jobTitle:'Staff' for an
+  // invited member who hasn't picked a title yet. 'Staff' used to be
+  // absent from ROLE_NOTIFICATION_DEFAULTS, so the fallback chain
+  // landed on [] and every invited member was notified about nothing,
+  // ever, until they manually visited Notification Settings.
+  it("falls back to a real default set (not []) for jobTitle 'Staff'", () => {
+    expect(shouldNotifyMember({ buttonId: "ice", label: "ICE" }, { id: "them", status: "active", jobTitle: "Staff" }, "me")).toBe(true);
+    expect(shouldNotifyMember({ buttonId: "break", label: "BREAK" }, { id: "them", status: "active", jobTitle: "Staff" }, "me")).toBe(true);
+  });
 });

--- a/functions/src/__tests__/onRequestCreated.test.ts
+++ b/functions/src/__tests__/onRequestCreated.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { chunk } from "../onRequestCreated";
+
+// sendEachForMulticast throws SYNCHRONOUSLY (not a rejected promise)
+// above 500 tokens — chunk() is what keeps a bar with more devices
+// than that from losing FCM entirely. See onRequestCreated.ts's
+// FCM_BATCH_SIZE comment.
+
+describe("chunk", () => {
+  it("returns a single batch when under the size limit", () => {
+    expect(chunk([1, 2, 3], 500)).toEqual([[1, 2, 3]]);
+  });
+
+  it("splits exactly at the boundary with no empty trailing batch", () => {
+    const items = Array.from({ length: 500 }, (_, i) => i);
+    expect(chunk(items, 500)).toHaveLength(1);
+  });
+
+  it("splits into multiple batches when over the size limit", () => {
+    const items = Array.from({ length: 1001 }, (_, i) => i);
+    const batches = chunk(items, 500);
+    expect(batches).toHaveLength(3);
+    expect(batches[0]).toHaveLength(500);
+    expect(batches[1]).toHaveLength(500);
+    expect(batches[2]).toHaveLength(1);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(chunk([], 500)).toEqual([]);
+  });
+});

--- a/functions/src/__tests__/onUserRoleChange.test.ts
+++ b/functions/src/__tests__/onUserRoleChange.test.ts
@@ -25,4 +25,46 @@ describe("computeClaimsForUser", () => {
   it("returns empty object when user has no bars", () => {
     expect(computeClaimsForUser([])).toEqual({ bars: {} });
   });
+
+  // Security-critical: a 'pending' or 'rejected' doc must not grant
+  // any claim for that bar. Before this filter existed, a self-created
+  // 'pending' membership got the full Staff claim immediately — see
+  // the comment on UNAPPROVED_STATUSES in onUserRoleChange.ts.
+  it("excludes a bar whose doc has status 'pending'", () => {
+    expect(computeClaimsForUser([
+      { barId: "bar_A", role: "Staff", status: "pending" },
+    ])).toEqual({ bars: {} });
+  });
+
+  it("excludes a bar whose doc has status 'rejected'", () => {
+    expect(computeClaimsForUser([
+      { barId: "bar_A", role: "Staff", status: "rejected" },
+    ])).toEqual({ bars: {} });
+  });
+
+  it("includes a bar whose doc has status 'active'", () => {
+    expect(computeClaimsForUser([
+      { barId: "bar_A", role: "Staff", status: "active" },
+    ])).toEqual({ bars: { bar_A: "Staff" } });
+  });
+
+  it("includes a bar whose doc has status 'off_clock' (approved, just not on shift)", () => {
+    expect(computeClaimsForUser([
+      { barId: "bar_A", role: "Staff", status: "off_clock" },
+    ])).toEqual({ bars: { bar_A: "Staff" } });
+  });
+
+  it("includes a bar whose doc has no status at all (legacy/undefined)", () => {
+    expect(computeClaimsForUser([{ barId: "bar_A", role: "Manager" }]))
+      .toEqual({ bars: { bar_A: "Manager" } });
+  });
+
+  it("filters pending/rejected bars independently across a mixed set", () => {
+    expect(computeClaimsForUser([
+      { barId: "bar_A", role: "Staff", status: "active" },
+      { barId: "bar_B", role: "Manager", status: "pending" },
+      { barId: "bar_C", role: "Owner", status: "rejected" },
+      { barId: "bar_D", role: "Staff", status: "off_clock" },
+    ])).toEqual({ bars: { bar_A: "Staff", bar_D: "Staff" } });
+  });
 });

--- a/functions/src/__tests__/ownershipClaims.test.ts
+++ b/functions/src/__tests__/ownershipClaims.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { canReviewClaim } from "../ownershipClaims";
+
+describe("canReviewClaim", () => {
+  // Security-critical: this is the fix for a real exploit — a Manager
+  // could file an ownership claim against their own bar and then
+  // approve it themselves, becoming Owner and demoting the real
+  // Owner, with nothing else in reviewOwnershipClaim checking that
+  // the reviewer and the claimant were different people.
+  it("denies a Manager reviewing their own claim", () => {
+    expect(canReviewClaim("mgr_1", "mgr_1", "Manager", false)).toBe(false);
+  });
+
+  it("denies an Owner reviewing their own claim", () => {
+    expect(canReviewClaim("owner_1", "owner_1", "Owner", false)).toBe(false);
+  });
+
+  it("denies an admin reviewing their own claim", () => {
+    expect(canReviewClaim("admin_1", "admin_1", undefined, true)).toBe(false);
+  });
+
+  it("allows a Manager reviewing someone else's claim", () => {
+    expect(canReviewClaim("mgr_1", "staff_2", "Manager", false)).toBe(true);
+  });
+
+  it("allows an Owner reviewing someone else's claim", () => {
+    expect(canReviewClaim("owner_1", "staff_2", "Owner", false)).toBe(true);
+  });
+
+  it("allows an admin reviewing anyone else's claim regardless of per-bar role", () => {
+    expect(canReviewClaim("admin_1", "staff_2", undefined, true)).toBe(true);
+  });
+
+  it("denies Staff (not Manager+) reviewing someone else's claim", () => {
+    expect(canReviewClaim("staff_1", "staff_2", "Staff", false)).toBe(false);
+  });
+
+  it("denies someone with no role at all", () => {
+    expect(canReviewClaim("outsider_1", "staff_2", undefined, false)).toBe(false);
+  });
+});

--- a/functions/src/migrateNoticesToChat.ts
+++ b/functions/src/migrateNoticesToChat.ts
@@ -6,11 +6,24 @@ const BATCH_SIZE = 400;
 // One-shot migration of a bar's old notices (bulletin board) into the
 // new chat collection, as pinned messages — see the "Migration"
 // section of docs/plans/2026-05-21-feature-set-purr-design.md. The
-// client calls this once, lazily, the first time any member of a bar
-// opens the chat panel (see useChat.ts); idempotency is enforced here
-// via a transaction that claims bars/{barId}.chatMigratedAt, so a
-// second call (e.g. two staff opening chat around the same moment)
-// is a cheap no-op rather than a duplicate copy.
+// client calls this on bar entry (see useChat.ts).
+//
+// chatMigratedAt is set ONLY after every batch has committed
+// successfully — not claimed up front. Claiming it first (the
+// previous approach) meant a mid-migration failure on a large bar
+// (deadline exceeded, transient UNAVAILABLE) left the flag set with
+// only some notices copied: every retry would then see the flag,
+// return early, and the remaining notices would be permanently
+// unreachable — firestore.rules has no match block for `notices` at
+// all (default deny) and the client's notice reader was removed when
+// chat replaced it, so there was no path back to them. This ordering
+// trades that unrecoverable data loss for a much milder race: two
+// staff opening chat in the same instant could both pass the
+// up-front check and copy the same notices twice, producing duplicate
+// (but still visible and manually deletable) pinned messages — a
+// realistic-enough scenario to accept given how rarely two people
+// open a bar's chat for the very first time in the same millisecond,
+// against a failure mode that is silent and permanent.
 //
 // The old notices schema never captured a role snapshot, so migrated
 // messages get authorRole: '' — they just render without a role badge
@@ -33,14 +46,9 @@ export const migrateNoticesToChat = onCall(async (request) => {
   const db = getFirestore();
   const barRef = db.doc(`bars/${barId}`);
 
-  const claimed = await db.runTransaction(async (tx) => {
-    const barDoc = await tx.get(barRef);
-    if (!barDoc.exists) throw new HttpsError("not-found", "Bar not found.");
-    if (barDoc.data()?.chatMigratedAt) return false;
-    tx.set(barRef, { chatMigratedAt: FieldValue.serverTimestamp() }, { merge: true });
-    return true;
-  });
-  if (!claimed) return { migrated: false, count: 0 };
+  const barDoc = await barRef.get();
+  if (!barDoc.exists) throw new HttpsError("not-found", "Bar not found.");
+  if (barDoc.data()?.chatMigratedAt) return { migrated: false, count: 0 };
 
   const noticesSnap = await db.collection(`bars/${barId}/notices`).get();
   let count = 0;
@@ -65,5 +73,6 @@ export const migrateNoticesToChat = onCall(async (request) => {
     await batch.commit();
   }
 
+  await barRef.set({ chatMigratedAt: FieldValue.serverTimestamp() }, { merge: true });
   return { migrated: true, count };
 });

--- a/functions/src/notifyEligibility.ts
+++ b/functions/src/notifyEligibility.ts
@@ -10,6 +10,11 @@ export const ROLE_NOTIFICATION_DEFAULTS: Record<string, string[]> = {
   Server: [],
   Runner: ['ice', 'glass', 'restock', 'mixers', 'restock_beer'],
   Security: ['security', 'manager', 'break'],
+  // See src/constants.ts's copy for why this exists — onInviteConsumed.ts
+  // sets jobTitle to literally 'Staff' for an invited member with no
+  // title picked yet, and without an entry here that member matched
+  // nothing and got zero notifications.
+  Staff: ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer', 'break'],
 };
 
 export interface NotifiableRequest {

--- a/functions/src/onRequestCreated.ts
+++ b/functions/src/onRequestCreated.ts
@@ -5,6 +5,19 @@ import { shouldNotifyMember, BarMember, NotifiableRequest } from "./notifyEligib
 
 const NTFY_CONCURRENCY = 5;
 
+// getMessaging().sendEachForMulticast() throws SYNCHRONOUSLY (not a
+// rejected promise) when given more than this many tokens — chunking
+// avoids that entirely, rather than just catching it, so a bar with
+// more devices than the limit still gets paged instead of silently
+// losing every notification channel at once.
+const FCM_BATCH_SIZE = 500;
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
 // Runs `items` through `fn` with at most `concurrency` in flight at
 // once. functions/ is a separate TS project from src/ (no shared
 // build step), so this is a minimal standalone copy of the same
@@ -68,29 +81,51 @@ export const onRequestCreated = onDocumentCreated("requests/{requestId}", async 
     .map((d) => d.data().token)
     .filter((t): t is string => !!t);
 
+  // Each batch's send is wrapped in its own try/catch (not a bare
+  // .catch() on the call expression) specifically because
+  // sendEachForMulticast throws synchronously rather than returning a
+  // rejected promise when a batch is malformed — a bare .catch() on
+  // the call site would never even attach, since the throw happens
+  // before sendEachForMulticast returns anything to call .catch() on.
   const fcmPromise = tokens.length > 0
-    ? getMessaging().sendEachForMulticast({
-        tokens,
-        notification: { title: "BarBacker Alert", body },
-        data: { type: "new_request", barId },
-        android: { priority: "high", notification: { sound: "default", channelId: "urgent_alerts" } },
-        apns: { payload: { aps: { sound: "default", "content-available": 1 } } },
-      }).catch((e) => { console.error("FCM send failed", e); })
+    ? Promise.all(chunk(tokens, FCM_BATCH_SIZE).map(async (batchTokens) => {
+        try {
+          await getMessaging().sendEachForMulticast({
+            tokens: batchTokens,
+            notification: { title: "BarBacker Alert", body },
+            data: { type: "new_request", barId },
+            android: { priority: "high", notification: { sound: "default", channelId: "urgent_alerts" } },
+            apns: { payload: { aps: { sound: "default", "content-available": 1 } } },
+          });
+        } catch (e) {
+          console.error("FCM send failed", e);
+        }
+      }))
     : Promise.resolve();
 
   // ntfy push (iOS / web). The topic lives on the global users/{uid}
   // doc (self-only per firestore.rules), not mirrored per-bar, so
-  // it's looked up per eligible member here.
+  // it's looked up per eligible member here. The doc read and the
+  // fetch are both inside the try/catch — previously the read sat
+  // outside it, so one transient failure reading a single member's
+  // doc threw out of withConcurrency's worker loop entirely, silently
+  // abandoning whatever other members that same worker still had left
+  // to notify. fetch() also doesn't reject on an HTTP error status
+  // (429 rate-limited, 5xx, etc.), so a failed ntfy send used to look
+  // identical to a successful one — nothing checked response.ok.
   const ntfyPromise = withConcurrency(eligible, NTFY_CONCURRENCY, async (member) => {
-    const userDoc = await db.doc(`users/${member.id}`).get();
-    const topic = userDoc.data()?.ntfyTopic;
-    if (!topic) return;
     try {
-      await fetch(`https://ntfy.sh/${topic}`, {
+      const userDoc = await db.doc(`users/${member.id}`).get();
+      const topic = userDoc.data()?.ntfyTopic;
+      if (!topic) return;
+      const response = await fetch(`https://ntfy.sh/${topic}`, {
         method: "POST",
         body,
         headers: { Title: "BarBacker Alert", Priority: "high", Tags: "bell,bar_chart" },
       });
+      if (!response.ok) {
+        console.error(`ntfy send to ${member.id} failed: HTTP ${response.status}`);
+      }
     } catch (e) {
       console.error(`Failed to send ntfy to ${member.id}`, e);
     }

--- a/functions/src/onUserRoleChange.ts
+++ b/functions/src/onUserRoleChange.ts
@@ -1,11 +1,31 @@
 import * as admin from "firebase-admin";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 
-type UserRoleDoc = { barId: string; role: string };
+type UserRoleDoc = { barId: string; role: string; status?: string };
+
+// Statuses that must NOT translate into a live claim. 'pending' means
+// a Manager hasn't approved the join yet (joinPolicy: 'approval');
+// 'rejected' means one explicitly declined it. Every other status
+// ('active', 'off_clock', or historically undefined/legacy docs) is
+// treated as a real member — off_clock is just "not currently on
+// shift", not "not approved".
+//
+// This distinction is security-critical: firestore.rules' hasRole()/
+// isManagerPlus() read ONLY this claim, never the live per-bar doc,
+// so before this filter existed, self-creating a 'pending' doc (which
+// any signed-in user can do — see firestore.rules' self-create rule)
+// granted full read/write access to that bar's chat, roster (with
+// emails), requests, and 86'd list immediately, before any Manager
+// ever saw the approval prompt. joinPolicy:'approval' was gating only
+// what the UI *rendered*, not what the backend actually allowed.
+const UNAPPROVED_STATUSES = new Set(["pending", "rejected"]);
 
 export function computeClaimsForUser(docs: UserRoleDoc[]): { bars: Record<string, string> } {
   const bars: Record<string, string> = {};
-  for (const d of docs) bars[d.barId] = d.role;
+  for (const d of docs) {
+    if (d.status !== undefined && UNAPPROVED_STATUSES.has(d.status)) continue;
+    bars[d.barId] = d.role;
+  }
   return { bars };
 }
 
@@ -20,6 +40,8 @@ export function computeClaimsForUser(docs: UserRoleDoc[]): { bars: Record<string
  *     drops out of the aggregated map).
  *   - The triggering `barId` is always included in the enumeration so that
  *     races against `users/{uid}.joinedBars` writes do not produce stale claims.
+ *   - A doc with status 'pending' or 'rejected' contributes NO claim at
+ *     all for that bar — see computeClaimsForUser above.
  */
 export const onUserRoleChange = onDocumentWritten(
   "bars/{barId}/users/{userId}",
@@ -34,8 +56,9 @@ export const onUserRoleChange = onDocumentWritten(
     await Promise.all(barIds.map(async (barId) => {
       const u = await db.doc(`bars/${barId}/users/${userId}`).get();
       const role = u.data()?.role;
+      const status = u.data()?.status;
       if (u.exists && typeof role === "string") {
-        docs.push({ barId, role });
+        docs.push({ barId, role, status: typeof status === "string" ? status : undefined });
       }
     }));
     const { bars } = computeClaimsForUser(docs);

--- a/functions/src/ownershipClaims.ts
+++ b/functions/src/ownershipClaims.ts
@@ -1,6 +1,21 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 
+// Pure decision logic for reviewOwnershipClaim, extracted so it's
+// directly unit-testable without mocking the Admin SDK. Manager+ (or
+// admin) may review, EXCEPT the claimant reviewing their own claim —
+// see the comment at its call site in reviewOwnershipClaim for why
+// this can't just be "Owner-only" instead.
+export function canReviewClaim(
+  reviewerUid: string,
+  claimantId: string,
+  reviewerRole: string | undefined,
+  isAdmin: boolean
+): boolean {
+  if (reviewerUid === claimantId) return false;
+  return isAdmin || reviewerRole === "Owner" || reviewerRole === "Manager";
+}
+
 // ownershipClaims is `allow write: if false` in firestore.rules —
 // writes flow through these two callables only, which is what the
 // rules comment on that collection has always claimed but nothing
@@ -72,9 +87,6 @@ export const reviewOwnershipClaim = onCall(async (request) => {
   const barsClaims = (auth.token.bars as Record<string, string> | undefined) ?? {};
   const isAdmin = auth.token.admin === true;
   const role = barsClaims[barId];
-  if (!isAdmin && role !== "Owner" && role !== "Manager") {
-    throw new HttpsError("permission-denied", "Only a Manager or Owner of this bar can review claims.");
-  }
 
   const db = getFirestore();
   const claimRef = db.doc(`bars/${barId}/ownershipClaims/${claimId}`);
@@ -83,6 +95,19 @@ export const reviewOwnershipClaim = onCall(async (request) => {
   const claim = claimDoc.data()!;
   if (claim.status !== "pending") {
     throw new HttpsError("failed-precondition", "This claim was already reviewed.");
+  }
+  // Blocks a reviewer approving their own claim — file one as a
+  // Manager, then immediately approve it, and you're Owner with the
+  // real Owner demoted — as well as anyone who isn't Manager+/admin.
+  // See canReviewClaim's comment for why this is "not the claimant"
+  // rather than "must be Owner".
+  if (!canReviewClaim(auth.uid, claim.claimantId, role, isAdmin)) {
+    throw new HttpsError(
+      "permission-denied",
+      claim.claimantId === auth.uid
+        ? "You cannot review your own ownership claim."
+        : "Only a Manager or Owner of this bar can review claims."
+    );
   }
 
   if (!approve) {
@@ -98,16 +123,27 @@ export const reviewOwnershipClaim = onCall(async (request) => {
   const barDoc = await barRef.get();
   const previousOwnerId = barDoc.data()?.ownerId as string | undefined;
 
+  // The claimant may already be a member here (the comment above this
+  // function calls that out explicitly — "a real owner reclaiming a
+  // bar staff set up" doesn't necessarily mean they're new to it).
+  // Preserve their existing joinedAt instead of always stamping now,
+  // the same way onInviteConsumed.ts already does for the equivalent
+  // case — otherwise an existing long-tenured member who wins an
+  // ownership claim has their join date silently reset to today.
+  const claimantRef = db.doc(`bars/${barId}/users/${claim.claimantId}`);
+  const existingClaimantDoc = await claimantRef.get();
+  const existingJoinedAt = existingClaimantDoc.data()?.joinedAt;
+
   const batch = db.batch();
   batch.update(barRef, { ownerId: claim.claimantId });
   batch.set(
-    db.doc(`bars/${barId}/users/${claim.claimantId}`),
+    claimantRef,
     {
       role: "Owner",
       jobTitle: "Owner",
       status: "active",
       displayName: claim.claimantName || "Owner",
-      joinedAt: FieldValue.serverTimestamp(),
+      joinedAt: existingJoinedAt ?? FieldValue.serverTimestamp(),
       lastSeen: FieldValue.serverTimestamp(),
     },
     { merge: true }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "deploy": "gh-pages -d dist",
     "test": "vitest",
-    "test:rules": "npx --no-install firebase-tools emulators:exec --only firestore --project barbacker-rules-test \"vitest --run --config vitest.rules.config.ts\""
+    "test:rules": "npx --no-install firebase-tools emulators:exec --only firestore,storage --project barbacker-rules-test \"vitest --run --config vitest.rules.config.ts\""
   },
   "dependencies": {
     "@capacitor/android": "^8.0.0",

--- a/scripts/generate-sw.js
+++ b/scripts/generate-sw.js
@@ -14,8 +14,24 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Helper function to safely get env vars or fallback.
-const getEnv = (key, fallback) => process.env[key] || fallback;
+// Helper function to retrieve a required env var, failing the build
+// (not silently substituting a placeholder) if it's missing.
+// Previously this fell back to strings like 'YOUR_API_KEY' — tsc,
+// vite build, and the deploy workflow all succeeded either way, so a
+// missing/rotated/renamed VITE_FIREBASE_* secret produced a shipped
+// firebase-messaging-sw.js that called
+// firebase.initializeApp({apiKey: "YOUR_API_KEY", ...}) with no build
+// signal at all. Background push silently doesn't work for anyone
+// until someone notices. Mirrors generate-google-services.js's
+// already-fail-closed pattern for the same class of secret.
+const getEnv = (key) => {
+  const val = process.env[key];
+  if (!val) {
+    console.error(`Error: Environment variable ${key} is missing.`);
+    process.exit(1);
+  }
+  return val;
+};
 
 // Define the content of the Service Worker.
 // We use a template string to inject environment variables at build time.
@@ -26,12 +42,12 @@ importScripts('https://www.gstatic.com/firebasejs/9.0.0/firebase-messaging-compa
 
 // Initialize Firebase with injected configuration.
 const firebaseConfig = {
-  apiKey: "${getEnv('VITE_FIREBASE_API_KEY', 'YOUR_API_KEY')}",
-  authDomain: "${getEnv('VITE_FIREBASE_AUTH_DOMAIN', 'YOUR_AUTH_DOMAIN')}",
-  projectId: "${getEnv('VITE_FIREBASE_PROJECT_ID', 'YOUR_PROJECT_ID')}",
-  storageBucket: "${getEnv('VITE_FIREBASE_STORAGE_BUCKET', 'YOUR_STORAGE_BUCKET')}",
-  messagingSenderId: "${getEnv('VITE_FIREBASE_MESSAGING_SENDER_ID', 'YOUR_MESSAGING_SENDER_ID')}",
-  appId: "${getEnv('VITE_FIREBASE_APP_ID', 'YOUR_APP_ID')}"
+  apiKey: "${getEnv('VITE_FIREBASE_API_KEY')}",
+  authDomain: "${getEnv('VITE_FIREBASE_AUTH_DOMAIN')}",
+  projectId: "${getEnv('VITE_FIREBASE_PROJECT_ID')}",
+  storageBucket: "${getEnv('VITE_FIREBASE_STORAGE_BUCKET')}",
+  messagingSenderId: "${getEnv('VITE_FIREBASE_MESSAGING_SENDER_ID')}",
+  appId: "${getEnv('VITE_FIREBASE_APP_ID')}"
 };
 
 firebase.initializeApp(firebaseConfig);

--- a/scripts/nag-bot.js
+++ b/scripts/nag-bot.js
@@ -45,6 +45,11 @@ const ROLE_NOTIFICATION_DEFAULTS = {
   'Server': [],
   'Runner': ['ice', 'glass', 'restock', 'mixers', 'restock_beer'],
   'Security': ['security', 'manager', 'break'],
+  // See src/constants.ts's copy for why this exists — onInviteConsumed.ts
+  // (Cloud Function) sets jobTitle to literally 'Staff' for an invited
+  // member with no title picked yet, and without an entry here that
+  // member matched nothing and got zero notifications/nags.
+  'Staff': ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer', 'break'],
 };
 
 // Given a pending request and a bar member, decide whether this nag
@@ -64,6 +69,15 @@ function shouldNagUserAbout(req, member) {
     || ROLE_NOTIFICATION_DEFAULTS[member.jobTitle] || ROLE_NOTIFICATION_DEFAULTS[member.role] || [];
   return prefs.includes(req.buttonId);
 }
+
+// Firestore caps a single batch at 500 writes. Bar-scoped chunks
+// below are already far under that in the common case, but nothing
+// stops a single bar from accumulating hundreds of stale pending
+// requests (nothing rate-limits creation), so this is enforced rather
+// than assumed. Matches the BATCH_SIZE convention used elsewhere in
+// this repo (functions/src/cleanupStaleRequests.ts,
+// functions/src/migrateNoticesToChat.ts).
+const BATCH_SIZE = 400;
 
 // Main function to check for ignored requests and send reminders ("Nags").
 async function nag() {
@@ -87,98 +101,127 @@ async function nag() {
   // --- Step 2: Group by Bar ---
   // We group requests by Bar ID to send a single consolidated notification per bar,
   // preventing notification spam if there are multiple pending items (e.g., 10 "Ice" requests).
-  const barUpdates = {}; // Map of barId -> [{ label, buttonId }]
+  // Keeps each doc (not just label/buttonId) so lastNotification can
+  // be bumped per-bar right after that bar's send attempt, below.
+  const barUpdates = {}; // Map of barId -> [{ label, buttonId, ref }]
 
   snapshot.docs.forEach(doc => {
     const data = doc.data();
     if (!barUpdates[data.barId]) barUpdates[data.barId] = [];
-    barUpdates[data.barId].push({ label: data.label, buttonId: data.buttonId });
+    barUpdates[data.barId].push({ label: data.label, buttonId: data.buttonId, ref: doc.ref });
   });
 
-  // --- Step 3: Send Notifications per Bar ---
+  // --- Step 3: Send Notifications per Bar, bumping lastNotification
+  // immediately after each bar's attempt (not once at the very end
+  // for every request in the whole run). Previously a failure sending
+  // to ANY bar (FCM quota/auth error, sendEachForMulticast throwing
+  // above its 500-token limit, etc.) threw out of this loop entirely
+  // — since the very last step updated every request's
+  // lastNotification in one shot, that meant bars already nagged
+  // successfully earlier in the same loop never got their timestamp
+  // bumped either, so the next run (5 minutes later) renagged them
+  // again — a permanent duplicate-nag loop for every bar that
+  // happened to be processed before whichever one failed. Wrapping
+  // each bar's send in its own try/catch, and bumping that bar's
+  // requests right after, means one bar's failure no longer poisons
+  // every other bar in the same run.
   for (const [barId, requests] of Object.entries(barUpdates)) {
-    // Fetch bar members (for status/prefs filtering) and tokens
-    // together — `bars/{barId}/tokens` has one doc per uid holding
-    // the FCM token; `bars/{barId}/users` has the same uid holding
-    // status/notificationPreferences/jobTitle.
-    const [tokensSnap, usersSnap] = await Promise.all([
-      db.collection(`bars/${barId}/tokens`).get(),
-      db.collection(`bars/${barId}/users`).get(),
-    ]);
-    const membersById = new Map(usersSnap.docs.map(d => [d.id, d.data()]));
+    try {
+      // Fetch bar members (for status/prefs filtering) and tokens
+      // together — `bars/{barId}/tokens` has one doc per uid holding
+      // the FCM token; `bars/{barId}/users` has the same uid holding
+      // status/notificationPreferences/jobTitle.
+      const [tokensSnap, usersSnap] = await Promise.all([
+        db.collection(`bars/${barId}/tokens`).get(),
+        db.collection(`bars/${barId}/users`).get(),
+      ]);
+      const membersById = new Map(usersSnap.docs.map(d => [d.id, d.data()]));
 
-    // Group recipients by the exact subset of requests they should be
-    // nagged about, so someone who only cares about ICE doesn't get
-    // paged about a KEG request too, and so we send the minimum
-    // number of distinct multicast calls.
-    const groups = new Map(); // key (sorted buttonId/label list) -> { labels, tokens }
-    for (const tokenDoc of tokensSnap.docs) {
-      const token = tokenDoc.data().token;
-      if (!token) continue;
-      const member = membersById.get(tokenDoc.id);
-      if (!member) continue; // Token orphaned from a removed member.
+      // Group recipients by the exact subset of requests they should be
+      // nagged about, so someone who only cares about ICE doesn't get
+      // paged about a KEG request too, and so we send the minimum
+      // number of distinct multicast calls.
+      const groups = new Map(); // key (sorted buttonId/label list) -> { labels, tokens }
+      for (const tokenDoc of tokensSnap.docs) {
+        const token = tokenDoc.data().token;
+        if (!token) continue;
+        const member = membersById.get(tokenDoc.id);
+        if (!member) continue; // Token orphaned from a removed member.
 
-      const relevant = requests.filter(r => shouldNagUserAbout(r, member));
-      if (relevant.length === 0) continue;
+        const relevant = requests.filter(r => shouldNagUserAbout(r, member));
+        if (relevant.length === 0) continue;
 
-      const key = relevant.map(r => r.buttonId || r.label).sort().join('|');
-      if (!groups.has(key)) groups.set(key, { labels: relevant.map(r => r.label), tokens: [] });
-      groups.get(key).tokens.push(token);
-    }
+        const key = relevant.map(r => r.buttonId || r.label).sort().join('|');
+        if (!groups.has(key)) groups.set(key, { labels: relevant.map(r => r.label), tokens: [] });
+        groups.get(key).tokens.push(token);
+      }
 
-    if (groups.size === 0) {
-      console.log(`No subscribed/active recipients for bar ${barId}; skipping.`);
+      if (groups.size === 0) {
+        console.log(`No subscribed/active recipients for bar ${barId}; skipping.`);
+      }
+
+      // sendEachForMulticast throws synchronously above 500 tokens —
+      // chunk defensively even though a single bar having that many
+      // subscribed devices is unlikely.
+      for (const { labels, tokens } of groups.values()) {
+        const summary = labels.join(', ');
+        const title = `IGNORED: ${labels.length} TASK${labels.length === 1 ? '' : 'S'}`;
+        const body = `${summary} still waiting. DO YOUR JOB.`;
+
+        for (let i = 0; i < tokens.length; i += BATCH_SIZE) {
+          const tokenChunk = tokens.slice(i, i + BATCH_SIZE);
+          // Send the Multicast Push Notification to this recipient group.
+          // This uses FCM to reach Android and iOS devices.
+          await messaging.sendEachForMulticast({
+            tokens: tokenChunk,
+            notification: {
+              title: title,
+              body: body,
+            },
+            data: {
+              type: 'nag_alert',
+              barId: barId
+            },
+            // Android specific config for high priority.
+            android: {
+              priority: 'high',
+              notification: {
+                sound: 'default',
+                channelId: 'urgent_alerts'
+              }
+            },
+            // APNs (iOS) specific config.
+            apns: {
+              payload: {
+                aps: {
+                  sound: 'default',
+                  'content-available': 1
+                }
+              }
+            }
+          });
+
+          console.log(`Nagged ${tokenChunk.length} recipient(s) at bar ${barId} regarding: ${summary}`);
+        }
+      }
+    } catch (e) {
+      console.error(`Failed to nag bar ${barId}; leaving its requests' lastNotification untouched so they're retried next run`, e);
       continue;
     }
 
-    for (const { labels, tokens } of groups.values()) {
-      const summary = labels.join(', ');
-      const title = `IGNORED: ${labels.length} TASK${labels.length === 1 ? '' : 'S'}`;
-      const body = `${summary} still waiting. DO YOUR JOB.`;
-
-      // Send the Multicast Push Notification to this recipient group.
-      // This uses FCM to reach Android and iOS devices.
-      await messaging.sendEachForMulticast({
-        tokens,
-        notification: {
-          title: title,
-          body: body,
-        },
-        data: {
-          type: 'nag_alert',
-          barId: barId
-        },
-        // Android specific config for high priority.
-        android: {
-          priority: 'high',
-          notification: {
-            sound: 'default',
-            channelId: 'urgent_alerts'
-          }
-        },
-        // APNs (iOS) specific config.
-        apns: {
-          payload: {
-            aps: {
-              sound: 'default',
-              'content-available': 1
-            }
-          }
-        }
-      });
-
-      console.log(`Nagged ${tokens.length} recipient(s) at bar ${barId} regarding: ${summary}`);
+    // --- Step 4: Update Last Notification Timestamp for this bar ---
+    // Chunked at BATCH_SIZE — Firestore caps a single batch at 500
+    // writes, and nothing limits how many stale requests one bar can
+    // accumulate (no rate limiting exists anywhere in this app).
+    const barRequests = requests;
+    for (let i = 0; i < barRequests.length; i += BATCH_SIZE) {
+      const batch = db.batch();
+      for (const { ref } of barRequests.slice(i, i + BATCH_SIZE)) {
+        batch.update(ref, { lastNotification: new Date() });
+      }
+      await batch.commit();
     }
   }
-
-  // --- Step 4: Update Last Notification Timestamp ---
-  // Update the 'lastNotification' field on the request documents so we don't nag them again immediately.
-  // We use a batch write for efficiency and atomicity.
-  const batch = db.batch();
-  snapshot.docs.forEach(doc => {
-    batch.update(doc.ref, { lastNotification: new Date() });
-  });
-  await batch.commit();
 }
 
 // Execute the function.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -24,18 +24,18 @@ if ! command_exists wget || ! command_exists unzip; then
     fi
 fi
 
-# 1. Java Setup (JDK 17)
+# 1. Java Setup (JDK 21)
 if ! command_exists java; then
-    echo "Java not found. Installing OpenJDK 17..."
+    echo "Java not found. Installing OpenJDK 21..."
     if command_exists apt-get; then
         sudo apt-get update
-        sudo apt-get install -y openjdk-17-jdk
+        sudo apt-get install -y openjdk-21-jdk
     elif command_exists yum; then
-        sudo yum install -y java-17-openjdk
+        sudo yum install -y java-21-openjdk
     elif command_exists apk; then
-        sudo apk add openjdk17
+        sudo apk add openjdk21
     else
-        echo "Error: Package manager not found. Please install JDK 17 manually."
+        echo "Error: Package manager not found. Please install JDK 21 manually."
         exit 1
     fi
 else
@@ -65,7 +65,7 @@ if [ ! -d "$ANDROID_HOME" ]; then
 
     # Install basic SDK packages
     yes | sdkmanager --licenses
-    sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+    sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
 else
     echo "Android SDK directory exists."
 fi

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,8 +409,33 @@ function App() {
 
   // --- 2. Bar Logic (Listeners) ---
   useEffect(() => {
-    // If no user or bar selected, do nothing.
-    if (!user || !barId) return;
+    // If no user or bar selected, clear everything the listeners
+    // below would otherwise leave stale — most critically on sign-out
+    // (see handleLogout) or a bar switch: without this, a second
+    // person signing into the same browser session (a shared device
+    // at the bar) would see the PREVIOUS user's bar name, roster,
+    // beer inventory, and role/permissions still rendered until a
+    // full page reload, since React state isn't reset just because
+    // an effect's guard condition starts failing.
+    if (!user || !barId) {
+      setUserRole(null);
+      setJobTitle('');
+      setUserStatus('active');
+      setDisplayName('');
+      setNotificationPreferences([]);
+      setBarName('');
+      setBarJoinPolicy('open');
+      setButtons(DEFAULT_BUTTONS);
+      setBeerInventory({});
+      setWells([]);
+      setHiddenButtonIds([]);
+      setButtonUsage({});
+      setCustomOrders({});
+      setBarSubscription('free');
+      setBarTheme(undefined);
+      setAllUsers([]);
+      return;
+    }
 
     // Persist Bar ID to URL and LocalStorage.
     setSearchParamsRef.current({ bar: barId });
@@ -508,7 +533,7 @@ function App() {
   // persistent rather than time-windowed, so it's owned by useChat
   // instead — see below.
   useEffect(() => {
-    if (!user || !barId) return;
+    if (!user || !barId) { setRequests([]); return; }
 
     const unsubReq = onSnapshot(
       query(
@@ -532,7 +557,7 @@ function App() {
   // side and avoids the client even attempting a private read it
   // can't decode.
   useEffect(() => {
-    if (!barId) return;
+    if (!barId) { setEightySixEntries([]); return; }
     const canSeePrivate = isPremium && isManagerPlus;
     const q = canSeePrivate
       ? query(collection(db, `bars/${barId}/eightySixed`), orderBy('timestamp', 'desc'), limit(200))
@@ -1164,8 +1189,25 @@ function App() {
   };
 
   // Sign out — also closes the account dialog that triggered it.
+  //
+  // Clearing barId (and its localStorage mirror) is what actually
+  // matters here, not just calling signOut(): every bar-scoped
+  // listener effect above is gated on `if (!user || !barId)`, and
+  // now clears its own state when that guard fails (see those
+  // effects' comments) — but only `user` was ever going to become
+  // falsy on sign-out, since nothing here ever reset `barId`. On a
+  // shared device, a second person signing in right after would have
+  // had the FIRST person's bar name, roster, requests, and role still
+  // rendered (barId was still set, so every listener just
+  // re-subscribed under the new uid) until a full page reload. Also
+  // matches the reset every other "leave this bar" path already does
+  // (handleLeaveBar, handleSwitchBar, the Cancel button on Approval
+  // Pending) — sign-out was the one path that never did it.
   const handleLogout = async () => {
     await signOut();
+    setBarId(null);
+    setJustCreatedBar(false);
+    localStorage.removeItem('barId');
     setShowAccountDialog(false);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -674,7 +674,12 @@ function App() {
 
   // --- Actions ---
 
-  // Save a new beer brand to the bar's inventory.
+  // Save a new beer brand to the bar's inventory. firestore.rules
+  // restricts bars/{barId} writes to Manager+ — a Staff member
+  // reaching this action (nothing in the UI currently hides "+ ADD
+  // BRAND" from them) previously got no feedback at all: the write
+  // threw, so neither the optimistic state update nor the dialog-close
+  // ever ran, and the InputDialog just sat there with no explanation.
   const saveBrand = async (brandName: string) => {
     if (!user || !barId) return;
 
@@ -686,10 +691,16 @@ function App() {
         return;
     }
 
-    // Write to Firestore.
-    await setDoc(doc(db, 'bars', barId), {
-        beerInventory: { [brandName]: [] } // Object syntax uses dot notation for updates, but here we merge.
-    }, { merge: true });
+    try {
+      // Write to Firestore.
+      await setDoc(doc(db, 'bars', barId), {
+          beerInventory: { [brandName]: [] } // Object syntax uses dot notation for updates, but here we merge.
+      }, { merge: true });
+    } catch (e) {
+      console.error('Failed to save brand', e);
+      alert('Failed to add brand. Only managers can edit the beer inventory.');
+      return;
+    }
 
     // Update local state optimistically.
     setBeerInventory(prev => ({ ...prev, [brandName]: [] }));
@@ -700,7 +711,8 @@ function App() {
     setNavStack(prev => [...prev, brandBtn]);
   };
 
-  // Save a new beer type (e.g., "Bottle") to a brand.
+  // Save a new beer type (e.g., "Bottle") to a brand. Same Manager+
+  // restriction and same previously-silent-failure issue as saveBrand.
   const saveType = async (typeName: string) => {
     if (!user || !barId || !inputDialog.parentContext) return;
     const brand = inputDialog.parentContext;
@@ -714,10 +726,16 @@ function App() {
         return;
     }
 
-    // Update Firestore (arrayUnion ensures uniqueness).
-    await updateDoc(doc(db, 'bars', barId), {
-        [`beerInventory.${brand}`]: arrayUnion(typeName)
-    });
+    try {
+      // Update Firestore (arrayUnion ensures uniqueness).
+      await updateDoc(doc(db, 'bars', barId), {
+          [`beerInventory.${brand}`]: arrayUnion(typeName)
+      });
+    } catch (e) {
+      console.error('Failed to save type', e);
+      alert('Failed to add type. Only managers can edit the beer inventory.');
+      return;
+    }
 
     // Update local state.
     setBeerInventory(prev => ({ ...prev, [brand]: [...(prev[brand] || []), typeName] }));
@@ -728,7 +746,8 @@ function App() {
     setNavStack(prev => [...prev, typeBtn]);
   };
 
-  // Save a new Well location.
+  // Save a new Well location. Same Manager+ restriction and same
+  // previously-silent-failure issue as saveBrand/saveType.
   const saveWell = async (wellName: string) => {
     if (!user || !barId) return;
 
@@ -740,10 +759,16 @@ function App() {
         return;
     }
 
-    // Add to Firestore.
-    await updateDoc(doc(db, 'bars', barId), {
-        wells: arrayUnion(wellName)
-    });
+    try {
+      // Add to Firestore.
+      await updateDoc(doc(db, 'bars', barId), {
+          wells: arrayUnion(wellName)
+      });
+    } catch (e) {
+      console.error('Failed to save well', e);
+      alert('Failed to add well. Only managers can edit wells.');
+      return;
+    }
 
     // Update local state.
     setWells(prev => [...prev, wellName]);
@@ -757,18 +782,30 @@ function App() {
   // Hide a button from the dashboard.
   const hideButton = async (btnId: string) => {
     if (!user || !barId) return;
-    await updateDoc(doc(db, 'bars', barId), {
-        hiddenButtonIds: arrayUnion(btnId)
-    });
+    try {
+      await updateDoc(doc(db, 'bars', barId), {
+          hiddenButtonIds: arrayUnion(btnId)
+      });
+    } catch (e) {
+      console.error('Failed to hide button', e);
+      alert('Failed to hide. Please try again.');
+      return;
+    }
     setHiddenButtonIds(prev => [...prev, btnId]);
   };
 
   // Unhide a button (premium only).
   const unhideButton = async (btnId: string) => {
     if (!user || !barId) return;
-    await updateDoc(doc(db, 'bars', barId), {
-        hiddenButtonIds: arrayRemove(btnId)
-    });
+    try {
+      await updateDoc(doc(db, 'bars', barId), {
+          hiddenButtonIds: arrayRemove(btnId)
+      });
+    } catch (e) {
+      console.error('Failed to unhide button', e);
+      alert('Failed to restore. Please try again.');
+      return;
+    }
     setHiddenButtonIds(prev => prev.filter(id => id !== btnId));
   };
 
@@ -1015,7 +1052,28 @@ function App() {
   const confirmRole = async (title: string, name: string) => {
     if (!user || !barId) return;
 
-    const role = justCreatedBar ? 'Owner' : 'Staff';
+    // Don't trust justCreatedBar alone — it's local UI state that's
+    // lost the moment a user backs out of this screen without
+    // confirming (the arrow-back / Cancel buttons both reset it) and
+    // never restored if they come back to the SAME bar they created
+    // via BarSearch's "already exists, just join it" path, which has
+    // no reason to know they're its creator. Someone who did that
+    // would confirm as 'Staff' on a bar whose ownerId already points
+    // at them — and since fileOwnershipClaim explicitly rejects
+    // "you already own this bar," there would be NO path back to
+    // Owner short of manually editing Firestore. Re-derive from the
+    // same source firestore.rules' self-create rule actually trusts:
+    // bars/{barId}.ownerId.
+    let isCreator = justCreatedBar;
+    if (!isCreator) {
+      try {
+        const barSnap = await getDoc(doc(db, 'bars', barId));
+        isCreator = barSnap.data()?.ownerId === user.uid;
+      } catch (e) {
+        console.error('Failed to verify bar ownership before joining', e);
+      }
+    }
+    const role = isCreator ? 'Owner' : 'Staff';
     const status = (role === 'Owner' || barJoinPolicy !== 'approval') ? 'active' : 'pending';
 
     try {
@@ -1662,19 +1720,16 @@ function App() {
         onSearchChange={(val) => setInputDialog(prev => ({ ...prev, searchTerm: val }))}
         onClose={() => setInputDialog(prev => ({ ...prev, open: false }))}
         onSelect={(val) => {
-            // Deduplication check — only meaningful for brand/type/well,
-            // which create a new persistent button. 'custom' is free-text
-            // request text, not a button; it should never be blocked just
-            // because the words happen to match an existing button label
-            // (e.g. typing "ice" as a custom note).
-            if (inputDialog.type !== 'custom') {
-                const existingLabels = currentButtonsSource.map(b => b.label.toLowerCase());
-                if (existingLabels.includes(val.toLowerCase())) {
-                    alert('This button already exists!');
-                    return;
-                }
-            }
-
+            // No dedup check here — saveBrand/saveType/saveWell each
+            // already check for an existing match themselves and
+            // navigate straight to it instead of creating a duplicate
+            // (see their "If it already exists, just open it"
+            // branches). This used to also check here first and, on a
+            // match, show a dead-end `alert('This button already
+            // exists!')` instead of ever calling through to that
+            // navigate-to-it behavior — so picking a suggested brand/
+            // type/well that already existed produced a blocking
+            // alert instead of just taking the user there.
             if (inputDialog.type === 'brand') saveBrand(val);
             else if (inputDialog.type === 'type') saveType(val);
             else if (inputDialog.type === 'well') saveWell(val);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,8 +143,19 @@ function App() {
   // depends on values that should actually trigger it.
   const setSearchParamsRef = useRef(setSearchParams);
   useEffect(() => { setSearchParamsRef.current = setSearchParams; }, [setSearchParams]);
-  // Get the 'bar' param from URL or fallback to localStorage.
-  const initialBarId = searchParams.get('bar') || localStorage.getItem('barId');
+  // Get the 'bar' param from URL or fallback to localStorage. Guarded
+  // — localStorage.getItem can throw (Safari private browsing
+  // historically, a storage-access-restricted iframe context) and
+  // this runs unconditionally on every render of the whole app, so an
+  // unguarded throw here would crash the entire component tree with
+  // no error boundary above it to catch it.
+  const initialBarId = searchParams.get('bar') || (() => {
+    try {
+      return localStorage.getItem('barId');
+    } catch {
+      return null;
+    }
+  })();
   // Store the current Bar ID.
   const [barId, setBarId] = useState<string | null>(initialBarId);
   
@@ -215,6 +226,12 @@ function App() {
   const [editNameValue, setEditNameValue] = useState('');
   const [editNameError, setEditNameError] = useState<string | null>(null);
 
+  // Cap on the persisted ignoredIds list (see below) — nothing ever
+  // pruned old entries as requests they referred to got resolved and
+  // deleted, so this grew by one entry every time anyone tapped
+  // "Ignore," unboundedly, for the lifetime of the browser profile.
+  const MAX_IGNORED_IDS = 200;
+
   // List of request IDs the user has locally ignored/muted. Persisted
   // to localStorage — previously plain useState, so a reload (or the
   // app being killed and reopened, routine on mobile) brought back
@@ -255,7 +272,7 @@ function App() {
 
   // Drag-and-drop sensors + handlers (dnd-kit). Persistence of
   // customOrders happens inside the hook on drag end.
-  const { sensors, activeId, isDraggingRef, handleDragStart, handleDragOver, handleDragEnd } =
+  const { sensors, activeId, isDraggingRef, handleDragStart, handleDragOver, handleDragEnd, handleDragCancel } =
     useDragAndDrop({ barId, customOrders, setCustomOrders });
 
   // Memoized lookup map for button IDs. Maps both top-level and child labels to top-level button ID.
@@ -619,26 +636,41 @@ function App() {
     const tokenRef = doc(db, `bars/${barId}/tokens`, user.uid);
 
     const autoClockIn = async () => {
-      // Store FCM token.
-      await setDoc(tokenRef, {
-        token: fcmToken,
-        updated: serverTimestamp()
-      });
-      // Set status to active and update heartbeat. Rules only permit
-      // this self-write when transitioning from 'off_clock' (or when
-      // status isn't changing at all) — a user still 'pending'
-      // manager approval correctly stays pending here.
-      await updateDoc(userRef, {
-        status: 'active',
-        lastSeen: serverTimestamp()
-      }).catch((e) => console.error('Auto clock-in failed', e));
+      try {
+        // Store FCM token. Previously unguarded — a rejection here
+        // (e.g. a transient offline write) threw out of autoClockIn()
+        // as an unhandled promise rejection (autoClockIn() is called
+        // below with no .then/.catch) AND skipped the updateDoc below
+        // entirely, silently leaving the user un-clocked-in with no
+        // error surfaced anywhere.
+        await setDoc(tokenRef, {
+          token: fcmToken,
+          updated: serverTimestamp()
+        });
+        // Set status to active and update heartbeat. Rules only permit
+        // this self-write when transitioning from 'off_clock' (or when
+        // status isn't changing at all) — a user still 'pending'
+        // manager approval correctly stays pending here.
+        await updateDoc(userRef, {
+          status: 'active',
+          lastSeen: serverTimestamp()
+        });
+      } catch (e) {
+        console.error('Auto clock-in failed', e);
+      }
     };
     autoClockIn();
   }, [user, barId, fcmToken]);
 
 
   // Auto-submit an "(Ask Me)" request if a sub-menu sits open for 60s.
-  useInactivityAutoSubmit(navStack, (label) => submitRequestSafe(label), () => setNavStack([]));
+  useInactivityAutoSubmit(
+    navStack,
+    (label) => submitRequestSafe(label),
+    () => setNavStack([]),
+    undefined,
+    inputDialog.open || quantityPicker.open,
+  );
 
   // --- Actions ---
 
@@ -1946,6 +1978,7 @@ function App() {
               onDragStart={handleDragStart}
               onDragOver={(e) => handleDragOver(e, currentContextId, currentButtons)}
               onDragEnd={(e) => handleDragEnd(e, currentContextId)}
+              onDragCancel={handleDragCancel}
             >
               <SortableContext items={currentButtons} strategy={rectSortingStrategy}>
                 <div className="grid grid-cols-2 gap-4 mb-auto">
@@ -1983,6 +2016,7 @@ function App() {
         onDragStart={handleDragStart}
         onDragOver={(e) => handleDragOver(e, 'main', mainScreenButtonsWithCustom)}
         onDragEnd={(e) => handleDragEnd(e, 'main')}
+        onDragCancel={handleDragCancel}
       >
         <SortableContext items={mainScreenButtonsWithCustom} strategy={rectSortingStrategy}>
           <div className="grid grid-cols-2 gap-8 p-6">
@@ -2094,7 +2128,10 @@ function App() {
                         ) : (
                             !isIgnored && (
                                 <md-outlined-button
-                                    onClick={(e: React.MouseEvent<HTMLElement>) => { e.stopPropagation(); setIgnoredIds(prev => [...prev, req.id]); }}
+                                    onClick={(e: React.MouseEvent<HTMLElement>) => {
+                                        e.stopPropagation();
+                                        setIgnoredIds(prev => [...prev, req.id].slice(-MAX_IGNORED_IDS));
+                                    }}
                                     style={{ height: '48px', minWidth: '100px' }}
                                 >
                                     Ignore

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -121,7 +121,18 @@ export const ROLE_NOTIFICATION_DEFAULTS: Record<string, string[]> = {
   // Runners focus on moving product.
   'Runner': ['ice', 'glass', 'restock', 'mixers', 'restock_beer'],
   // Security deals with safety.
-  'Security': ['security', 'manager', 'break']
+  'Security': ['security', 'manager', 'break'],
+  // 'Staff' is not a selectable JOB_TITLES entry — it's what
+  // onInviteConsumed.ts (Cloud Function) sets jobTitle to for an
+  // invited member who hasn't picked one yet. Without an entry here,
+  // that fallback chain (member.notificationPreferences ??
+  // ROLE_NOTIFICATION_DEFAULTS[jobTitle] ?? []) landed on the final
+  // [] and an invited member received precisely zero request
+  // notifications — silently, forever, until they manually opened
+  // Notification Settings and picked preferences themselves. Mirrors
+  // Barback's set (the broadest "generic floor worker" default)
+  // rather than defaulting to nothing.
+  'Staff': ['ice', 'glass', 'fruit', 'restock', 'keg', 'trash', 'mixers', 'restock_beer', 'break'],
 };
 
 // POS provider picker honesty (Phase 3 — see

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -48,6 +48,11 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
   const [latestMessageAt, setLatestMessageAt] = useState<number>(0);
   const [lastReadAt, setLastReadAt] = useState<number>(0);
   const migratedRef = useRef<string | null>(null);
+  // Tracks the latest barId synchronously (a ref, not state) so
+  // loadMore's async cancellation guard can tell, after an await,
+  // whether the bar changed out from under it — see loadMore below.
+  const barIdRef = useRef(barId);
+  barIdRef.current = barId;
 
   // One-time-per-bar migration of any leftover notices into chat.
   // Fire-and-forget: the server-side function is idempotent (guarded
@@ -107,14 +112,33 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
 
   useEffect(() => {
     if (!barId) { setLastReadAt(0); return; }
-    const stored = Number(localStorage.getItem(lastReadKey(barId)) || 0);
+    // Guards two independent failure modes: localStorage.getItem
+    // itself can throw (Safari private browsing historically, or a
+    // storage-access-restricted iframe context), and even a
+    // successful read can hold a non-numeric value (corrupted
+    // storage, a value written by a since-changed format) — Number()
+    // on that returns NaN, which compares false against every message
+    // timestamp in both directions, permanently stuck showing either
+    // "everything unread" or "everything read" depending on which way
+    // the comparison runs, with no way for the user to clear it.
+    let stored = 0;
+    try {
+      const raw = Number(localStorage.getItem(lastReadKey(barId)) || 0);
+      if (!Number.isNaN(raw)) stored = raw;
+    } catch (e) {
+      console.warn('Failed to read lastReadAt from localStorage', e);
+    }
     setLastReadAt(stored);
   }, [barId]);
 
   const markRead = useCallback(() => {
     if (!barId) return;
     const now = Date.now();
-    localStorage.setItem(lastReadKey(barId), String(now));
+    try {
+      localStorage.setItem(lastReadKey(barId), String(now));
+    } catch (e) {
+      console.warn('Failed to persist lastReadAt to localStorage', e);
+    }
     setLastReadAt(now);
   }, [barId]);
 
@@ -138,6 +162,7 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
 
   const loadMore = useCallback(async () => {
     if (!barId || loadingMore || !hasMore) return;
+    const requestedBarId = barId;
     const oldest = olderMessages[0] ?? messages[0];
     if (!oldest) return;
     setLoadingMore(true);
@@ -146,6 +171,14 @@ export function useChat({ user, barId, displayName, userRole, panelOpen }: UseCh
         query(collection(db, `bars/${barId}/chat`), orderBy('timestamp', 'desc'),
           where('timestamp', '<', oldest.timestamp as any), limit(PAGE_SIZE)),
       );
+      // Cancellation guard: if the user switched bars while this
+      // getDocs() was in flight, applying its result now would
+      // prepend the PREVIOUS bar's older messages onto the new bar's
+      // (already-reset-to-empty) scrollback — cross-bar contamination
+      // that a plain `if (!barId) return` at the top can't catch,
+      // since it only checks the guard's value at call time, not
+      // after the await.
+      if (barIdRef.current !== requestedBarId) return;
       if (cursorSnap.empty) { setHasMore(false); return; }
       const older = cursorSnap.docs.map((d) => ({ id: d.id, ...d.data() } as ChatMessage)).reverse();
       setOlderMessages((prev) => [...older, ...prev]);

--- a/src/hooks/useDragAndDrop.test.ts
+++ b/src/hooks/useDragAndDrop.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+const mockUpdateDoc = vi.fn().mockResolvedValue(undefined);
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+}));
+vi.mock('../firebase', () => ({ db: {} }));
+
+import { useDragAndDrop } from './useDragAndDrop';
+
+describe('useDragAndDrop', () => {
+  it('handleDragStart sets activeId and isDraggingRef', () => {
+    const setCustomOrders = vi.fn();
+    const { result } = renderHook(() =>
+      useDragAndDrop({ barId: 'bar1', customOrders: {}, setCustomOrders })
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: 'btn1' } } as any);
+    });
+
+    expect(result.current.activeId).toBe('btn1');
+    expect(result.current.isDraggingRef.current).toBe(true);
+  });
+
+  // Regression: dnd-kit fires onDragCancel instead of onDragEnd when a
+  // drag is cancelled (Escape key, the draggable unmounting mid-drag,
+  // etc.). Without a handler for it, isDraggingRef stayed stuck at
+  // `true` forever, which permanently blocked this client from ever
+  // applying another remote customOrders update again (see the bar
+  // listener effect in App.tsx, which skips the update while dragging
+  // to avoid clobbering an in-progress local reorder).
+  it('handleDragCancel resets activeId and isDraggingRef without writing to Firestore', () => {
+    const setCustomOrders = vi.fn();
+    const { result } = renderHook(() =>
+      useDragAndDrop({ barId: 'bar1', customOrders: { main: ['a', 'b'] }, setCustomOrders })
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: 'btn1' } } as any);
+    });
+    expect(result.current.isDraggingRef.current).toBe(true);
+
+    act(() => {
+      result.current.handleDragCancel({} as any);
+    });
+
+    expect(result.current.activeId).toBeNull();
+    expect(result.current.isDraggingRef.current).toBe(false);
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('handleDragEnd resets isDraggingRef and persists the order', async () => {
+    const setCustomOrders = vi.fn();
+    const { result } = renderHook(() =>
+      useDragAndDrop({ barId: 'bar1', customOrders: { main: ['a', 'b'] }, setCustomOrders })
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: 'btn1' } } as any);
+    });
+
+    await act(async () => {
+      await result.current.handleDragEnd({} as any, 'main');
+    });
+
+    expect(result.current.isDraggingRef.current).toBe(false);
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -67,9 +67,21 @@ export function useDragAndDrop({ barId, customOrders, setCustomOrders }: UseDrag
     setActiveId(null);
     isDraggingRef.current = false;
     if (barId && customOrders[contextId]) {
-      await updateDoc(doc(db, 'bars', barId), {
-        [`customOrders.${contextId}`]: customOrders[contextId],
-      });
+      try {
+        await updateDoc(doc(db, 'bars', barId), {
+          [`customOrders.${contextId}`]: customOrders[contextId],
+        });
+      } catch (e) {
+        // handleDragOver already applied this reorder to local state
+        // optimistically as the drag progressed, so the button visibly
+        // moved before this write was even attempted — without
+        // surfacing the failure, a Staff member (customOrders lives on
+        // bars/{barId}, Manager+-only per firestore.rules) would see
+        // their reorder "succeed," only to have it silently revert on
+        // the next reload or remote sync with no explanation.
+        console.error('Failed to save button order', e);
+        alert('Failed to save the new order. Only managers can reorder buttons.');
+      }
     }
   };
 

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -7,6 +7,7 @@ import {
   useSensors,
   DragEndEvent,
   DragStartEvent,
+  DragCancelEvent,
 } from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { doc, updateDoc } from 'firebase/firestore';
@@ -72,6 +73,22 @@ export function useDragAndDrop({ barId, customOrders, setCustomOrders }: UseDrag
     }
   };
 
+  // dnd-kit fires onDragCancel (Escape key, the draggable unmounting
+  // mid-drag, etc.) INSTEAD OF onDragEnd — without a handler wired to
+  // it, isDraggingRef stayed stuck at `true` forever after any
+  // cancelled drag, since only handleDragEnd ever reset it. The bar
+  // listener effect in App.tsx skips applying a remote customOrders
+  // update while `isDraggingRef.current` is true (so it doesn't
+  // clobber an in-progress local reorder) — once stuck, that made
+  // this client permanently stop picking up anyone else's button
+  // reordering for the rest of the session. No Firestore write here:
+  // a cancelled drag shouldn't persist whatever order handleDragOver
+  // had optimistically applied.
+  const handleDragCancel = (_event: DragCancelEvent) => {
+    setActiveId(null);
+    isDraggingRef.current = false;
+  };
+
   return {
     sensors,
     activeId,
@@ -79,5 +96,6 @@ export function useDragAndDrop({ barId, customOrders, setCustomOrders }: UseDrag
     handleDragStart,
     handleDragOver,
     handleDragEnd,
+    handleDragCancel,
   };
 }

--- a/src/hooks/useInactivityAutoSubmit.test.ts
+++ b/src/hooks/useInactivityAutoSubmit.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useInactivityAutoSubmit } from './useInactivityAutoSubmit';
+import type { ButtonConfig } from '../types';
+
+const navStack: ButtonConfig[] = [{ id: 'beer', label: 'BEER' }, { id: 'brand_Corona', label: 'Corona' }];
+
+describe('useInactivityAutoSubmit', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('auto-submits after the timeout when navStack is non-empty and not paused', () => {
+    const submit = vi.fn();
+    const reset = vi.fn();
+    renderHook(() => useInactivityAutoSubmit(navStack, submit, reset, 1000, false));
+
+    vi.advanceTimersByTime(1000);
+
+    expect(submit).toHaveBeenCalledWith('BEER: Corona (Ask Me)');
+    expect(reset).toHaveBeenCalled();
+  });
+
+  it('does not arm the timer when navStack is empty', () => {
+    const submit = vi.fn();
+    const reset = vi.fn();
+    renderHook(() => useInactivityAutoSubmit([], submit, reset, 1000, false));
+
+    vi.advanceTimersByTime(5000);
+
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  // Regression: a user who opens InputDialog (add brand/type) or the
+  // quantity picker from within a sub-menu, and takes longer than the
+  // timeout to decide, previously got hit with both an unwanted
+  // auto-submitted request AND resetNavStack() yanking the sub-menu
+  // out from under the dialog they were still using.
+  it('does not fire while paused, even with a non-empty navStack', () => {
+    const submit = vi.fn();
+    const reset = vi.fn();
+    renderHook(() => useInactivityAutoSubmit(navStack, submit, reset, 1000, true));
+
+    vi.advanceTimersByTime(5000);
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('fires once un-paused and the timeout subsequently elapses', () => {
+    const submit = vi.fn();
+    const reset = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }) => useInactivityAutoSubmit(navStack, submit, reset, 1000, paused),
+      { initialProps: { paused: true } },
+    );
+
+    vi.advanceTimersByTime(5000);
+    expect(submit).not.toHaveBeenCalled();
+
+    rerender({ paused: false });
+    vi.advanceTimersByTime(1000);
+
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useInactivityAutoSubmit.ts
+++ b/src/hooks/useInactivityAutoSubmit.ts
@@ -8,11 +8,20 @@ import type { ButtonConfig } from '../types';
 // `submitRequest` is captured by ref so its identity changing on
 // every render does not re-arm the timer — only navStack changes do.
 // `resetNavStack` clears the stack after the timeout fires.
+//
+// `paused` should be true while a dialog reachable FROM a sub-menu is
+// open on top of it (InputDialog's add-brand/add-type/custom actions,
+// the quantity picker) — without it, a user who opens one of those
+// and takes longer than timeoutMs to type/decide got hit with both an
+// unwanted auto-submitted "(Ask Me)" request AND resetNavStack()
+// yanking the sub-menu out from under the dialog they were still
+// using, mid-input.
 export function useInactivityAutoSubmit(
   navStack: ButtonConfig[],
   submitRequest: (label: string) => void,
   resetNavStack: () => void,
   timeoutMs: number = 60000,
+  paused: boolean = false,
 ) {
   const timerRef = useRef<number | null>(null);
   const submitRef = useRef(submitRequest);
@@ -24,7 +33,7 @@ export function useInactivityAutoSubmit(
   useEffect(() => {
     if (timerRef.current) window.clearTimeout(timerRef.current);
 
-    if (navStack.length > 0) {
+    if (navStack.length > 0 && !paused) {
       timerRef.current = window.setTimeout(() => {
         const trail = navStack.map(b => b.label).join(': ');
         submitRef.current(`${trail} (Ask Me)`);
@@ -35,5 +44,5 @@ export function useInactivityAutoSubmit(
     return () => {
       if (timerRef.current) window.clearTimeout(timerRef.current);
     };
-  }, [navStack, timeoutMs]);
+  }, [navStack, timeoutMs, paused]);
 }

--- a/src/hooks/useLatestRelease.ts
+++ b/src/hooks/useLatestRelease.ts
@@ -32,7 +32,11 @@ async function fetchLatestRelease(): Promise<GitHubRelease> {
     }
     if (response.status === 429 && attempt < MAX_ATTEMPTS - 1) {
       // Secondary/abuse limit. Honor Retry-After if present; otherwise
-      // exponential backoff (1s, 2s, 4s).
+      // exponential backoff. With MAX_ATTEMPTS=3 the retry condition
+      // (attempt < MAX_ATTEMPTS - 1) only holds for attempt 0 and 1,
+      // so this actually waits 1s then 2s — attempt 2 is the final
+      // try and falls through to the generic throw below instead of
+      // backing off a third time.
       const retryAfter = Number(response.headers.get('Retry-After')) || 2 ** attempt;
       await new Promise(r => setTimeout(r, retryAfter * 1000));
       continue;

--- a/src/hooks/useMyBars.ts
+++ b/src/hooks/useMyBars.ts
@@ -37,11 +37,34 @@ export function useMyBars(user: User | null) {
   const [globalNtfyTopic, setGlobalNtfyTopic] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user) return;
+    // Clearing on sign-out matters on a shared device: without it, a
+    // second person signing in right after someone else signs out
+    // would briefly (until their own listener resolves) see the
+    // FIRST person's joined-bars list and ntfy topic still rendered —
+    // the same class of stale-state leak fixed for App.tsx's own
+    // listeners (see handleLogout's comment there).
+    if (!user) {
+      setMyBars([]);
+      setBarDetails({});
+      setGlobalNtfyTopic(null);
+      return;
+    }
     const userRef = doc(db, 'users', user.uid);
     const unsub = onSnapshot(userRef, (d) => {
       const data = d.exists() ? d.data() : {};
-      setMyBars(data.joinedBars || []);
+      const joinedBars: string[] = data.joinedBars || [];
+      // Only update if the actual bar list changed — Firestore
+      // delivers a new snapshot (and thus a new `data.joinedBars`
+      // array reference) for ANY change to this doc, including one
+      // that only touched ntfyTopic. Setting state with a new-but-
+      // content-identical array triggers the barDetails effect below
+      // (keyed on [myBars]) to redundantly re-fetch every bar's name
+      // from Firestore for no reason.
+      setMyBars(prev =>
+        prev.length === joinedBars.length && prev.every((id, i) => id === joinedBars[i])
+          ? prev
+          : joinedBars
+      );
 
       if (data.ntfyTopic) {
         setGlobalNtfyTopic(data.ntfyTopic);

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -54,14 +54,27 @@ export function usePushNotifications() {
             }).catch((e) => console.error('Failed to create urgent_alerts channel', e));
           }
 
+          // Checked before each addListener (not just once, after all
+          // four) — a fast mount/unmount (React StrictMode's double-
+          // invoke, hot reload) could otherwise unmount and run
+          // cleanup's removeAllListeners() WHILE this sequence of
+          // awaits was still partway through registering listeners;
+          // anything added after that point would never get removed,
+          // since cleanup only runs once per mount. This doesn't
+          // retroactively unregister a listener added in the same
+          // microtask as the cancellation, but it stops the leak from
+          // growing any further once cancellation is observed.
+          if (cancelled) return;
           await PushNotifications.addListener('registration', token => {
             setFcmToken(token.value);
           });
 
+          if (cancelled) return;
           await PushNotifications.addListener('registrationError', err => {
             console.error('Registration error: ', err.error);
           });
 
+          if (cancelled) return;
           await PushNotifications.addListener('pushNotificationReceived', () => {
             if (navigator.vibrate) navigator.vibrate([500, 200, 500]);
             if (!audioRef.current) audioRef.current = new Audio(`${import.meta.env.BASE_URL}alert.wav`);
@@ -72,6 +85,7 @@ export function usePushNotifications() {
             audio.play().catch(() => {});
           });
 
+          if (cancelled) return;
           await PushNotifications.addListener('pushNotificationActionPerformed', () => {
             // Future: open specific request from tap.
           });

--- a/src/hooks/useUsageBatching.ts
+++ b/src/hooks/useUsageBatching.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { doc, FieldValue, increment, updateDoc } from 'firebase/firestore';
+import { App as CapacitorApp } from '@capacitor/app';
 import { db } from '../firebase';
 
 // Buffers per-button click counts and flushes them to the bar's
 // `buttonUsage.<btnId>` map field every 10s (and on unmount /
-// beforeunload). Batching keeps the Firestore write rate down on a
+// backgrounding). Batching keeps the Firestore write rate down on a
 // busy bar — a bartender mashing the ICE button shouldn't trigger one
 // updateDoc per tap.
 //
@@ -18,6 +19,14 @@ export function useUsageBatching(barId: string | null) {
     const buffer = bufferRef.current;
     if (Object.keys(buffer).length === 0) return;
 
+    // Clear only on success, not before the write — the previous
+    // version cleared synchronously and then fired the write, so a
+    // failed/offline updateDoc lost that buffer's counts permanently
+    // (the .catch only logged; nothing put them back). Any tap
+    // buffered locally between the clear-on-flush-start and the
+    // response is merged back on top of the (still-empty-until-now)
+    // buffer, rather than being able to clobber counts that arrived
+    // during the in-flight write.
     bufferRef.current = {};
 
     const updates: Record<string, FieldValue> = {};
@@ -26,16 +35,38 @@ export function useUsageBatching(barId: string | null) {
     }
 
     updateDoc(doc(db, 'bars', barId), updates)
-      .catch(e => console.error('Failed to flush usage', e));
+      .catch(e => {
+        console.error('Failed to flush usage', e);
+        const current = bufferRef.current;
+        bufferRef.current = { ...buffer };
+        for (const [btnId, count] of Object.entries(current)) {
+          bufferRef.current[btnId] = (bufferRef.current[btnId] || 0) + count;
+        }
+      });
   }, [barId]);
 
   useEffect(() => {
     const interval = window.setInterval(flushUsage, 10000);
+    // 'beforeunload' is a browser-tab-close event — it doesn't fire
+    // reliably (often not at all) when a Capacitor native app is
+    // backgrounded or killed, which is how the overwhelming majority
+    // of mobile sessions actually end. appStateChange covers both:
+    // native backgrounding/foregrounding AND, on web, the same
+    // document-visibility signal Capacitor's web implementation backs
+    // it with — kept alongside beforeunload rather than replacing it,
+    // since desktop-web tab closes are still worth flushing on too.
     const onUnload = () => flushUsage();
     window.addEventListener('beforeunload', onUnload);
+    const appStateListener = CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+      if (!isActive) flushUsage();
+    }).catch(e => {
+      console.warn('Failed to register appStateChange listener', e);
+      return null;
+    });
     return () => {
       window.clearInterval(interval);
       window.removeEventListener('beforeunload', onUnload);
+      appStateListener.then(handle => handle?.remove());
       flushUsage();
     };
   }, [flushUsage]);

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
   /* Typeface */

--- a/src/test/rules/privilegeEscalation.test.ts
+++ b/src/test/rules/privilegeEscalation.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import { doc, setDoc, updateDoc, addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { getTestEnv, authedAs } from "./helpers";
+
+// Regression coverage for privilege-escalation holes found by an
+// adversarial audit pass — each of these was independently confirmed
+// exploitable (several emulator-verified) before this file's
+// corresponding firestore.rules fix landed. One test per closed
+// exploit, plus one confirming the legitimate path still works.
+describe("privilege escalation regressions", () => {
+  let env: Awaited<ReturnType<typeof getTestEnv>>;
+
+  beforeAll(async () => { env = await getTestEnv(); });
+  beforeEach(async () => {
+    await env.clearFirestore();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, "bars/bar_A"), { name: "Bar A", joinPolicy: "approval", subscription: "free" });
+      await setDoc(doc(db, "bars/bar_A/users/manager_alice"), { role: "Manager", status: "active", displayName: "Alice" });
+      await setDoc(doc(db, "bars/bar_A/users/staff_bob"), { role: "Staff", status: "active", displayName: "Bob" });
+    });
+  });
+  afterAll(async () => { await env.cleanup(); });
+
+  describe("off_clock status laundering (approval-gate bypass)", () => {
+    it("denies pending -> off_clock (the first half of the bypass)", async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "bars/bar_A/users/pending_carol"), { role: "Staff", status: "pending" });
+      });
+      const db = authedAs(env, "pending_carol", { bars: { bar_A: "Staff" } });
+      await assertFails(updateDoc(doc(db, "bars/bar_A/users/pending_carol"), { status: "off_clock" }));
+    });
+
+    it("denies rejected -> off_clock", async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "bars/bar_A/users/rejected_dan"), { role: "Staff", status: "rejected" });
+      });
+      const db = authedAs(env, "rejected_dan", { bars: { bar_A: "Staff" } });
+      await assertFails(updateDoc(doc(db, "bars/bar_A/users/rejected_dan"), { status: "off_clock" }));
+    });
+
+    it("still allows active -> off_clock -> active (the legitimate clock-out/in)", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertSucceeds(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), { status: "off_clock" }));
+      await assertSucceeds(updateDoc(doc(db, "bars/bar_A/users/staff_bob"), { status: "active" }));
+    });
+  });
+
+  describe("bar.subscription self-upgrade", () => {
+    it("denies a Manager flipping their own bar to premium", async () => {
+      const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+      await assertFails(updateDoc(doc(db, "bars/bar_A"), { subscription: "premium" }));
+    });
+
+    it("still allows a Manager updating an unrelated operational field", async () => {
+      const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+      await assertSucceeds(updateDoc(doc(db, "bars/bar_A"), { wells: ["Well 1"] }));
+    });
+  });
+
+  describe("/requests field spoofing", () => {
+    it("denies a create with a forged requesterName", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "EVERYONE GO HOME", requesterId: "staff_bob",
+        requesterName: "Alice (Manager)", requesterRole: "Manager",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+      }));
+    });
+
+    it("denies a create with an extra unlisted field", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "ICE", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+        junk: "x".repeat(1000),
+      }));
+    });
+
+    it("denies a create with a client-chosen literal timestamp", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "ICE", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: new Date("2099-01-01"), lastNotification: serverTimestamp(),
+      }));
+    });
+
+    it("denies a non-string photoUrl", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "ICE", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+        photoUrl: { not: "a string" },
+      }));
+    });
+
+    it("still allows a legitimate create with correctly-bound fields", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertSucceeds(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "ICE", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+      }));
+    });
+
+    it("still allows a legitimate create with a photoUrl (bottle scanner alert)", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertSucceeds(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "RESTOCK: Jameson", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+        photoUrl: "https://storage.googleapis.com/bucket/bottlePhotos/bar_A/x.jpg",
+      }));
+    });
+  });
+
+  describe("86'd list submitter spoofing", () => {
+    it("denies a Manager attributing an entry to someone else", async () => {
+      const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+      await assertFails(addDoc(collection(db, "bars/bar_A/eightySixed"), {
+        patronName: "Troublemaker", submittedBy: "staff_bob", submitterName: "Bob",
+        visibility: "public", timestamp: serverTimestamp(),
+      }));
+    });
+
+    it("still allows a Manager creating a correctly-attributed public entry", async () => {
+      const db = authedAs(env, "manager_alice", { bars: { bar_A: "Manager" } });
+      await assertSucceeds(addDoc(collection(db, "bars/bar_A/eightySixed"), {
+        patronName: "Troublemaker", submittedBy: "manager_alice", submitterName: "Alice",
+        visibility: "public", timestamp: serverTimestamp(),
+      }));
+    });
+  });
+
+  describe("invite replay", () => {
+    async function seedConsumedInvite() {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "bars/bar_A/invites/inv1"), {
+          email: "bob@example.com", role: "Staff", consumed: true,
+          consumedBy: "staff_bob", consumedAt: new Date(),
+        });
+      });
+    }
+
+    it("denies flipping consumed back to false", async () => {
+      await seedConsumedInvite();
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" }, email: "bob@example.com", email_verified: true });
+      await assertFails(updateDoc(doc(db, "bars/bar_A/invites/inv1"), { consumed: false }));
+    });
+
+    it("denies reconsuming an already-consumed invite with a different consumedBy", async () => {
+      await seedConsumedInvite();
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" }, email: "bob@example.com", email_verified: true });
+      await assertFails(updateDoc(doc(db, "bars/bar_A/invites/inv1"), {
+        consumed: true, consumedBy: "manager_alice", consumedAt: new Date(),
+      }));
+    });
+
+    it("denies consuming with a consumedBy that isn't the caller's own uid", async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "bars/bar_A/invites/inv2"), {
+          email: "carol@example.com", role: "Staff", consumed: false,
+        });
+      });
+      const db = authedAs(env, "outsider_carol", { bars: {}, email: "carol@example.com", email_verified: true });
+      await assertFails(updateDoc(doc(db, "bars/bar_A/invites/inv2"), {
+        consumed: true, consumedBy: "manager_alice", consumedAt: serverTimestamp(),
+      }));
+    });
+
+    it("still allows a fresh invite to be consumed once by its rightful invitee", async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "bars/bar_A/invites/inv3"), {
+          email: "carol@example.com", role: "Staff", consumed: false,
+        });
+      });
+      const db = authedAs(env, "outsider_carol", { bars: {}, email: "carol@example.com", email_verified: true });
+      await assertSucceeds(updateDoc(doc(db, "bars/bar_A/invites/inv3"), {
+        consumed: true, consumedBy: "outsider_carol", consumedAt: serverTimestamp(),
+      }));
+    });
+  });
+
+  describe("joinedBars size cap", () => {
+    it("denies a self-write with more than 50 joinedBars entries", async () => {
+      const db = authedAs(env, "staff_bob", {});
+      const junk = Array.from({ length: 51 }, (_, i) => `bar_junk_${i}`);
+      await assertFails(setDoc(doc(db, "users/staff_bob"), { joinedBars: junk }));
+    });
+
+    it("still allows a normal-sized joinedBars list", async () => {
+      const db = authedAs(env, "staff_bob", {});
+      await assertSucceeds(setDoc(doc(db, "users/staff_bob"), { joinedBars: ["bar_A", "bar_B"] }));
+    });
+  });
+});

--- a/src/test/storage-rules.test.ts
+++ b/src/test/storage-rules.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import {
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} from '@firebase/rules-unit-testing';
+import { ref, uploadBytes, deleteObject } from 'firebase/storage';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Regression coverage for storage.rules, which — until this file
+// existed — was never actually loaded by anything in this repo (see
+// firebase.json/vitest.rules.config.ts): a partial-segment wildcard
+// (`logo.{ext}`) made the entire file fail to parse, so neither the
+// logo rule nor the bottlePhotos rule was ever in force. `npm run
+// test:rules` now starts the Storage emulator alongside Firestore
+// specifically so a syntax regression here fails CI the same way one
+// in firestore.rules already does.
+const PROJECT_ID = 'barbacker-storage-rules-test';
+const RULES_PATH = fileURLToPath(new URL('../../storage.rules', import.meta.url));
+
+let env: RulesTestEnvironment;
+
+const BAR_A = 'bar-a';
+const BAR_B = 'bar-b';
+const staffOfA = { bars: { [BAR_A]: 'Staff' } };
+const managerOfA = { bars: { [BAR_A]: 'Manager' } };
+const staffOfB = { bars: { [BAR_B]: 'Staff' } };
+const admin = { admin: true };
+
+const tinyJpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+const jpegMeta = { contentType: 'image/jpeg' };
+
+describe('storage rules', () => {
+  beforeAll(async () => {
+    env = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      storage: {
+        rules: readFileSync(RULES_PATH, 'utf8'),
+        host: '127.0.0.1',
+        port: 9199,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  beforeEach(async () => {
+    await env.clearStorage();
+  });
+
+  describe('bar logo', () => {
+    it('lets a Manager upload a logo under 2MB', async () => {
+      const storage = env.authenticatedContext('mgr', managerOfA).storage();
+      await assertSucceeds(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('denies Staff (not Manager+) from uploading a logo', async () => {
+      const storage = env.authenticatedContext('staff', staffOfA).storage();
+      await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('denies a Manager of a different bar', async () => {
+      const storage = env.authenticatedContext('mgr-b', { bars: { [BAR_B]: 'Manager' } }).storage();
+      await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('lets an admin upload regardless of per-bar role', async () => {
+      const storage = env.authenticatedContext('root', admin).storage();
+      await assertSucceeds(uploadBytes(ref(storage, `bars/${BAR_A}/logo.png`), tinyJpeg, { contentType: 'image/png' }));
+    });
+
+    it('rejects a file over 2MB', async () => {
+      const storage = env.authenticatedContext('mgr', managerOfA).storage();
+      const big = new Uint8Array(2 * 1024 * 1024 + 1);
+      await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), big, jpegMeta));
+    });
+
+    it('rejects a non-image contentType', async () => {
+      const storage = env.authenticatedContext('mgr', managerOfA).storage();
+      await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), tinyJpeg, { contentType: 'text/html' }));
+    });
+
+    it('only matches files literally named logo.<ext> — a Manager cannot write elsewhere under bars/{barId}/ via this rule', async () => {
+      const storage = env.authenticatedContext('mgr', managerOfA).storage();
+      await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/not-a-logo.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('is readable by any signed-in user, including a member of a different bar', async () => {
+      const uploader = env.authenticatedContext('mgr', managerOfA).storage();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await uploadBytes(ref(ctx.storage(), `bars/${BAR_A}/logo.jpg`), tinyJpeg, jpegMeta);
+      });
+      const outsider = env.authenticatedContext('staff-b', staffOfB).storage();
+      // getDownloadURL isn't emulator-friendly here; getBytes proves the read rule.
+      const { getBytes } = await import('firebase/storage');
+      await assertSucceeds(getBytes(ref(outsider, `bars/${BAR_A}/logo.jpg`)));
+      void uploader;
+    });
+  });
+
+  describe('bottlePhotos', () => {
+    it('lets any bar member (not just Manager+) upload', async () => {
+      const storage = env.authenticatedContext('staff', staffOfA).storage();
+      await assertSucceeds(uploadBytes(ref(storage, `bottlePhotos/${BAR_A}/staff_123.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('denies a member of a different bar from writing into bar A\'s path', async () => {
+      const storage = env.authenticatedContext('staff-b', staffOfB).storage();
+      await assertFails(uploadBytes(ref(storage, `bottlePhotos/${BAR_A}/staff-b_123.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('denies a signed-in user with no role at all', async () => {
+      const storage = env.authenticatedContext('nobody', {}).storage();
+      await assertFails(uploadBytes(ref(storage, `bottlePhotos/${BAR_A}/nobody_123.jpg`), tinyJpeg, jpegMeta));
+    });
+
+    it('rejects a file over 5MB', async () => {
+      const storage = env.authenticatedContext('staff', staffOfA).storage();
+      const big = new Uint8Array(5 * 1024 * 1024 + 1);
+      await assertFails(uploadBytes(ref(storage, `bottlePhotos/${BAR_A}/staff_big.jpg`), big, jpegMeta));
+    });
+
+    it('is readable by a member of that bar', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await uploadBytes(ref(ctx.storage(), `bottlePhotos/${BAR_A}/staff_1.jpg`), tinyJpeg, jpegMeta);
+      });
+      const reader = env.authenticatedContext('mgr', managerOfA).storage();
+      const { getBytes } = await import('firebase/storage');
+      await assertSucceeds(getBytes(ref(reader, `bottlePhotos/${BAR_A}/staff_1.jpg`)));
+    });
+
+    it('is NOT readable by a member of a different bar (unlike the logo, this is per-bar content)', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await uploadBytes(ref(ctx.storage(), `bottlePhotos/${BAR_A}/staff_1.jpg`), tinyJpeg, jpegMeta);
+      });
+      const reader = env.authenticatedContext('staff-b', staffOfB).storage();
+      const { getBytes } = await import('firebase/storage');
+      await assertFails(getBytes(ref(reader, `bottlePhotos/${BAR_A}/staff_1.jpg`)));
+    });
+
+    it('is not readable by a signed-in user with no bar membership at all', async () => {
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await uploadBytes(ref(ctx.storage(), `bottlePhotos/${BAR_A}/staff_1.jpg`), tinyJpeg, jpegMeta);
+      });
+      const reader = env.authenticatedContext('nobody', {}).storage();
+      const { getBytes } = await import('firebase/storage');
+      await assertFails(getBytes(ref(reader, `bottlePhotos/${BAR_A}/staff_1.jpg`)));
+    });
+  });
+
+  it('denies every path for an unauthenticated request', async () => {
+    const storage = env.unauthenticatedContext().storage();
+    await assertFails(uploadBytes(ref(storage, `bars/${BAR_A}/logo.jpg`), tinyJpeg, jpegMeta));
+    await assertFails(uploadBytes(ref(storage, `bottlePhotos/${BAR_A}/x.jpg`), tinyJpeg, jpegMeta));
+  });
+});
+
+// Referenced only to keep the deleteObject import intentional if a
+// future rule adds delete coverage — currently write also governs
+// delete (Storage has no separate `allow delete`), and no rule here
+// permits it since `request.resource` is null on a delete request
+// and every write rule requires `request.resource.size`/`contentType`.
+void deleteObject;

--- a/storage.rules
+++ b/storage.rules
@@ -11,12 +11,23 @@ service firebase.storage {
     // by any signed-in user. Writes are restricted to Manager+ of
     // that specific bar, checked against the same `bars` custom claim
     // firestore.rules uses (stamped by the onUserRoleChange Cloud
-    // Function), plus the `admin` claim for moderation. Size/type
-    // limits mirror the client-side check in ThemeEditor.tsx so a
-    // client that skips the UI validation can't bypass it.
-    match /bars/{barId}/logo.{ext} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null &&
+    // Function), plus the `admin` claim for moderation. Size limit
+    // mirrors the client-side check in ThemeEditor.tsx. contentType
+    // is a client-supplied header, not a verification of the actual
+    // bytes — Storage rules cannot inspect file contents — so treat
+    // this as a UX nicety, not a security boundary; it's still useful
+    // against a client that skips the UI validation, just not against
+    // a deliberately malicious one.
+    //
+    // Wildcards must occupy a whole path segment (`logo.{ext}` is
+    // invalid rules syntax and fails to compile, which silently
+    // dropped this ENTIRE FILE and left the bucket governed by
+    // whatever was last set in the Firebase console — see the header
+    // comment above). {fileName} matches the whole segment; the
+    // string check below re-narrows it to "logo.<ext>" specifically.
+    match /bars/{barId}/{fileName} {
+      allow read: if request.auth != null && fileName.matches('logo\\..+');
+      allow write: if request.auth != null && fileName.matches('logo\\..+') &&
         (request.auth.token.admin == true ||
          request.auth.token.get('bars', {}).get(barId, '') in ['Manager', 'Owner']) &&
         request.resource.size < 2 * 1024 * 1024 &&
@@ -24,15 +35,21 @@ service firebase.storage {
     }
 
     // Bottle-scanner photos (BottleScanner.tsx "Send Alert" action).
-    // Unlike the logo, any bar member can write here — the whole
+    // Unlike the logo, any bar member can WRITE here — the whole
     // point is a bartender/barback flagging something to a manager,
     // not just managers themselves. Membership is "holds any role for
     // this bar", the same check firestore.rules' hasRole() does.
-    // Readable by any signed-in user, matching the logo rule, since a
-    // request's photo is only ever shown to other members of the same
-    // bar anyway (firestore.rules gates the /requests doc itself).
+    //
+    // READ is scoped to that same membership (not "any signed-in
+    // user" as the logo rule is) — unlike the logo, this is
+    // per-bar content that shouldn't be fetchable by an outsider, an
+    // ex-staff member of a different bar, or anyone else who happens
+    // across the download URL (which never expires and is stored
+    // un-redacted on the /requests doc every bar member can read).
     match /bottlePhotos/{barId}/{fileName} {
-      allow read: if request.auth != null;
+      allow read: if request.auth != null &&
+        (request.auth.token.admin == true ||
+         request.auth.token.get('bars', {}).get(barId, '') != '');
       allow write: if request.auth != null &&
         (request.auth.token.admin == true ||
          request.auth.token.get('bars', {}).get(barId, '') != '') &&

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
       // place in the jsdom suite.
       '**/firestore-rules.test.ts',
       'src/test/rules/**',
+      'src/test/storage-rules.test.ts',
       // The Cloud Functions package has its own vitest config; the
       // root suite shouldn't pick it up.
       'functions/**',

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/test/firestore-rules.test.ts', 'src/test/rules/**/*.test.ts'],
+    include: ['src/test/firestore-rules.test.ts', 'src/test/rules/**/*.test.ts', 'src/test/storage-rules.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     reporters: ['verbose'],


### PR DESCRIPTION
## Summary

Six independent adversarial audits were run across the app: the bottle scanner feature, Firestore + Storage rules, the Cloud Functions backend, client hooks/state management, UX/accessibility, and deployment/CI. Combined they found a large number of real, mostly CONFIRMED (many emulator- or execution-verified) bugs — several of them privilege-escalation or data-integrity issues, plus a foundational one (nothing in `functions/src/` was ever actually deployable).

This PR is being built incrementally, one logical batch per commit, all against this branch. **This is not yet the complete fix set** — it will keep growing with more commits before being marked ready for review. Opening it now as a draft so CI runs on each push and progress is visible.

## Landed so far

**Foundational (nothing else could be verified without these):**
- `firebase.json` had no `"functions"` target at all — confirmed by actually running `firebase deploy --only functions` (failed: "no targets match") and the functions emulator (wouldn't start). Every Cloud Function in this repo has likely never reached production. Fixed, and re-verified both now succeed/load correctly.
- `storage.rules` has had a syntax error since it was introduced (`logo.{ext}` — an illegal partial-segment wildcard) that made the **entire file** fail to parse. Confirmed by loading it into the real Storage emulator. The bucket has been governed by whatever's in the Firebase console instead of this repo's rules, for both the logo rule and the bottle-scanner's `bottlePhotos` rule. Fixed, and added 16 new Storage rules tests (there were previously zero — that's how this went unnoticed). While fixing it also narrowed `bottlePhotos` reads to bar members only (was "any signed-in user") and corrected a comment that claimed the `contentType` check can't be bypassed (it validates a client-supplied header, not the actual bytes).
- `src/index.css` used Tailwind v3's `@tailwind base/components/utilities` directives in a Tailwind v4 project. Verified by diffing actual build output before/after: the v3 directives were producing a degraded CSS bundle (149 rules, no theme/color-token layer) — every color utility class used throughout the app (`text-red-100`, etc.) was silently absent. Switched to the v4 `@import "tailwindcss";` form; rebuild now produces 427 rules including the full theme layer.
- Deploy docs/scripts only ever ran `firebase deploy --only functions`, which never deploys `firestore.rules`/`storage.rules`/indexes — so a rules change shipped alongside a functions change (exactly what happened with the bottle scanner) could go out of sync with what's enforced. Now deploys all four together.
- CI never built or tested `functions/` at all, and never started the Storage emulator. Added a dedicated `functions` CI job and wired Storage into the existing rules-tests workflow.
- `deploy.yml` used `npm install` instead of `npm ci`, and never set `VITE_ICAL_FEED_BASE_URL` — the outbound iCal feed link has never been shown in a single deployed build.

## Verification (this batch)
- [x] `firebase deploy --only functions` — now proceeds past target resolution to auth (previously failed immediately)
- [x] `firebase emulators:exec --only functions` — all 28 functions load and initialize
- [x] `firebase emulators:exec --only storage` — file now parses; ran a real exploit/behavior suite against it
- [x] `npm run test:rules` — 108/108 passing (92 existing Firestore + 16 new Storage)
- [x] `cd functions && npm run build && npm test` — 19/19 passing
- [x] `npx tsc --noEmit` + `npm run build` (full vite build) — clean
- [x] `npm test -- --run` — 132/132 passing
- [x] All touched workflow YAML re-validated with a YAML parser

## Still coming in follow-up commits to this branch
- Firestore rules privilege-escalation fixes (self-approved ownership claims, invite replay, approval-gate bypass via status laundering, subscription self-upgrade, missing field allowlists on `/requests` and the 86'd list)
- Cloud Functions backend fixes (notification fanout failure handling, migration idempotency ordering, nag-bot batching, missing `Staff` notification defaults)
- CI/CD security (the Jules automation's merge-on-comment exposure, Android release-pipeline integrity)
- Client state management (sign-out doesn't clear app state, bar-switch data leaks, several hook bugs)
- UX fixes (silent write failures, owner lockout, inconsistent premium gating, blocking `alert()`/`confirm()` calls)
- Bottle-scanner-specific bugs found in its own dedicated audit pass (brand-name Firestore field-path corruption, a fuzzy-matcher false-positive class, an irreversible "86 It" action, and others)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Harden storage security, fix deployment gaps, and ensure Cloud Functions and rules are consistently built, tested, and deployed together.

Bug Fixes:
- Fix Storage rules so they parse correctly and enforce access/size/content-type constraints for bar logos and bottlePhotos instead of silently failing.
- Ensure the outbound iCal feed URL is wired into CI builds so the iCal link is present in deployed web builds.
- Correct Tailwind CSS initialization to use the Tailwind v4 import so the full utility theme is available in production builds.
- Update Cloud Functions deploy commands to include Firestore rules, Firestore indexes, and Storage rules to keep backend logic and security rules in sync.

Enhancements:
- Document the GitHub Pages deployment workflow and clarify correct manual deploy usage and required environment variables.
- Strengthen the rules test suite and Vite test config to include Storage rules coverage alongside Firestore rules.
- Add a dedicated CI job that builds and tests the Cloud Functions package, preventing type or unit test regressions from reaching main.
- Tighten CI workflows with job timeouts, Node.js dependency caching, and immutable installs via npm ci for more reliable, reproducible builds.

Build:
- Adjust root and functions package scripts so test:rules and deploy flows start both Firestore and Storage emulators and deploy all relevant rules and indexes together.

CI:
- Expand the rules-tests workflow to run Storage emulator-based rules tests and add a separate functions job that builds and tests the Cloud Functions package on every push.
- Improve the deploy workflow with timeouts, npm caching, and npm ci to make production builds deterministic and faster.

Documentation:
- Update deployment documentation to describe the automated GitHub Pages workflow and to recommend deploying functions and Firestore/Storage rules together via firebase deploy.
- Clarify that the manual npm run deploy command is for exceptional use only and requires all VITE_FIREBASE_* variables to be set to avoid generating unusable service workers.

Tests:
- Introduce a dedicated Storage rules test suite covering bar logo and bottlePhotos access controls, sizes, and content types, and wire it into vitest and CI so Storage rule regressions fail the pipeline.