### PR TITLE
Drop java-kotlin and swift from CodeQL matrix: autobuild can't build them

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
@@ -57,12 +57,20 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: java-kotlin
-          build-mode: autobuild
         - language: javascript-typescript
           build-mode: none
-        - language: swift
-          build-mode: autobuild
+        # java-kotlin and swift were in the auto-detected matrix but
+        # dropped here: both are Capacitor's generated wrapper
+        # boilerplate only (android/app's MainActivity.kt and a couple
+        # of stub test files; ios/App's AppDelegate.swift and a
+        # 1-line SPM package) with no custom app logic to scan, and
+        # `build-mode: autobuild` can't actually build either without
+        # first running `npx cap sync` (which generates files Gradle/
+        # CocoaPods require, e.g. android/capacitor-cordova-android-
+        # plugins/cordova.variables.gradle) — confirmed by autobuild
+        # failing on exactly that missing file. Replicating build-
+        # mobile.yml's full Node+JDK+Gradle(+Firebase secrets) setup
+        # here just to scan boilerplate isn't worth it.
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## Summary

Fixes the `Analyze (java-kotlin)` CI failure introduced by #300 (that PR's own build already merged before the failure event arrived, so this is a direct follow-up fix on main).

- `Analyze (java-kotlin)` failed: `autobuild` ran `./gradlew clean` without ever running `npx cap sync android` first, so Gradle immediately failed on a missing generated file (`android/capacitor-cordova-android-plugins/cordova.variables.gradle`) — confirmed from the job log.
- `swift` has the identical structural problem — its `autobuild` would need `npx cap sync ios` for CocoaPods/SPM config that doesn't exist until that runs either.

Making autobuild work for either would mean replicating `build-mobile.yml`'s entire Node+JDK+Gradle(+Firebase secrets) setup inside this workflow too, for essentially no payoff: both directories are Capacitor's generated wrapper boilerplate only —
- `android/app`: `MainActivity.kt` plus two stub test files
- `ios/App`: `AppDelegate.swift` plus a 1-line SPM package

No custom app logic in either language to actually scan. Dropped both from the matrix, keeping `actions` and `javascript-typescript` — which cover everything with real custom logic (the React/TS app, Cloud Functions, and the workflow files themselves) and both already passed clean in the same run.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [ ] Confirm the next CodeQL run only has `actions` and `javascript-typescript` jobs, both passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

CI:
- Update the CodeQL workflow matrix to drop java-kotlin and swift entries that cannot be built by autobuild and standardize the runner to ubuntu-latest.