### PR TITLE
Fix UX gating inconsistencies and missing destructive-action confirms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1571,7 +1571,11 @@ function App() {
 
   // Check for pending users (for Managers).
   const pendingUsers = allUsers.filter(u => u.status === 'pending');
-  const showApprovals = pendingUsers.length > 0;
+  // Gated by isManagerPlus: the badge previously showed to every role,
+  // but WhoIsOnDialog only renders the approvals section for
+  // Manager+, so Staff clicking it landed on a dialog with nothing
+  // relevant to approve — a confusing dead end.
+  const showApprovals = isManagerPlus && pendingUsers.length > 0;
 
   // 4. Pending Approval Screen
   if (userStatus === 'pending') {
@@ -1611,7 +1615,6 @@ function App() {
         onDelete={deleteEightySixEntry}
         isPremium={isPremium}
         userRole={userRole}
-        currentUserId={user?.uid}
       />
 
       {isPremium && (

--- a/src/components/BarManager.test.tsx
+++ b/src/components/BarManager.test.tsx
@@ -85,11 +85,36 @@ describe('BarManager', () => {
         onHideButton={onHide}
         isPremium={true}
         onUnhideButton={onUnhide}
+        isManagerPlus={true}
       />
     );
 
     // Should show the hidden button in the "Restorable" section
     expect(screen.getByText('Restorable Buttons (Premium)')).toBeDefined();
     expect(screen.getByText('Hidden Button B')).toBeDefined();
+  });
+
+  it('hides remove/restore controls for non-Manager+ viewers', () => {
+    const onHide = vi.fn();
+    const onClose = vi.fn();
+    const onUnhide = vi.fn();
+
+    render(
+      <BarManager
+        open={true}
+        onClose={onClose}
+        barName="Test Bar"
+        allButtons={buttons}
+        hiddenButtonIds={['2']}
+        onHideButton={onHide}
+        isPremium={true}
+        onUnhideButton={onUnhide}
+        isManagerPlus={false}
+      />
+    );
+
+    expect(screen.queryByLabelText(/Remove Visible Button A/)).toBeNull();
+    // Restorable section itself is Manager+-gated, so it shouldn't render at all.
+    expect(screen.queryByText('Restorable Buttons (Premium)')).toBeNull();
   });
 });

--- a/src/components/BarManager.tsx
+++ b/src/components/BarManager.tsx
@@ -119,10 +119,15 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
                     <div slot="headline">{btn.label}</div>
                     {/* Button Icon */}
                     <md-icon slot="start">{btn.icon || 'circle'}</md-icon>
-                    {/* Delete Action */}
-                    <md-icon-button slot="end" onClick={() => handleDeleteClick(btn.id)}>
-                        <md-icon>close</md-icon>
-                    </md-icon-button>
+                    {/* Delete Action — Manager+ only; writes to the bar doc are
+                        rejected by firestore.rules for anyone else, so a
+                        visible-but-broken control here would just alert a
+                        confusing "failed, try again" for Staff. */}
+                    {isManagerPlus && (
+                      <md-icon-button slot="end" aria-label={`Remove ${btn.label}`} onClick={() => handleDeleteClick(btn.id)}>
+                          <md-icon>close</md-icon>
+                      </md-icon-button>
+                    )}
                     </md-list-item>
                 ))}
                 {/* Empty State */}
@@ -162,8 +167,8 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
              </div>
            )}
 
-           {/* Hidden Buttons (Premium Only) */}
-           {isPremium && hiddenButtons.length > 0 && (
+           {/* Hidden Buttons (Manager+, Premium Only) */}
+           {isManagerPlus && isPremium && hiddenButtons.length > 0 && (
                <div className="mt-4 border border-red-800 rounded overflow-y-auto max-h-[30vh]">
                    <div className="bg-red-900/20 p-2 text-xs font-bold text-red-400 uppercase">Restorable Buttons (Premium)</div>
                    <md-list>
@@ -171,7 +176,7 @@ const BarManager = ({ open, onClose, barName, allButtons, hiddenButtonIds, onHid
                            <md-list-item key={btn.id}>
                                <div slot="headline">{btn.label}</div>
                                <md-icon slot="start">{btn.icon || 'circle'}</md-icon>
-                               <md-icon-button slot="end" onClick={() => onUnhideButton && onUnhideButton(btn.id)}>
+                               <md-icon-button slot="end" aria-label={`Restore ${btn.label}`} onClick={() => onUnhideButton && onUnhideButton(btn.id)}>
                                    <md-icon>restore</md-icon>
                                </md-icon-button>
                            </md-list-item>

--- a/src/components/CalendarView.test.tsx
+++ b/src/components/CalendarView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CalendarView } from './CalendarView';
 import { CalendarEvent } from '../types';
@@ -45,16 +45,20 @@ describe('CalendarView', () => {
 
   it('shows Edit/Delete for a local event but not for an externally-owned one', () => {
     renderView();
-    // Local event gets both; external event gets neither.
+    // Local event gets both; external event gets neither. The confirm-delete
+    // dialog's own Delete button is always mounted (just unopened), so one
+    // extra 'Delete' is expected alongside the event row's.
     expect(screen.getAllByText('Edit').length).toBe(1);
-    expect(screen.getAllByText('Delete').length).toBe(1);
+    expect(screen.getAllByText('Delete').length).toBe(2);
   });
 
   it('hides Add Event and Edit/Delete entirely for non-Manager+ viewers', () => {
     renderView({ isManagerPlus: false });
     expect(screen.queryByText('Add Event')).not.toBeInTheDocument();
     expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    // Only the (unopened) confirm-delete dialog's own Delete button remains;
+    // no event row renders one when the viewer isn't Manager+.
+    expect(screen.getAllByText('Delete').length).toBe(1);
   });
 
   it('shows an empty state with no events', () => {
@@ -62,10 +66,23 @@ describe('CalendarView', () => {
     expect(screen.getByText('No events.')).toBeInTheDocument();
   });
 
-  it('calls onDelete for the right event', () => {
+  it('calls onDelete for the right event after confirming', async () => {
     renderView();
-    fireEvent.click(screen.getByText('Delete'));
-    expect(mockOnDelete).toHaveBeenCalledWith('e1');
+    // Two 'Delete' texts exist: the event row's, and the (unopened)
+    // confirm dialog's own button, in that DOM order.
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+    expect(mockOnDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByText('Delete')[1]);
+    await waitFor(() => expect(mockOnDelete).toHaveBeenCalledWith('e1'));
+  });
+
+  it('does not delete when the confirmation is cancelled', () => {
+    renderView();
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+    // Two 'Cancel' texts exist: the (unopened) edit dialog's, and the
+    // confirm-delete dialog's, in that DOM order.
+    fireEvent.click(screen.getAllByText('Cancel')[1]);
+    expect(mockOnDelete).not.toHaveBeenCalled();
   });
 
   it('opens the add-event form and creates an event on save', async () => {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -38,6 +38,8 @@ export function CalendarView({ open, onClose, events, isManagerPlus, onCreate, o
   const [editing, setEditing] = useState<CalendarEvent | 'new' | null>(null);
   const [form, setForm] = useState({ title: '', start: '', end: '', type: 'event', description: '' });
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const upcoming = [...events].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
 
@@ -56,6 +58,7 @@ export function CalendarView({ open, onClose, events, isManagerPlus, onCreate, o
   const handleSave = async () => {
     if (!form.title.trim() || !form.start || !form.end) return;
     setSaving(true);
+    setSaveError(null);
     try {
       const payload = {
         title: form.title.trim(),
@@ -67,8 +70,27 @@ export function CalendarView({ open, onClose, events, isManagerPlus, onCreate, o
       if (editing === 'new') await onCreate(payload);
       else if (editing) await onUpdate(editing.id, payload);
       setEditing(null);
+    } catch (e) {
+      // Previously uncaught — onCreate/onUpdate rejecting (permission
+      // denied, offline) surfaced nothing at all: the dialog just sat
+      // there with the Save button re-enabled and no indication
+      // anything had gone wrong.
+      console.error('Failed to save calendar event', e);
+      setSaveError('Failed to save. Please try again.');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!confirmDeleteId) return;
+    try {
+      await onDelete(confirmDeleteId);
+    } catch (e) {
+      console.error('Failed to delete calendar event', e);
+      alert('Failed to delete. Please try again.');
+    } finally {
+      setConfirmDeleteId(null);
     }
   };
 
@@ -98,7 +120,7 @@ export function CalendarView({ open, onClose, events, isManagerPlus, onCreate, o
                 {canEdit && (
                   <div className="flex flex-col gap-1 shrink-0">
                     <md-text-button onClick={() => openEdit(event)}>Edit</md-text-button>
-                    <md-text-button onClick={() => onDelete(event.id)}>Delete</md-text-button>
+                    <md-text-button onClick={() => setConfirmDeleteId(event.id)}>Delete</md-text-button>
                   </div>
                 )}
               </div>
@@ -127,10 +149,22 @@ export function CalendarView({ open, onClose, events, isManagerPlus, onCreate, o
           </select>
           <md-filled-text-field label="Description" value={form.description}
             onInput={(e: any) => setForm((f) => ({ ...f, description: e.target.value }))} />
+          {saveError && <div className="text-xs text-red-400">{saveError}</div>}
         </div>
         <div slot="actions">
           <md-text-button onClick={() => setEditing(null)}>Cancel</md-text-button>
-          <md-filled-button disabled={!form.title.trim() || saving || undefined} onClick={handleSave}>Save</md-filled-button>
+          <md-filled-button disabled={!form.title.trim() || saving || undefined} onClick={handleSave}>
+            {saving ? 'Saving…' : 'Save'}
+          </md-filled-button>
+        </div>
+      </MdDialog>
+
+      <MdDialog open={confirmDeleteId !== null} onClose={() => setConfirmDeleteId(null)}>
+        <div slot="headline">Delete Event?</div>
+        <div slot="content">This can't be undone.</div>
+        <div slot="actions">
+          <md-text-button onClick={() => setConfirmDeleteId(null)}>Cancel</md-text-button>
+          <md-filled-button className="btn-alert" onClick={handleConfirmDelete}>Delete</md-filled-button>
         </div>
       </MdDialog>
     </>

--- a/src/components/ChatPanel.test.tsx
+++ b/src/components/ChatPanel.test.tsx
@@ -7,7 +7,7 @@ const mockOnClose = vi.fn();
 const mockOnLoadMore = vi.fn();
 const mockOnSend = vi.fn();
 const mockOnTogglePin = vi.fn();
-const mockOnDelete = vi.fn();
+const mockOnDelete = vi.fn().mockResolvedValue(undefined);
 
 const baseMessage: ChatMessage = {
   id: 'm1',
@@ -54,15 +54,28 @@ describe('ChatPanel', () => {
     expect(screen.getByText(/no messages yet/i)).toBeInTheDocument();
   });
 
-  it('lets the author delete their own message even when not Manager+', () => {
+  it('lets the author delete their own message after confirming, even when not Manager+', async () => {
     renderPanel({ isManagerPlus: false, currentUserId: 'alice' });
-    fireEvent.click(screen.getByText('Delete'));
-    expect(mockOnDelete).toHaveBeenCalledWith('m1');
+    // Two 'Delete' texts exist: the message's own, and the (unopened)
+    // confirm dialog's own button, in that DOM order.
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+    expect(mockOnDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByText('Delete')[1]);
+    await waitFor(() => expect(mockOnDelete).toHaveBeenCalledWith('m1'));
+  });
+
+  it('does not delete when the confirmation is cancelled', () => {
+    renderPanel({ isManagerPlus: false, currentUserId: 'alice' });
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockOnDelete).not.toHaveBeenCalled();
   });
 
   it('hides delete for a non-author, non-Manager+ viewer', () => {
     renderPanel({ isManagerPlus: false, currentUserId: 'bob' });
-    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    // Only the (unopened) confirm dialog's own Delete button remains;
+    // the message itself doesn't render one for this viewer.
+    expect(screen.getAllByText('Delete').length).toBe(1);
   });
 
   it('hides pin/unpin controls for non-Manager+ viewers', () => {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -20,7 +20,7 @@ interface ChatPanelProps {
   isManagerPlus: boolean;
   onSend: (text: string, pin: boolean) => Promise<void>;
   onTogglePin: (messageId: string, pin: boolean) => void;
-  onDelete: (messageId: string) => void;
+  onDelete: (messageId: string) => Promise<void>;
 }
 
 // Full-screen chat sheet — Phase 2 of
@@ -36,6 +36,7 @@ export function ChatPanel({
   const [pinNext, setPinNext] = useState(false);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
 
@@ -72,7 +73,20 @@ export function ChatPanel({
     }
   };
 
+  const handleConfirmDelete = async () => {
+    if (!confirmDeleteId) return;
+    try {
+      await onDelete(confirmDeleteId);
+    } catch (e) {
+      console.error('Failed to delete chat message', e);
+      alert('Failed to delete. Please try again.');
+    } finally {
+      setConfirmDeleteId(null);
+    }
+  };
+
   return (
+    <>
     <MdDialog
       open={open}
       onClose={onClose}
@@ -116,7 +130,7 @@ export function ChatPanel({
                     </md-text-button>
                   )}
                   {canDelete && (
-                    <md-text-button onClick={() => onDelete(m.id)}>Delete</md-text-button>
+                    <md-text-button onClick={() => setConfirmDeleteId(m.id)}>Delete</md-text-button>
                   )}
                 </div>
               </div>
@@ -153,6 +167,16 @@ export function ChatPanel({
         <md-text-button onClick={onClose}>Close</md-text-button>
       </div>
     </MdDialog>
+
+    <MdDialog open={confirmDeleteId !== null} onClose={() => setConfirmDeleteId(null)}>
+      <div slot="headline">Delete Message?</div>
+      <div slot="content">This can't be undone.</div>
+      <div slot="actions">
+        <md-text-button onClick={() => setConfirmDeleteId(null)}>Cancel</md-text-button>
+        <md-filled-button className="btn-alert" onClick={handleConfirmDelete}>Delete</md-filled-button>
+      </div>
+    </MdDialog>
+    </>
   );
 }
 

--- a/src/components/EightySixDialog.test.tsx
+++ b/src/components/EightySixDialog.test.tsx
@@ -32,7 +32,6 @@ describe('EightySixDialog', () => {
     onDelete: vi.fn().mockResolvedValue(undefined),
     isPremium: false,
     userRole: 'Bartender' as string | null,
-    currentUserId: 'user3',
   };
 
   it('renders public entries for all users', () => {

--- a/src/components/EightySixDialog.tsx
+++ b/src/components/EightySixDialog.tsx
@@ -22,7 +22,6 @@ interface EightySixDialogProps {
   onDelete: (entryId: string) => Promise<void>;
   isPremium: boolean;
   userRole: string | null;
-  currentUserId?: string;
 }
 
 const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, userRole }: EightySixDialogProps) => {
@@ -172,7 +171,7 @@ const EightySixDialog = ({ open, onClose, entries, onAdd, onDelete, isPremium, u
                       )}
                     </div>
                     {canDelete && (
-                      <md-icon-button slot="end" onClick={() => setConfirmDeleteId(entry.id)}>
+                      <md-icon-button slot="end" aria-label={`Remove ${entry.patronName} from 86'd list`} onClick={() => setConfirmDeleteId(entry.id)}>
                         <md-icon>close</md-icon>
                       </md-icon-button>
                     )}

--- a/src/components/WhoIsOnDialog.tsx
+++ b/src/components/WhoIsOnDialog.tsx
@@ -43,6 +43,7 @@ export const WhoIsOnDialog = ({
   // Filter for active users (clocked in).
   // Note: users with undefined status are treated as active for backward compatibility.
   const clockedInUsers = users.filter(u => u.status === 'active' || u.status === undefined);
+  const offClockUsers = users.filter(u => u.status === 'off_clock');
   const pendingUsers = users.filter(u => u.status === 'pending');
 
   return (
@@ -114,6 +115,24 @@ export const WhoIsOnDialog = ({
                </md-list>
            </div>
         </div>
+
+        {/* Section: Off Clock */}
+        {offClockUsers.length > 0 && (
+          <div>
+             <h3 className="text-gray-400 font-bold text-sm uppercase tracking-wide mb-2">Off Clock ({offClockUsers.length})</h3>
+             <div className="border border-gray-800 rounded overflow-hidden">
+                 <md-list>
+                     {offClockUsers.map(u => (
+                         <md-list-item key={u.id}>
+                             <div slot="headline" className="text-gray-300">{u.displayName || 'Unknown'}</div>
+                             <div slot="supporting-text" className="text-gray-500">{u.jobTitle || u.role}</div>
+                             <md-icon slot="start" className="text-gray-600">radio_button_unchecked</md-icon>
+                         </md-list-item>
+                     ))}
+                 </md-list>
+             </div>
+          </div>
+        )}
       </div>
       <div slot="actions">
         <md-text-button onClick={onClose}>Close</md-text-button>

--- a/src/hooks/useMyBars.ts
+++ b/src/hooks/useMyBars.ts
@@ -74,6 +74,14 @@ export function useMyBars(user: User | null) {
         setDoc(userRef, { ntfyTopic: newTopic }, { merge: true })
           .catch(e => console.warn('Failed to persist ntfy topic', e));
       }
+    }, (err) => {
+      // Previously had no error handler at all: if this listener ever
+      // errored (permission-denied, offline), globalNtfyTopic stayed
+      // null forever with nothing logged — NotificationSettings reads
+      // that as "still loading" and shows a spinner-less "Loading..."
+      // badge indefinitely, with no way for the user to tell it's
+      // actually failed rather than just slow.
+      console.error('Failed to load user doc / ntfy topic', err);
     });
     return () => unsub();
   }, [user]);


### PR DESCRIPTION
## Summary

Continuation of the UX findings from the earlier 6-way adversarial audit (the bulk of that work already landed and merged in #295). This picks up the remaining items in that audit's "gating consistency, missing confirms, misc component bugs" bucket.

- **Approvals badge shown to non-Managers**: `showApprovals` only checked `pendingUsers.length`, not role, so Staff could see the "N Approvals" badge and tap into a `WhoIsOnDialog` whose approvals section only renders for Manager+ — a dead-end empty dialog. Now gated by `isManagerPlus`.
- **BarManager controls not gated despite being Manager+-only server-side**: the remove/restore icon buttons for pager buttons had no `isManagerPlus` gate in the UI, even though `firestore.rules` already restricts the underlying bar-doc write to Manager+. Staff could see and click them, only to hit a generic "failed, try again" alert with no explanation. Both controls (and the whole Restorable-buttons section) are now Manager+-gated to match what the rules already enforce.
- **WhoIsOnDialog missing off-clock section**: `docs/COMPONENTS.md` claims it "displays a list of currently active and off-clock users"; it only ever rendered "Clocked In". Added an Off Clock section sourced from the same `allUsers` list already being passed in.
- **useMyBars ntfy-topic listener had no error handler**: if the `users/{uid}` snapshot listener ever failed (permission-denied, offline), `globalNtfyTopic` stayed `null` forever with nothing logged, and `NotificationSettings` reads that as "still loading" — a silently permanent "Loading..." badge with no way to tell it had actually failed. Added the missing error handler.
- **Chat message delete had zero confirmation**: fired immediately on click, the same one-click-destructive pattern already fixed for calendar events in a prior batch. Added a confirm dialog matching that pattern; `onDelete`'s prop type now reflects the `Promise` it always returned, so the confirm handler can catch and surface failures instead of leaving a stuck dialog on a rejected delete.
- **EightySixDialog delete icon-button missing an aria-label.**

Test changes are mostly mechanical fallout of dialogs that were previously asserted as singly-rendered now needing disambiguation — the `MdDialog` wrapper always mounts its children regardless of the `open` prop (only the attribute toggles), so adding a second dialog (the delete-confirmation one) means its own "Delete"/"Cancel" text is always present in the DOM alongside the row/message's own button.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 142/142 passing
- [x] `npm run build` — clean
- [x] `npm run test:rules` — 127/127 passing (unaffected by this batch, run as a sanity check since a prior batch touches rules)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Tighten UX gating and destructive-action flows across calendar, chat, bar management, approvals, and 86 list dialogs for consistency with permissions and accessibility expectations.

New Features:
- Add confirmation dialogs for deleting calendar events and chat messages, with user-visible failure handling.
- Display a dedicated Off Clock section in the WhoIsOn dialog when off-clock users are present.

Bug Fixes:
- Gate the approvals badge and pending-approvals flow to Manager+ users to match WhoIsOnDialog behavior.
- Restrict BarManager remove and restore controls, including the restorable-buttons section, to Manager+ viewers to align with server-side rules.
- Ensure the ntfy-topic listener in useMyBars logs errors instead of silently leaving notification settings in a perpetual loading state.

Enhancements:
- Surface save status and errors in the calendar event editor, including a saving state indicator.
- Add aria-labels to destructive icon buttons in BarManager and EightySixDialog to improve accessibility.
- Adjust tests to account for always-mounted dialogs and new gating/confirmation behaviors.