### PR TITLE
Restrict build-mobile.yml to main only, drop pull_request trigger

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,29 +1,26 @@
 name: Merged Build & Release
 
 on:
-  # Previously `branches: ["**"]` — every push to every branch. Once a
-  # branch has an open PR against main, that meant the SAME commit
-  # triggered two independent runs: one from this push trigger (group
-  # keyed on refs/heads/<branch>) and one from the pull_request
-  # trigger below (group keyed on refs/pull/<n>/merge) — different
-  # concurrency groups, so `cancel-in-progress` never saw them as the
-  # same thing and both ran to completion, doubling build minutes and
-  # doubling the "Report Failure to Jules" duplicate-issue risk for
-  # every push while a PR was open. Restricted to main: a feature
-  # branch's own build/test signal already comes from pull_request
-  # once its PR exists (which is effectively always, in this repo's
-  # workflow — a branch is pushed and its PR opened immediately
-  # after), and the release steps below already only ever fire on a
-  # push to main, so this doesn't change what gets released.
+  # This workflow builds the release APK and, on main, publishes it —
+  # it has no reason to run on every branch push or on PRs (PR-side
+  # rules/functions coverage already comes from rules-tests.yml; this
+  # one is specifically the Android release pipeline). Previously also
+  # had `branches: ["**"]` on push plus a pull_request trigger, which
+  # meant a single commit on an open PR's branch fired two separate
+  # runs — one from each trigger, in different concurrency groups, so
+  # neither cancelled the other. Restricting to main-only removes the
+  # PR-side run entirely rather than just deduping it.
   push:
-    branches: [ "main" ]
-  pull_request:
     branches: [ "main" ]
   workflow_dispatch:
 
-# ⚡ Concurrency: Cancels the entire job if a new push comes in.
+# ⚡ Concurrency: cancels an in-progress run for the same branch when a
+# new one starts. head_ref (set for pull_request-family events, the
+# PR's source branch) falls back to ref (set for push/workflow_dispatch)
+# so a manual dispatch against a non-main branch still gets its own
+# group instead of colliding with whatever ref happened to run last.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Per direction: `build-mobile.yml` (the Android release pipeline) should only run for `main`.

- Dropped the `pull_request` trigger entirely — PR-side coverage for rules/functions already comes from `rules-tests.yml`; this workflow's job is specifically building and publishing the release APK, which only ever happens on a push to `main` anyway (the RELEASE STEPS gating further down is unchanged).
- Switched the concurrency group from `github.ref` alone to `github.head_ref || github.ref`, so a `workflow_dispatch` run against a non-main branch gets its own group instead of colliding with whatever ref last used the bare `refs/heads/main` group.

Note: since this workflow no longer runs on PRs, this specific PR won't show a build-mobile.yml check on itself — that's expected, it's the direct consequence of the change. `rules-tests.yml` still runs.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [ ] Confirm the next push to `main` runs build-mobile.yml exactly once, with no corresponding PR-side run

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Restrict the Android release GitHub Actions workflow to main-only and improve its concurrency grouping.

CI:
- Limit the build-mobile workflow to run only on pushes to main and manual dispatches, removing the pull_request trigger.
- Adjust the workflow concurrency group to use the head ref when available to avoid collisions between manual or branch runs and main.