### PR TITLE
Fix BottleScanner bugs from the dedicated audit pass

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -426,7 +426,21 @@ service cloud.firestore {
              get(/databases/$(database)/documents/bars/$(request.resource.data.barId)/users/$(request.auth.uid)).data.get('role', '')
         && request.resource.data.timestamp == request.time
         && request.resource.data.lastNotification == request.time
-        && (!('photoUrl' in request.resource.data) || request.resource.data.photoUrl is string);
+        // A bare "is string" check only constrained the type, not the
+        // value — a client could still point this at an arbitrary
+        // attacker-controlled URL. It's rendered as a raw `<img src>`
+        // on every other member's device (see App.tsx), so that was
+        // an open tracking-pixel/IP-collection vector: every other bar
+        // member's client would fetch whatever URL was set, no user
+        // action needed. Pinned to this bar's own bottlePhotos Storage
+        // path — the only thing sendBottleAlert ever actually uploads
+        // to (see storage.rules' matching bottlePhotos rule) — so it
+        // can't reference another bar's photos or an external host.
+        && (!('photoUrl' in request.resource.data) || (
+             request.resource.data.photoUrl is string &&
+             request.resource.data.photoUrl
+               .matches('^https://firebasestorage\\.googleapis\\.com/v0/b/[^/]+/o/bottlePhotos%2F' + request.resource.data.barId + '%2F.*$')
+           ));
       // The only client-side update is claiming: pending -> claimed,
       // touching only the claim fields, with barId/requesterId/label
       // immutable so a member of one bar can't rewrite a request into

--- a/functions/src/__tests__/onRequestDeleted.test.ts
+++ b/functions/src/__tests__/onRequestDeleted.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { parseStorageObjectPath } from "../onRequestDeleted";
+
+describe("parseStorageObjectPath", () => {
+  it("extracts and decodes the object path from a getDownloadURL()-style URL", () => {
+    const url =
+      "https://firebasestorage.googleapis.com/v0/b/my-bucket.appspot.com/o/bottlePhotos%2Fbar_A%2Fuser1_123.jpg?alt=media&token=abc-123";
+    expect(parseStorageObjectPath(url)).toBe("bottlePhotos/bar_A/user1_123.jpg");
+  });
+
+  it("returns null for a URL with no /o/ segment", () => {
+    expect(parseStorageObjectPath("https://example.com/not-a-storage-url")).toBeNull();
+  });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,7 @@ getFirestore().settings({ ignoreUndefinedProperties: true });
 
 export { onUserRoleChange } from "./onUserRoleChange";
 export { onRequestCreated } from "./onRequestCreated";
+export { onRequestDeleted } from "./onRequestDeleted";
 export { cleanupStaleRequests } from "./cleanupStaleRequests";
 export { onInviteConsumed } from "./onInviteConsumed";
 export { fileOwnershipClaim, reviewOwnershipClaim } from "./ownershipClaims";

--- a/functions/src/onRequestDeleted.ts
+++ b/functions/src/onRequestDeleted.ts
@@ -1,0 +1,47 @@
+import { onDocumentDeleted } from "firebase-functions/v2/firestore";
+import { getStorage } from "firebase-admin/storage";
+
+// The bottle scanner's "Send Alert" action (App.tsx's sendBottleAlert)
+// uploads a photo to Storage *before* creating the /requests doc that
+// references it via photoUrl — an upload and a Firestore write can't
+// be made atomic, so a request can exist without a photo, but never
+// the reverse. Nothing ever cleaned the photo up once its request
+// went away: cancelRequest deletes the doc directly, and
+// cleanupStaleRequests batch-deletes anything pending for 12+ hours,
+// and neither touches Storage. Every bottle alert that got claimed-
+// and-forgotten, cancelled, or aged out left its photo in the bucket
+// forever. Triggering on delete (rather than trying to thread cleanup
+// through every place a request doc can go away) covers all of those
+// paths uniformly, including any added later.
+// getDownloadURL() URLs look like
+// https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{urlEncodedObjectPath}?alt=media&token=...
+// — exported standalone so its parsing can be unit tested without
+// mocking the Firestore trigger or Admin Storage SDK.
+export function parseStorageObjectPath(photoUrl: string): string | null {
+  const match = photoUrl.match(/\/o\/([^?]+)/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
+export const onRequestDeleted = onDocumentDeleted("requests/{requestId}", async (event) => {
+  const photoUrl = event.data?.data()?.photoUrl as string | undefined;
+  if (!photoUrl) return;
+
+  const objectPath = parseStorageObjectPath(photoUrl);
+  if (!objectPath) {
+    console.warn(`onRequestDeleted: could not parse a Storage object path from photoUrl: ${photoUrl}`);
+    return;
+  }
+
+  try {
+    await getStorage().bucket().file(objectPath).delete();
+  } catch (e) {
+    // Already gone — e.g. a duplicate delete event, or a previous
+    // invocation that succeeded but crashed before returning. Not
+    // worth logging as an error.
+    const code = (e as { code?: number })?.code;
+    if (code !== 404) {
+      console.error(`onRequestDeleted: failed to delete photo at ${objectPath}`, e);
+    }
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
   deleteDoc,
   arrayUnion,
   arrayRemove,
+  FieldPath,
 } from 'firebase/firestore';
 // Import initialized Firebase instances and helper functions.
 import {
@@ -727,10 +728,16 @@ function App() {
     }
 
     try {
-      // Update Firestore (arrayUnion ensures uniqueness).
-      await updateDoc(doc(db, 'bars', barId), {
-          [`beerInventory.${brand}`]: arrayUnion(typeName)
-      });
+      // Update Firestore (arrayUnion ensures uniqueness). Uses a
+      // FieldPath instance rather than a `beerInventory.${brand}`
+      // template-string key: Firestore splits string field paths on
+      // literal '.' characters, so a brand name containing a period
+      // (e.g. "St. Pauli Girl") would silently write into a nested
+      // "St" -> " Pauli Girl" sub-object instead of the intended
+      // top-level beerInventory[brand] entry. FieldPath takes each
+      // segment as a separate argument, bypassing that parsing
+      // entirely regardless of what characters the brand name has.
+      await updateDoc(doc(db, 'bars', barId), new FieldPath('beerInventory', brand), arrayUnion(typeName));
     } catch (e) {
       console.error('Failed to save type', e);
       alert('Failed to add type. Only managers can edit the beer inventory.');
@@ -823,9 +830,11 @@ function App() {
       }, { merge: true });
       setBeerInventory(prev => ({ ...prev, [brand]: type ? [type] : [] }));
     } else if (type && !existingTypes.includes(type)) {
-      await updateDoc(doc(db, 'bars', barId), {
-        [`beerInventory.${brand}`]: arrayUnion(type),
-      });
+      // FieldPath, not a `beerInventory.${brand}` string key — see the
+      // comment on the equivalent write in saveType above. Scanned
+      // brand names come straight from OCR and are especially likely
+      // to contain a literal period.
+      await updateDoc(doc(db, 'bars', barId), new FieldPath('beerInventory', brand), arrayUnion(type));
       setBeerInventory(prev => ({ ...prev, [brand]: [...(prev[brand] || []), type] }));
     }
   };
@@ -835,12 +844,28 @@ function App() {
   // exactly as it does for any other request) referencing the bottle
   // by name with the photo attached.
   const sendBottleAlert = async (brand: string, photo: Blob) => {
-    if (!user || !barId) return;
+    // Previously returned silently here — BottleScanner's runAction
+    // only shows an error (and keeps the dialog open) when this
+    // rejects, so a no-op success looked identical to a sent alert:
+    // the dialog just closed as if it had gone out.
+    if (!user || !barId) throw new Error('Not signed into a bar.');
     const path = `bottlePhotos/${barId}/${user.uid}_${Date.now()}.jpg`;
     const photoRef = storageRef(storage, path);
     await uploadBytes(photoRef, photo, { contentType: photo.type || 'image/jpeg' });
     const photoUrl = await getDownloadURL(photoRef);
-    await submitRequest(`RESTOCK: ${brand}`, photoUrl);
+    // Prefixed to match the "BEER" button's exact label (see
+    // constants.ts's restock_beer entry) rather than a made-up
+    // "RESTOCK:" prefix that matched no configured button at all.
+    // getButtonIdForLabel resolved that to no buttonId, and
+    // shouldNotifyMember treats a missing buttonId as "can't tell
+    // who this is for, notify everyone" — so every bottle-scanner
+    // alert (beer or spirits) was mass-notifying the entire bar
+    // regardless of anyone's notification preferences. This isn't a
+    // perfect category match for a scanned spirits bottle, but it's
+    // the same inventory bucket "Add to Menu" already files spirits
+    // into (see addBottleToMenu), so it's at least consistent with
+    // how this feature already treats the two.
+    await submitRequest(`BEER: ${brand}`, photoUrl);
   };
 
   // Add a person to the 86'd list. Visibility decides whether all
@@ -1559,6 +1584,21 @@ function App() {
   // Sorting for main screen.
   const sortedAllButtons = sortButtons(buttons, 'main');
   const mainScreenButtons = sortedAllButtons.filter(btn => !hiddenButtonIds.includes(btn.id));
+
+  // Brand buttons (BEER > a specific brand) are synthesized on the fly
+  // from beerInventory's keys in getDynamicChildren rather than living
+  // in the `buttons` config array — so BottleScanner's "86 It" action
+  // (which hides `brand_${brand}`) was hiding an id that never
+  // appeared in `allButtons`, meaning BarManager's Restorable Buttons
+  // section (which only ever looks at `allButtons`) had nothing to
+  // show: once 86'd, a brand had no path back, premium or not.
+  // Surfacing the hidden ones here — merged into the same array
+  // BarManager already filters into "active" vs "hidden" — gives them
+  // a restore path through the exact same UI, for free.
+  const hiddenBrandButtons: ButtonConfig[] = hiddenButtonIds
+    .filter(id => id.startsWith('brand_'))
+    .map(id => ({ id, label: id.slice('brand_'.length) }));
+  const allButtonsForManager = [...sortedAllButtons, ...hiddenBrandButtons];
   // CUSTOM is a permanent, non-configurable tile appended to every
   // bar's grid — it must be part of the SAME array passed to
   // SortableContext's `items` and to handleDragOver's `items` param
@@ -1598,7 +1638,7 @@ function App() {
         open={showBarManager}
         onClose={() => setShowBarManager(false)}
         barName={barName}
-        allButtons={sortedAllButtons}
+        allButtons={allButtonsForManager}
         hiddenButtonIds={hiddenButtonIds}
         onHideButton={hideButton}
         isPremium={isPremium}

--- a/src/components/BottleScanner.tsx
+++ b/src/components/BottleScanner.tsx
@@ -34,10 +34,13 @@ type Stage = 'idle' | 'capturing' | 'recognizing' | 'ready';
 type Action = 'menu' | '86' | 'alert';
 
 // Camera capture + on-device OCR (tesseract.js, running entirely
-// client-side — no photo or recognized text is ever sent to a
-// server) for premium bars. Point the camera at a bottle, confirm
+// client-side — the photo never leaves the device just to recognize
+// the label) for premium bars. Point the camera at a bottle, confirm
 // the recognized (or manually typed) brand, then either add it to
-// the menu, 86 it, or send a photo-referencing alert to staff.
+// the menu, 86 it, or send a photo-referencing alert to staff — that
+// last action does upload the photo, to this bar's own Storage
+// bucket (see App.tsx's sendBottleAlert), so staff can see what was
+// scanned; it isn't sent anywhere outside the app's own backend.
 const BottleScanner = ({
   open, onClose, isManagerPlus, candidates, existingBrands, onAddToMenu, onEightySix, onSendAlert,
 }: BottleScannerProps) => {
@@ -48,6 +51,15 @@ const BottleScanner = ({
   const [type, setType] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submittingAction, setSubmittingAction] = useState<Action | null>(null);
+  // Bumped on every close; handleCapture snapshots it and checks it
+  // after each await so a capture/OCR run still in flight when the
+  // user closes the dialog mid-recognition can't land its result
+  // afterward. MdDialog keeps this component mounted regardless of
+  // `open` (only the attribute toggles), so without this guard the
+  // async chain would resolve after reset() already ran and silently
+  // repopulate stage/photo/brand with stale data — the next open
+  // would show a capture the user never took.
+  const closeTokenRef = useRef(0);
 
   const reset = () => {
     setStage('idle');
@@ -60,32 +72,49 @@ const BottleScanner = ({
   };
 
   const handleClose = () => {
+    closeTokenRef.current += 1;
     reset();
     onClose();
   };
 
   const handleCapture = async () => {
+    const token = closeTokenRef.current;
     setError(null);
     setStage('capturing');
     try {
       const result = await Camera.takePhoto({});
+      if (closeTokenRef.current !== token) return;
       if (!result.webPath) throw new Error('No photo captured.');
       const blob = await (await fetch(result.webPath)).blob();
+      if (closeTokenRef.current !== token) return;
       photoBlobRef.current = blob;
       setPhotoUrl(result.webPath);
 
       setStage('recognizing');
       const lines = await recognizeBottleText(blob);
+      if (closeTokenRef.current !== token) return;
       setBrand(matchBrand(lines, candidates) ?? '');
       setStage('ready');
     } catch (e) {
+      if (closeTokenRef.current !== token) return;
       console.error('Bottle capture/recognition failed', e);
       setError(e instanceof Error ? e.message : 'Failed to capture or read the bottle label.');
       setStage('idle');
     }
   };
 
-  const brandExists = existingBrands.some((b) => b.toLowerCase() === brand.trim().toLowerCase());
+  const trimmedBrand = brand.trim();
+  // Case-insensitive existence check, but every downstream write is
+  // case-sensitive — beerInventory keys in App.tsx's addBottleToMenu
+  // and the `brand_${brand}` hideButton id are both looked up/built
+  // by exact string match. Scanning (or manually correcting to)
+  // "JAMESON" against an existing "Jameson" entry needs to resolve to
+  // "Jameson" everywhere downstream, or "Add to Menu" silently
+  // creates a second, disconnected "JAMESON" entry and "86 It" writes
+  // a hidden-button id that matches no real button.
+  const matchedExistingBrand = existingBrands.find((b) => b.toLowerCase() === trimmedBrand.toLowerCase());
+  const brandExists = !!matchedExistingBrand;
+  const canonicalBrand = matchedExistingBrand ?? trimmedBrand;
 
   const runAction = async (action: Action, fn: () => Promise<void>) => {
     if (submittingAction) return;
@@ -165,7 +194,7 @@ const BottleScanner = ({
               <md-outlined-button
                 className="btn-alert"
                 disabled={!!submittingAction || undefined}
-                onClick={() => runAction('86', () => onEightySix(brand.trim()))}
+                onClick={() => runAction('86', () => onEightySix(canonicalBrand))}
               >
                 {submittingAction === '86' ? 'Marking…' : '86 It'}
               </md-outlined-button>
@@ -173,7 +202,7 @@ const BottleScanner = ({
             {isManagerPlus && (
               <md-filled-button
                 disabled={!brand.trim() || !!submittingAction || undefined}
-                onClick={() => runAction('menu', () => onAddToMenu(brand.trim(), type.trim()))}
+                onClick={() => runAction('menu', () => onAddToMenu(canonicalBrand, type.trim()))}
               >
                 {submittingAction === 'menu' ? 'Adding…' : 'Add to Menu'}
               </md-filled-button>

--- a/src/test/rules/privilegeEscalation.test.ts
+++ b/src/test/rules/privilegeEscalation.test.ts
@@ -110,10 +110,30 @@ describe("privilege escalation regressions", () => {
     it("still allows a legitimate create with a photoUrl (bottle scanner alert)", async () => {
       const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
       await assertSucceeds(addDoc(collection(db, "requests"), {
-        barId: "bar_A", label: "RESTOCK: Jameson", requesterId: "staff_bob",
+        barId: "bar_A", label: "BEER: Jameson", requesterId: "staff_bob",
         requesterName: "Bob", requesterRole: "Staff",
         status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
-        photoUrl: "https://storage.googleapis.com/bucket/bottlePhotos/bar_A/x.jpg",
+        photoUrl: "https://firebasestorage.googleapis.com/v0/b/some-bucket.appspot.com/o/bottlePhotos%2Fbar_A%2Fstaff_bob_123.jpg?alt=media&token=abc",
+      }));
+    });
+
+    it("denies a photoUrl pointing at an external (tracking-pixel) host", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "BEER: Jameson", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+        photoUrl: "https://attacker.example/tracking-pixel.gif",
+      }));
+    });
+
+    it("denies a photoUrl pointing at a different bar's bottlePhotos path", async () => {
+      const db = authedAs(env, "staff_bob", { bars: { bar_A: "Staff" } });
+      await assertFails(addDoc(collection(db, "requests"), {
+        barId: "bar_A", label: "BEER: Jameson", requesterId: "staff_bob",
+        requesterName: "Bob", requesterRole: "Staff",
+        status: "pending", timestamp: serverTimestamp(), lastNotification: serverTimestamp(),
+        photoUrl: "https://firebasestorage.googleapis.com/v0/b/some-bucket.appspot.com/o/bottlePhotos%2Fbar_B%2Fstaff_bob_123.jpg?alt=media&token=abc",
       }));
     });
   });

--- a/src/utils/bottleRecognition.test.ts
+++ b/src/utils/bottleRecognition.test.ts
@@ -31,4 +31,11 @@ describe('matchBrand', () => {
   it('picks the closer of two plausible candidates', () => {
     expect(matchBrand(['GREY GOOSE VODKA'], ['Grey Goose', 'Ketel One'])).toBe('Grey Goose');
   });
+
+  it('does not confidently match a short generic OCR fragment against an unrelated longer candidate', () => {
+    // "GIN" is a substring of "Hendrick's Gin", but that alone
+    // shouldn't be enough to call it a match for a completely
+    // different (and un-candidated, here) gin bottle.
+    expect(matchBrand(['GIN'], ['Hendrick\'s Gin'])).toBeNull();
+  });
 });

--- a/src/utils/bottleRecognition.ts
+++ b/src/utils/bottleRecognition.ts
@@ -56,16 +56,30 @@ export function matchBrand(lines: string[], candidates: string[]): string | null
       const normCandidate = normalize(candidate);
       if (!normCandidate) continue;
 
+      const lengthRatio = Math.min(line.length, normCandidate.length) / Math.max(line.length, normCandidate.length);
       let score: number;
       if (line === normCandidate) {
         score = 0;
-      } else if (line.includes(normCandidate) || normCandidate.includes(line)) {
+      } else if (line.includes(normCandidate)) {
+        // The full candidate name appears somewhere in the OCR line —
+        // e.g. "Jameson" inside "JAMESON IRISH WHISKEY 750ML 40% ABV".
+        // Safe regardless of length ratio, since the whole candidate
+        // string had to match, not just a fragment of it.
+        score = 0.05;
+      } else if (normCandidate.includes(line) && lengthRatio >= 0.5) {
+        // The OCR line is a substring OF the candidate — only trusted
+        // when it's not a tiny generic fragment. Without the ratio
+        // guard, a short OCR line like "GIN" is a substring of every
+        // candidate ending in "Gin" (e.g. "Hendrick's Gin"), so a
+        // completely unrelated gin bottle would confidently match
+        // whichever gin brand happens to be first in the candidate
+        // list — a confidently wrong match, not a low-confidence one
+        // that falls through to manual entry.
         score = 0.05;
       } else {
         // Edit distance is only meaningful between strings of
         // comparable length — otherwise a one-word OCR line always
         // "wins" against a long candidate purely on raw distance.
-        const lengthRatio = Math.min(line.length, normCandidate.length) / Math.max(line.length, normCandidate.length);
         if (lengthRatio < 0.5) continue;
         score = levenshtein(line, normCandidate) / normCandidate.length;
       }


### PR DESCRIPTION
## Summary

Closes out the remaining findings from the bottle-scanner-specific adversarial audit (the general UX/gating findings from the same overall audit round already landed in #296).

- **Dot-path Firestore field corruption**: `saveType`/`addBottleToMenu` wrote to `beerInventory` via a `` `beerInventory.${brand}` `` template-string key. Firestore splits string field paths on literal `.` characters, so a scanned brand containing one (e.g. "St. Pauli Girl") silently wrote into a nested sub-object instead of the intended entry, corrupting the inventory doc. Both now use a `FieldPath` instance instead.
- **`matchBrand` false-positive matches**: the substring-match branch scored `0.05` unconditionally, so a short generic OCR fragment (e.g. "GIN") would substring-match every candidate ending the same way (e.g. "Hendrick's Gin") — a confidently wrong match. Added a length-ratio guard on that specific direction only, preserving the legitimate "candidate name found inside a longer OCR line" case.
- **Case-sensitivity mismatch**: `brandExists` compared case-insensitively, but downstream writes (`beerInventory` keys, the `brand_${brand}` hide-button id) are case-sensitive — scanning "JAMESON" against an existing "Jameson" entry created a disconnected duplicate instead of acting on the real one. Now resolves to the existing entry's exact casing first.
- **Irreversible "86 It"**: the hidden `brand_${brand}` id is synthesized on the fly and never lived in the config array `BarManager`'s Restorable Buttons section reads from, so a scanned-and-86'd brand had no restore path at all. Now merged in as synthetic entries.
- **No OCR cancellation on close**: closing the dialog mid-recognition didn't stop the in-flight async chain from later repopulating stage/photo/brand with stale data. Added a close-token guard.
- **Silent no-op alert**: `sendBottleAlert` returned instead of throwing on `!user/!barId`, so the dialog closed as if the alert had actually sent.
- **Notification-preference bypass**: the alert's `"RESTOCK: ${brand}"` label matched no configured button, so it fell through to "notify everyone" regardless of preferences. Relabeled to `"BEER: ${brand}"` to resolve correctly.
- **Unvalidated `photoUrl`**: the create-rule only checked it was a *string*, not what it pointed at, despite an existing comment already noting it's rendered as a raw `<img src>` on every other member's device — a live tracking-pixel/IP-collection vector. Now regex-constrained to this bar's own bottlePhotos Storage path.
- **Orphaned photos**: uploads happen before the referencing `/requests` doc exists, and nothing cleaned them up once that doc went away (cancel, or the stale-request sweep). New `onRequestDeleted` trigger covers every deletion path uniformly.
- Corrected a header comment that claimed no photo is "ever sent to a server" — true only of the OCR step; Send Alert does upload to the bar's own Storage.

**Not changed**: "Add to Menu" still files scanned spirits into `beerInventory` alongside actual beer — the whole feature already treats one bucket as covering both (including manual entry), so splitting it out is a data-model decision beyond this pass. `storage.rules`' contentType check was already accurately caveated as a client-header check, not a byte-level guarantee, so no change needed there.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 143/143 passing
- [x] `npm run build` — clean
- [x] `npm run test:rules` — 129/129 passing (includes 2 new photoUrl-validation cases)
- [x] `cd functions && npm run build && npm test` — 40/40 passing (includes 2 new cases for the new trigger's URL-parsing helper)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Address multiple BottleScanner audit findings across Firestore writes, brand matching, alerts, and cleanup to make scanning, notifications, and storage safer and more consistent.

Bug Fixes:
- Prevent Firestore beerInventory corruption for brands containing periods by using a FieldPath-based update instead of dot-path string keys.
- Align BottleScanner brand matching with user intent by tightening substring-matching to avoid short generic OCR fragments producing false-positive brand matches.
- Ensure case-insensitive brand scans act on existing entries by resolving to the canonical brand casing before 86/menu actions.
- Fix BottleScanner alerts so missing user or bar context fails visibly instead of silently no-oping while closing the dialog.
- Ensure closing the BottleScanner dialog cancels any in-flight capture/OCR pipeline so stale results do not repopulate the UI.
- Respect notification preferences for bottle alerts by labeling requests to match the configured BEER button instead of an unrecognized RESTOCK prefix.
- Constrain bottle alert photoUrl values in Firestore to this bar's own bottlePhotos Storage path, blocking external/tracking URLs and cross-bar references.
- Automatically delete bottle alert photos from Storage when their corresponding request document is removed, preventing orphaned images and storage bloat.

Enhancements:
- Expose hidden brand_*-style synthetic buttons to BarManager so 86'd brands can be restored via the existing Restorable Buttons UI.
- Clarify BottleScanner documentation about when photos are uploaded and where they are stored.

Tests:
- Extend bottleRecognition tests to cover the new generic-fragment matching behavior.
- Add Firestore rules tests to validate accepted and rejected bottle alert photoUrl patterns.
- Add unit tests for the Storage URL parser used by the new onRequestDeleted trigger.