### PR TITLE
Add concurrency control to CodeQL Advanced-setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,18 @@ on:
   schedule:
     - cron: '42 4 * * 5'
 
+# Auto-generated setup had no concurrency control at all: a push to
+# main and every PR push each started their own set of scans with
+# nothing to cancel a superseded one, so rapid merges (this repo
+# routinely opens and merges PRs within minutes) left several runs —
+# some already stale — piling up in_progress simultaneously. head_ref
+# (set for pull_request events, the PR's source branch) falls back to
+# ref (push/schedule/workflow_dispatch) so a PR's own re-pushes cancel
+# their own previous scan without colliding with main's group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
## Summary

Follow-up to switching CodeQL from Default setup to Advanced setup (which auto-committed `.github/workflows/codeql.yml` to main directly). That auto-generated file kept the same underlying issue Default setup had — no `concurrency` block at all — so PR pushes and main pushes each start their own set of scans with nothing to cancel a superseded run. On this repo's cadence (PRs routinely merged within minutes of opening), that left multiple scans `in_progress` simultaneously, several already stale by the time a runner picked them up.

Added the same fix shape already applied to `build-mobile.yml`: a concurrency group keyed on `head_ref` (the PR's source branch) falling back to `ref` (for push/schedule/workflow_dispatch), with `cancel-in-progress: true`.

Everything else in the auto-generated file (the language matrix — `actions`, `java-kotlin`, `javascript-typescript`, `swift` — and its triggers) is left as GitHub generated it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [ ] Confirm a subsequent push to main (or PR re-push) cancels an in-progress CodeQL run for the same ref instead of piling up

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Enhancements:
- Introduce a concurrency group keyed by workflow name and branch/ref to ensure newer CodeQL runs cancel superseded in-progress runs.