### PR TITLE
Fix "Failed to join this bar" caused by stale joinPolicy race

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,10 +178,6 @@ function App() {
   // 'Owner' instead of 'Staff'. Reset to false the moment it's
   // consumed or the user backs out of bar selection.
   const [justCreatedBar, setJustCreatedBar] = useState(false);
-  // The bar's join policy ('open' | 'approval'), read off the bar
-  // document. Determines whether confirmRole writes status 'active'
-  // or 'pending' for a joining (non-creator) user.
-  const [barJoinPolicy, setBarJoinPolicy] = useState<'open' | 'approval'>('open');
   // Store the user's notification preferences (list of button IDs).
   const [notificationPreferences, setNotificationPreferences] = useState<string[]>([]);
 
@@ -442,7 +438,6 @@ function App() {
       setDisplayName('');
       setNotificationPreferences([]);
       setBarName('');
-      setBarJoinPolicy('open');
       setButtons(DEFAULT_BUTTONS);
       setBeerInventory({});
       setWells([]);
@@ -492,7 +487,6 @@ function App() {
       if (d.exists()) {
         const data = d.data() as Bar;
         setBarName(data.name);
-        setBarJoinPolicy(data.joinPolicy === 'approval' ? 'approval' : 'open');
 
         // Merge default buttons with custom bar buttons.
         if (data.buttons) {
@@ -1090,16 +1084,31 @@ function App() {
     // same source firestore.rules' self-create rule actually trusts:
     // bars/{barId}.ownerId.
     let isCreator = justCreatedBar;
+    // Same staleness problem as isCreator above, and the same fix:
+    // barJoinPolicy is only as fresh as the bar-config listener's
+    // last snapshot, but RoleSelector renders (and is tappable) the
+    // moment userRole is null — before that listener's FIRST snapshot
+    // has necessarily arrived. A user who confirms fast, or on a slow
+    // connection, computed status from barJoinPolicy's 'open' default
+    // even when the bar's real joinPolicy was 'approval', and
+    // firestore.rules' self-create rule checks the server's actual
+    // value — status=='active' against a real 'approval' policy is
+    // rejected outright, surfacing as "Failed to join this bar" with
+    // no indication why. Reading it fresh here (reusing the same
+    // getDoc as the ownership check, when one was needed) closes that
+    // window instead of just working around one symptom of it.
+    let joinPolicy: string = 'open';
     if (!isCreator) {
       try {
         const barSnap = await getDoc(doc(db, 'bars', barId));
         isCreator = barSnap.data()?.ownerId === user.uid;
+        joinPolicy = barSnap.data()?.joinPolicy ?? 'open';
       } catch (e) {
         console.error('Failed to verify bar ownership before joining', e);
       }
     }
     const role = isCreator ? 'Owner' : 'Staff';
-    const status = (role === 'Owner' || barJoinPolicy !== 'approval') ? 'active' : 'pending';
+    const status = (role === 'Owner' || joinPolicy !== 'approval') ? 'active' : 'pending';
 
     try {
       // Update Global User Document with joined bar.


### PR DESCRIPTION
## Summary

Fixes a live bug: confirming a role on a bar reached via a deep link (`?bar=...`) could fail with "Failed to join this bar. Please try again." — reproduced from an actual screenshot.

**Root cause**: `RoleSelector` renders (and is immediately tappable) as soon as `userRole` is `null` — there's no wait for the bar-config listener's first `onSnapshot` to land. `confirmRole` computed the write's `status` field from `barJoinPolicy`, client state that only reflects that listener's last delivered snapshot and starts at a hardcoded `'open'` default. Confirming fast, or on a slow connection, meant that default was still in effect even when the bar's actual `joinPolicy` was `'approval'` — and `firestore.rules`' self-create rule checks the bar document's real `joinPolicy` server-side, rejecting `status=='active'` against an actual `'approval'` policy outright. The write threw, the alert fired, but gave no indication why, and the user was stuck unable to join.

**Fix**: read `joinPolicy` fresh in `confirmRole` itself, reusing the same `getDoc` call that already re-derives `isCreator` for the identical staleness reason a few lines above (`justCreatedBar` has the same "can go stale" problem, already fixed there in an earlier pass). `barJoinPolicy`, the client-cached copy, is now unused anywhere in the file, so removed it (state declaration + both listener setters) rather than leave dead state around.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 143/143 passing
- [x] `npm run build` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Ensure bar join status is computed from a fresh joinPolicy read at confirmation time to prevent failed joins caused by stale client state.

Bug Fixes:
- Fix bar join failures when confirming a role on newly opened or deep-linked bars by avoiding use of a stale cached join policy.

Enhancements:
- Remove unused barJoinPolicy state now that joinPolicy is read directly from Firestore during role confirmation to keep local state lean and accurate.