### PR TITLE
Bring documentation up to date with everything shipped since Phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,20 +18,25 @@ This document provides guidelines for AI agents working on the BarBacker codebas
 
 ## Project Structure
 
-*   **`src/components/`**: Place new reusable components here.
-*   **`src/types.ts`**: All shared interfaces must be defined here.
-*   **`src/constants.ts`**: hardcoded values like Roles and Default Buttons.
+*   **`src/components/`**: Place new reusable components here. See [docs/COMPONENTS.md](docs/COMPONENTS.md) for the current inventory.
+*   **`src/hooks/`**: Shared/async logic (Firestore listeners + the actions that write to them) belongs in a hook here, not inline in `App.tsx` — this is the established pattern for every feature area (chat, calendar, POS, drag-and-drop, push notifications, usage batching, ...). One hook per concern; see [docs/COMPONENTS.md](docs/COMPONENTS.md) for the current list.
+*   **`src/types.ts`**: All shared interfaces must be defined here. This file is close to a literal schema doc — see [docs/DATA_MODEL.md](docs/DATA_MODEL.md), which is generated from it plus `firestore.rules`.
+*   **`src/constants.ts`**: hardcoded values like job titles, default buttons, notification defaults, and the POS provider list.
+*   **`functions/src/`**: the Cloud Functions backend — a separate TypeScript project/build from the client (own `package.json`, own `tsconfig`). Organized by trigger type at the top level, with `pos/` and `calendar/` subdirectories for those integrations and `shared/` for cross-cutting helpers (KMS encryption, authz). See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full function inventory.
+*   **`scripts/`**: plain Node.js scripts for build-time codegen and scheduled maintenance jobs — distinct from `functions/`. See [docs/SCRIPTS.md](docs/SCRIPTS.md).
 
 ## Testing
 
-*   **Framework**: Vitest + React Testing Library.
-*   **Requirement**: All new features must have accompanying tests.
-*   **Running**: `npm test` runs all tests.
+*   **Client**: Vitest + React Testing Library (`npm test`). All new features must have accompanying tests.
+*   **Cloud Functions**: Vitest, run from `functions/` (`cd functions && npm test`). Prefer testing pure exported helpers over the trigger wiring itself — mocking the Admin SDK/Firebase Functions SDK for a full trigger is usually not worth it; the pattern used throughout `functions/src/__tests__/` is to extract the interesting logic into a small exported function and test that directly.
+*   **Firestore/Storage security rules**: `npm run test:rules` (spins up the Firebase emulator, requires `firebase-tools`; also runs in CI via `rules-tests.yml`). Every rules change should come with both a positive test (the intended write still succeeds) and a negative one (the specific thing being closed off is actually rejected) — see `src/test/rules/` for the existing convention, especially `privilegeEscalation.test.ts` for the style of "one test per closed exploit."
 
 ## Firebase
 
-*   Use the exported `db` and `auth` instances from `src/firebase.ts`.
-*   Ensure security rules are considered when modifying data structures.
+*   Use the exported `db`, `auth`, and `storage` instances from `src/firebase.ts`.
+*   Any new Firestore/Storage field, collection, or write path needs a corresponding `firestore.rules`/`storage.rules` change — the rules are the actual security boundary, not client-side checks. Never assume a field is safe just because the UI doesn't expose a way to set it maliciously.
+*   Role (`Staff`/`Manager`/`Owner`, the privilege tier) and job title (`Bartender`/`Barback`/etc., cosmetic/notification routing) are separate fields — don't conflate them. See [docs/DATA_MODEL.md](docs/DATA_MODEL.md).
+*   When adding a listener (`onSnapshot`) that depends on `user`/`barId`, reset every piece of state that effect owns *before* an early-return guard, not just skip the subscribe — otherwise a sign-out or bar switch leaves stale data rendered on a shared device. This is the single most common class of bug found in this codebase's audit history.
 
 ## Material Web
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BarBacker
 
-**BarBacker** is a real-time communication tool designed to bridge the gap between bartenders and barbacks in high-volume environments. It replaces shouting and hand signals with a streamlined, digital paging system.
+**BarBacker** is a real-time operations tool for bars and restaurants — a digital paging system that replaces shouting and hand signals between bartenders, barbacks, and management, plus a growing set of shift-management features (team chat, a calendar, POS integration, and a bottle-recognition scanner) built on top of the same real-time backend.
 
 ## Documentation
 
@@ -9,24 +9,46 @@
 *   [Components](docs/COMPONENTS.md)
 *   [Deployment](docs/DEPLOYMENT.md)
 *   [Scripts](docs/SCRIPTS.md)
+*   [Security Policy](SECURITY.md)
+*   [Agent/contributor guidelines](AGENTS.md)
 
 ## What is it?
 
-In a busy bar, bartenders often need items—ice, glassware, fruit, restocking—immediately. **BarBacker** allows bartenders to send these requests with a single tap. Barbacks receive these requests instantly on their device and can "claim" them to let the team know they are on it.
+In a busy bar, bartenders often need items — ice, glassware, fruit, restocking — immediately. **BarBacker** lets bartenders send these requests with a single tap. Barbacks (and anyone else subscribed to that request type) receive them instantly and can "claim" a request to let the team know they're on it. Everything else in the app — chat, the 86'd list, the calendar, POS sync, the bottle scanner — grew out of that same core loop: get information from the person who has it to the person who needs it, as fast as possible, with everyone seeing the same state.
 
 ## Key Features
 
-*   **⚡ Quick Requests**: Simple button grids for common needs like "ICE", "GLASSWARE", or "RESTOCK" — some are one tap, others (like picking a well or a beer brand/type) are a couple of taps deep.
-*   **🔔 Real-Time Alerts**: Requests appear instantly for anyone subscribed to that request type and clocked in; ntfy.sh handles push delivery.
-*   **🔎 Bar Search**: Find your bar by name via OpenStreetMap, or create an entry for your venue if it isn't listed yet.
-*   **👥 Role-Based**: Distinct interfaces for Bartenders (sending requests) and Barbacks/Support (fulfilling requests).
-*   **📱 Installable PWA**: Works like a native app on iOS and Android.
+*   **⚡ Quick Requests**: Simple button grids for common needs like "ICE", "BEER", or "WELL" — some are one tap, others (picking a well, a beer brand/type, or a custom quantity) are a couple of taps deep. Buttons can be reordered by drag-and-drop and hidden/restored per bar.
+*   **🔔 Real-Time Alerts**: Requests fan out server-side (a Cloud Function, not the client) to everyone subscribed to that request type and currently clocked in — FCM push on native/web, `ntfy.sh` for iOS, plus in-app sound/vibration. A scheduled job re-nags anyone who hasn't dismissed a matching request.
+*   **💬 Team Chat**: A per-bar chat with infinite scrollback. Manager+ can pin messages, which drive the dashboard marquee — the same real-time channel everyone already has open, instead of a separate announcements board.
+*   **🚫 86'd List**: Track patrons who shouldn't be served. Public entries are visible to any staff member; private entries (with a reason) are Manager+-only and gated behind the bar's premium subscription.
+*   **📸 Bottle Scanner** *(premium)*: Point the camera at a bottle label; on-device OCR (no photo ever leaves the device for recognition) suggests a matching brand from the bar's own inventory plus a curated beer/spirits list. Add it to the menu, mark it 86'd, or flag a manager with a photo.
+*   **📅 Calendar** *(premium)*: Shift scheduling and bookings, with two-way Google Calendar sync and both inbound and outbound iCal feeds. A scheduled event auto-clocks-in whoever's assigned when their shift starts.
+*   **🧾 POS Integration** *(premium)*: Connect Square or Toast (more providers scaffolded, not yet wired up) to sync a live menu and pull order/sales data into the app.
+*   **🎨 Custom Branding** *(premium)*: Per-bar logo, primary/accent colors, and font.
+*   **👥 Role-Based Access**: Three privilege tiers — Staff, Manager, Owner — enforced server-side by Firestore/Storage security rules, independent of a member's job title (Bartender, Barback, Server, Security, Runner). Bars can require Manager approval to join, or stay open to anyone.
+*   **✉️ Invites**: Manager+ can invite a specific email address at a specific role; the invite is consumed automatically the next time that person signs in.
+*   **🔎 Bar Search**: Find your bar by name via OpenStreetMap, or create an entry for your venue if it isn't listed yet. If the venue is later reclaimed by its real owner, they can file an ownership claim for a Manager (or the current Owner) to approve.
+*   **📱 Installable PWA + Native Android**: Works like a native app on iOS and desktop (installable PWA) and ships as a real Android app via Capacitor.
 
 ## How to Use
 
-1.  **Open the App**: Navigate to the deployed URL.
-2.  **Join a Bar**: Search for your bar by name. If it isn't listed yet, you can create it.
-3.  **Select Your Role**:
-    *   **Bartender**: You will see a grid of buttons. Tap to request items.
-    *   **Barback**: You will see a list of incoming requests. Tap a request to claim it.
-4.  **Stay synced**: The app keeps everyone on the same page, preventing duplicate work and ensuring the bar never runs dry.
+1.  **Open the App**: Navigate to the deployed URL, or open the Android app.
+2.  **Join a Bar**: Search for your bar by name. If it isn't listed yet, you can create it — you'll automatically become its Owner.
+3.  **Select Your Role**: Pick a job title (Bartender, Barback, Server, Security, or Runner). If the bar requires approval to join, you'll wait for a Manager to activate your account.
+4.  **Use the dashboard**:
+    *   Tap a button to send a request; anyone subscribed to it is notified instantly and can claim it.
+    *   Open Chat to talk with the team, or Calendar/POS/the bottle scanner if the bar has them enabled.
+5.  **Stay synced**: Every device sees the same state in real time — no duplicate work, no dropped requests.
+
+## Local Development
+
+```bash
+npm install
+npm run dev          # Vite dev server
+npm test              # Vitest unit/component tests
+npm run test:rules     # Firestore + Storage rules tests (spins up the Firebase emulator)
+cd functions && npm install && npm test   # Cloud Functions tests
+```
+
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for environment variables, the CI pipeline, and Android/Cloud Functions deployment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,24 @@
 # Security Policy
 
-## Supported Versions
+BarBacker is a single continuously-deployed application (web + Android), not a versioned library — there's no "supported version" matrix to maintain. Security fixes land on `main` and go out with the next deploy.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+## Security Model
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+*   **Authorization** is enforced server-side by Firestore and Storage security rules (`firestore.rules`, `storage.rules`), keyed off a per-bar privilege role (`Staff` / `Manager` / `Owner`) stamped as a Firebase Auth custom claim. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the claim is set and its known staleness window on revocation.
+*   **Never trust the client** for anything security-relevant: privileged fields (role, subscription tier, ownership) are either bound to server-verified values in the rules themselves, or written exclusively by Cloud Functions running under the Admin SDK.
+*   **Secrets** (OAuth tokens for POS/Calendar integrations) are encrypted with Cloud KMS before being stored, in Firestore collections with no client read/write access in either direction — see [DATA_MODEL.md](docs/DATA_MODEL.md).
+*   Both rule files have an automated test suite (`npm run test:rules`, run in CI on every push/PR — see [DEPLOYMENT.md](docs/DEPLOYMENT.md)) that includes regression coverage for previously-found privilege-escalation issues, not just the happy path.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you find a security issue in this repository (a rules gap, a client-trust bug, exposed secrets, a CI/CD supply-chain issue, etc.), please report it privately rather than opening a public issue:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+*   Preferred: use GitHub's [private vulnerability reporting](https://github.com/HereLiesAz/BarBacker/security/advisories/new) for this repository (Security tab → "Report a vulnerability").
+*   If that's not available to you, open an issue with minimal detail asking for a private contact channel, and avoid posting exploit details publicly until a fix has shipped.
+
+Please include:
+*   What you found and where (file/rule/component).
+*   Steps to reproduce, or a concrete scenario showing impact.
+*   Anything you've already tried as a fix, if applicable.
+
+There's no formal SLA (this is a small project maintained on a best-effort basis), but a report with clear reproduction steps will generally get triaged quickly.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,55 +1,58 @@
 # Architecture Overview
 
-**BarBacker** is a client-side Single Page Application (SPA) built with React, hosted on GitHub Pages, and wrapped as a native Android application using Capacitor. It relies on Firebase for real-time data synchronization, authentication, and messaging.
+**BarBacker** is a React single-page app deployed two ways — a static site (GitHub Pages) and a Capacitor-wrapped native Android app — backed by Firebase (Firestore, Auth, Storage, Cloud Messaging) and a Cloud Functions backend that owns everything that shouldn't run on the client: notification fanout, third-party OAuth, and scheduled maintenance.
 
 ## Technology Stack
 
-*   **Frontend Framework**: [React](https://react.dev/) (v19)
-    *   Used for building the user interface.
-    *   Utilizes Hooks (`useState`, `useEffect`, `useRef`) for state management.
+*   **Frontend Framework**: [React](https://react.dev/) 19, function components + hooks. No global state library — Firestore's own `onSnapshot` listeners *are* the state store (see "State management" below).
 *   **Build Tool**: [Vite](https://vitejs.dev/)
-    *   Provides fast development server and optimized production builds.
-*   **Language**: [TypeScript](https://www.typescriptlang.org/)
-    *   Ensures type safety and code maintainability.
-*   **UI Library**: [Material Web](https://github.com/material-components/material-web)
-    *   Google's official Web Components implementation of Material Design 3.
-    *   Provides accessible and performant UI elements (buttons, dialogs, lists).
-*   **Styling**: [Tailwind CSS](https://tailwindcss.com/)
-    *   Utility-first CSS framework for layout and spacing.
-*   **Mobile Runtime**: [Capacitor](https://capacitorjs.com/)
-    *   Wraps the web application in a native Android WebView.
-    *   Provides access to native APIs (Push Notifications, Geolocation, Camera).
+*   **Language**: TypeScript, strict mode, throughout both the client (`src/`) and the Cloud Functions backend (`functions/src/`) — two separate `tsconfig`/build projects.
+*   **UI Library**: [Material Web](https://github.com/material-components/material-web) (Google's Material Design 3 web components) for interactive controls, [Tailwind CSS v4](https://tailwindcss.com/) for layout/spacing. Note: v4 uses `@import "tailwindcss";` in `src/index.css`, not the v3 `@tailwind base/components/utilities` directives — the latter silently degrades to near-nothing under v4's PostCSS plugin.
+*   **Mobile Runtime**: [Capacitor](https://capacitorjs.com/) wraps the same web build in a native Android WebView (an iOS project scaffold exists under `ios/` but isn't part of the CI pipeline). Provides Camera (bottle scanner) and Push Notifications.
+*   **Drag & drop**: [`@dnd-kit`](https://dndkit.com/) for reorderable buttons.
+*   **On-device OCR**: [`tesseract.js`](https://tesseract.projectnaptha.com/) for the bottle scanner — runs entirely client-side (WASM); no photo is sent anywhere just to recognize a label.
 
 ## Backend Services (Firebase)
 
-BarBacker is a serverless application relying on [Firebase](https://firebase.google.com/):
+1.  **Authentication** — Email/Password and Google Sign-In. Authorization is layered on top via **custom claims**: `onUserRoleChange` (a Firestore-triggered Cloud Function) watches every `bars/{barId}/users/{uid}` write and stamps a `bars: { [barId]: role }` map onto that user's ID token, filtering out unapproved statuses (`pending`, `rejected`). `firestore.rules` and `storage.rules` both read this claim (`request.auth.token.bars[barId]`) rather than doing a live document read per request — cheap and fast, but it means a **grant** takes effect immediately (the client force-refreshes its token right after joining/being promoted) while a **revoke** (kick, demotion) only takes effect on the token's next natural refresh, up to about an hour later. This is the standard tradeoff of Firebase's custom-claims model, documented inline in `firestore.rules`.
+2.  **Firestore** — the primary datastore. See [DATA_MODEL.md](DATA_MODEL.md) for every collection. Real-time listeners (`onSnapshot`) sync data instantly between devices; there is no polling anywhere in the client.
+3.  **Storage** — bar logos and bottle-scanner alert photos. See `storage.rules` and [DATA_MODEL.md](DATA_MODEL.md).
+4.  **Cloud Messaging (FCM)** — push to native Android/installed-PWA devices. iOS (which can't receive FCM in a browser context) instead gets `ntfy.sh` push, keyed by a per-account topic (`users/{uid}.ntfyTopic`).
+5.  **Cloud Functions** (`functions/`, Admin SDK, bypasses all client-facing security rules) — see below.
 
-1.  **Authentication**:
-    *   Manages user identity via Email/Password and Google Sign-In.
-    *   Persists user sessions across reloads.
-2.  **Firestore (Database)**:
-    *   NoSQL document database.
-    *   Stores `bars`, `users`, `requests`, and `notices`.
-    *   Uses real-time listeners (`onSnapshot`) to sync data instantly between devices.
-3.  **Cloud Messaging (FCM)**:
-    *   Sends push notifications to Android devices when requests are made.
-    *   Web users receive in-app alerts via audio and visual cues.
+## Cloud Functions (`functions/src/`)
 
-## Data Flow
+Split by trigger type:
 
-1.  **User Action**: A bartender taps a button (e.g., "ICE").
-2.  **Firestore Write**: The app writes a new document to the `requests` collection.
-3.  **Real-time Sync**: Firestore pushes this new document to all connected devices (Barbacks) subscribed to the `requests` collection.
-4.  **UI Update**: The React state updates, rendering the new request card.
-5.  **Notification**:
-    *   **In-App**: The `useNag` hook detects the pending request and plays an alert sound.
-    *   **Push**: If configured, an FCM message is sent to native devices or an `ntfy` request is sent for iOS.
+*   **Firestore-triggered** — react to a write, run with Admin privileges:
+    *   `onUserRoleChange` — stamps the `bars` custom claim (see above).
+    *   `onRequestCreated` / `onRequestDeleted` — server-side FCM+ntfy fanout on a new request (client-side fanout was removed: it required every client to be able to read every bar member's ntfy topic, an exposure closed by moving this server-side), and Storage cleanup of a bottle-scanner photo once its referencing request doc is gone.
+    *   `onInviteConsumed` — grants an invite's role when the invitee's account consumes it.
+    *   `onChatPinned` — pushes a notification when a chat message is pinned (drives the dashboard marquee).
+    *   `onEventWritten` (`calendar/outboundSync.ts`) — mirrors a locally-created calendar event out to Google.
+*   **Scheduled** (`onSchedule`) — `cleanupStaleRequests` (hourly, clears anything pending 12+ hours), `rotatePOSTokens` (hourly), `resubscribeCalendarWatches` (daily), `pollICalSubscriptions` (every 15 min) / `removeICalSubscriptionEvents` (daily), `sendShiftReminders` (every 5 min).
+*   **Callable** (`onCall`, invoked from the client via the Firebase SDK) — `fileOwnershipClaim` / `reviewOwnershipClaim`, `migrateNoticesToChat` (one-shot legacy-data migration), `posSyncMenu` / `posGetOrders` / `posGetSales`, `calendarListCalendars` / `calendarSelectCalendar`, `rotateICalFeedToken`, and most of the OAuth flow itself: `posGetAuthorizeUrl` / `posConnectToast` / `posDisconnect`, `calendarGetAuthorizeUrl` / `calendarDisconnect`.
+*   **HTTP-triggered** (`onRequest`) — only the pieces that must be a plain URL because something other than this app's own client calls them: the OAuth redirect targets themselves (`oauthCallback` for Square, `calendarOauthCallback` for Google — the provider's consent screen redirects the browser here after approval, so these can't be callable), the Google Calendar push-notification webhook (`calendarWebhook`), and `icalFeed` (serves this bar's outbound `.ics` file to any calendar client — reachable at `/ical/**` via a Firebase Hosting rewrite, see `firebase.json`).
+
+Every OAuth token (POS and Calendar alike) is encrypted with a Cloud KMS key before being stored, in a Firestore collection with **no client access in either direction** (`posSecrets`/`calendarSecrets`) — clients only ever see connection *status* (`posConnection`/`calendarConnection`), never a token.
+
+## Data Flow (a request, end to end)
+
+1.  **User action**: a bartender taps "ICE".
+2.  **Firestore write**: the client writes a new `requests` doc directly (governed by `firestore.rules` — see [DATA_MODEL.md](DATA_MODEL.md)).
+3.  **Real-time sync**: Firestore pushes the new doc to every connected client with a matching listener.
+4.  **UI update**: React state updates from the `onSnapshot` callback; the request card renders.
+5.  **Notification** (server-side, `onRequestCreated`): computes who's eligible (active, not the requester, subscribed to this request type — see [DATA_MODEL.md](DATA_MODEL.md)#Notification-model) and sends FCM to native/PWA devices, `ntfy.sh` to iOS. A scheduled job (`scripts/nag-bot.js`, run by `.github/workflows/nag.yml` every 5 minutes) re-notifies anyone who still hasn't dismissed a matching request.
 
 ## Key Design Decisions
 
-*   **Optimistic UI**: The app assumes network success for some actions but relies primarily on the Firestore `onSnapshot` stream to drive the UI. This ensures the UI always reflects the *server* state, preventing desync.
-*   **Role-Based Access**: The UI adapts based on the user's role (Bartender vs. Barback), hiding irrelevant controls (e.g., Barbacks claim requests, Bartenders create them).
-*   **Local Persistence**: `localStorage` is used to remember the last visited Bar ID, allowing for quick re-entry on reload.
-*   **Performance**:
-    *   Audio objects are reused (`useRef`) to prevent memory leaks.
-    *   Firestore queries are limited (e.g., `limit(100)`) to prevent fetching excessive historical data.
+*   **Firestore is the state store.** The `onSnapshot` streams in `App.tsx` (and the per-feature hooks — `useChat`, `useCalendar`, `usePOS`, `useMyBars`) are the single source of truth; there's no client-side cache layer or global store to keep in sync with it.
+*   **Role vs. job title.** `role` (`Staff`/`Manager`/`Owner`) is the security-relevant privilege tier, computed server-side-verifiable (never trusted from the client beyond the narrow self-create case `firestore.rules` allows). `jobTitle` (`Bartender`, `Barback`, etc.) is a separate, purely cosmetic/notification-routing field. Conflating the two was an earlier design mistake this codebase moved away from — see the git history around the Phase 1 hardening pass.
+*   **Server does the fanout, not the client.** Notification eligibility logic exists in three synchronized places — `functions/src/notifyEligibility.ts` (server), `scripts/nag-bot.js` (the scheduled nag job, plain JS, hand-kept in sync), and a client-side mirror in `App.tsx` for the active-requests list filter — because nothing shares a build step across `src/`, `functions/`, and `scripts/`.
+*   **Shared-device safety.** Signing out or switching bars resets every piece of state a `useEffect` listener owns before its guard condition can short-circuit past a stale value — otherwise a second person on the same physical device (a phone at the bar) would briefly see the previous user's data.
+*   **Stale-listener cancellation guards.** Async flows that can outlive a bar switch or component close (e.g. `useChat.loadMore`, the bottle scanner's OCR pipeline) snapshot an identity value in a ref and check it after each `await`, so a slow response from a superseded context can't clobber current state.
+*   **Premium gating** is a single `bars/{barId}.subscription` field, checked both client-side (hide/upsell UI) and server-side (`firestore.rules`, the actual authority) — theme, calendar, POS, the bottle scanner, and private 86'd entries all gate on it. No billing flow exists yet; the field has no legitimate write path today.
+
+## CI/CD
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for the full pipeline. In short: `rules-tests.yml` runs the Firestore/Storage emulator test suite and the Cloud Functions build+tests on every push/PR against `main`; `build-mobile.yml` builds and publishes the Android release APK on every push to `main`; `codeql.yml` runs static analysis (JS/TS + the workflow files themselves) on push/PR/a weekly schedule; `deploy.yml` publishes the web app to GitHub Pages on push to `main`. Firestore/Storage rules and Cloud Functions deploys to the actual Firebase project are manual (`firebase deploy`), not automated.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,74 +1,71 @@
 # Component Guide
 
-The application is structured as a tree of React components.
+The application is structured as a tree of React function components, with shared logic pulled out into custom hooks (`src/hooks/`) rather than a global state store — see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Core Components
 
 ### `App.tsx`
-The root component. It handles:
-*   Authentication state monitoring.
-*   Routing (handling `?bar=` query param).
-*   Global subscriptions (Firestore listeners for User, Bar, Requests).
-*   Main layout rendering (Navbar, Dashboard, Footer).
-*   Conditional rendering based on state (Auth -> Bar Selection -> Role Selection -> Dashboard).
+The root component, and by far the largest file in the client. Handles:
+*   Authentication state monitoring (via `useAuth`).
+*   Routing (the `?bar=` query param, `justCreatedBar` new-bar-onboarding state).
+*   Every top-level Firestore listener (bar doc, per-bar user doc, all-users roster, requests, 86'd list) — each resets the state it owns before its `!user || !barId` guard returns, so a sign-out or bar switch can't leave stale data rendered on a shared device.
+*   Main dashboard layout, drag-and-drop button grid, and the dialogs that hang off it (BarManager, RoleSelector, NotificationSettings, WhoIsOnDialog, ChatPanel, EightySixDialog, CalendarView/CalendarSettings, POSSettings, BottleScanner, ThemeEditor).
+*   Request submission/claim/unclaim logic (delegated to `useRequestActions`) and the button-config actions (`saveBrand`, `saveType`, `saveWell`, `hideButton`/`unhideButton`).
 
 ### `main.tsx`
-The entry point. It wraps `App` in:
-*   `StrictMode`: For React best practices.
-*   `ErrorBoundary`: For catching crash loops.
-*   `HashRouter`: For routing (using hash to support static host navigation).
+The entry point: wraps `App` in `StrictMode`, `ErrorBoundary`, and `HashRouter` (hash-based routing so a static host like GitHub Pages doesn't need server-side rewrite rules for deep links).
 
-## UI Components (`src/components/`)
+## Dialogs and feature UI (`src/components/`)
 
-*   **`BarSearch.tsx`**:
-    *   Handles searching for bars via OpenStreetMap API and Firestore.
-    *   Allows creating new temporary bars.
-    *   Uses a debounced search input.
+*   **`MdDialog.tsx`** — a thin wrapper around `<md-dialog>` that every other dialog in this codebase uses instead of the raw custom element. Fixes a real React 19 bug: React binds a JSX `onClose` prop on a custom (hyphenated) element by listening for an event named literally `"Close"`, but Material's `md-dialog` dispatches lowercase `close` — so the prop silently never fired and a dialog closed by Escape/scrim-click got permanently stuck. Binds the real DOM event via a ref instead. **Note**: `MdDialog` always renders its children regardless of the `open` prop (only the `open` attribute toggles) — several components' tests query `getAllByText(...)[n]` for this reason when a confirm-sub-dialog's own button text would otherwise collide with the parent dialog's.
+*   **`BarSearch.tsx`** — search for a bar via OpenStreetMap Nominatim + Firestore, or create a new (temporary) one. Debounced input; handles OSM's `(osm_id, osm_type)` compound identity correctly (osm_id alone isn't unique) and keeps stale results from a slow/failed request off-screen.
+*   **`RoleSelector.tsx`** — first-time-in-this-bar screen: pick a display name and job title. The security-relevant `role` (Staff/Manager/Owner) is computed in `App.tsx`'s `confirmRole`, never taken from anything client-selectable here.
+*   **`BarManager.tsx`** — Manager+ dialog for hiding/restoring pager buttons and sending invites. Remove/restore controls are gated on `isManagerPlus` in the UI to match what `firestore.rules` actually enforces server-side (a non-Manager could otherwise see live but always-failing controls).
+*   **`NotificationSettings.tsx`** — toggle which request types trigger alerts, and (for iOS) the `ntfy.sh` subscription link.
+*   **`WhoIsOnDialog.tsx`** — roster of who's clocked in, off clock, and (Manager+) pending approval or a filed ownership claim, with approve/reject actions.
+*   **`ChatPanel.tsx`** — full-screen chat sheet. Any bar member posts; Manager+ can pin (drives the dashboard marquee) and delete anyone's message; everyone can delete their own, behind a confirm dialog.
+*   **`EightySixDialog.tsx`** — the 86'd list. Manager+ can add/remove entries (behind a confirm dialog); private entries (with a reason) are Manager+-only and premium-gated.
+*   **`CalendarView.tsx`** — agenda-style (chronological list, not a grid) view of shifts/bookings/events. Manager+ can create/edit/delete local events; externally-synced (Google/iCal) events render read-only with a badge. Save failures surface inline instead of silently no-opping; delete requires confirmation.
+*   **`CalendarSettings.tsx`** — connect/disconnect Google Calendar, manage inbound iCal subscriptions, and view/copy this bar's outbound iCal feed URL.
+*   **`POSSettings.tsx`** — connect/disconnect a POS provider (Square via OAuth, Toast via manually-entered partner credentials), trigger a menu sync, and view the synced menu. Only `square`/`toast` are actually wired up (`POS_PROVIDER_STATUS` in `src/constants.ts`); the rest of the provider list renders disabled as "Coming soon".
+*   **`BottleScanner.tsx`** — camera capture + on-device OCR (`utils/bottleRecognition.ts`, via `tesseract.js`) to recognize a bottle label against the bar's own inventory plus the curated brand lists in `src/constants.ts`. Confirm/correct the recognized brand, then Add to Menu, 86 It (if already on the menu), or Send Alert (uploads the photo and files a normal request referencing it). Guards its async capture/OCR chain with a close-token ref so closing the dialog mid-recognition can't repopulate stale state on next open.
+*   **`ThemeEditor.tsx`** — premium-only bar branding: primary/accent color pickers, logo upload (Storage), and a font picker.
+*   **`InputDialog.tsx`** — generic text-entry dialog used for adding a brand/type/well, with a "this already exists, navigate to it instead" flow rather than a blocking error.
+*   **`SortableButton.tsx`** — `@dnd-kit` wrapper making a dashboard button draggable/reorderable, including keyboard (`KeyboardSensor`) support.
+*   **`ErrorBoundary.tsx`** — catches render errors, shows a "Something went wrong" screen with a "Copy Debug Info" button (see `src/utils/debug.ts`).
 
-*   **`BarManager.tsx`**:
-    *   A dialog for managing the bar's configuration (hiding buttons).
-    *   Only accessible to authorized roles (logic in App.tsx).
+## Hooks (`src/hooks/`)
 
-*   **`RoleSelector.tsx`**:
-    *   Forces the user to select a role (Bartender, Barback, etc.) and display name upon joining a bar.
+Most shared/async logic lives here rather than inline in `App.tsx`, one hook per concern:
 
-*   **`NotificationSettings.tsx`**:
-    *   Allows users to toggle which request types trigger alerts.
-    *   Displays the `ntfy` subscription link for iOS.
+*   **`useAuth.ts`** — tracks the current Firebase Auth user; exposes sign-in (Google popup, email/password), sign-up, sign-out, and a `loading` flag.
+*   **`useGodMode.ts`** — resolves whether the current user has the `admin` custom claim (set via `scripts/set-admin-claim.js`), the same claim `firestore.rules`/`storage.rules` check for moderation bypass.
+*   **`useMyBars.ts`** — the account-level list of joined bars (with names resolved), plus the account's global `ntfyTopic` (auto-generated on first login if missing).
+*   **`useRequestActions.ts`** — `submitRequest`/`claimRequest`/`unclaimRequest`/`cancelRequest`. Firestore's single-document write serialization is what actually resolves a claim race between two people tapping the same request — no client transaction needed.
+*   **`useChat.ts`** — chat messages (paginated scrollback + always-live pinned-messages/unread-badge listeners), `sendMessage`/`togglePin`/`deleteMessage`. `loadMore` guards against a bar switch mid-fetch via a ref-snapshotted identity check after its `await`.
+*   **`useCalendar.ts`** — calendar events CRUD (local events only — externally-synced ones are read-only per `firestore.rules`).
+*   **`usePOS.ts`** — POS connection status/menu listeners and the connect/disconnect/sync actions (thin wrappers over the callable Cloud Functions).
+*   **`useBarTheme.ts`** — applies a premium bar's custom theme as CSS custom properties on `document.documentElement`. Uses `useLayoutEffect`, not `useEffect`, specifically to avoid a one-frame flash of the previous theme.
+*   **`useDragAndDrop.ts`** — `@dnd-kit` sensors/handlers for the button grid, including `onDragCancel` (Escape mid-drag) alongside the more obvious `onDragEnd`.
+*   **`useInactivityAutoSubmit.ts`** — auto-submits an "(Ask Me)" request if a sub-menu sits open too long with no input; `paused` while a dialog reachable from that sub-menu is open, so it doesn't fire out from under an active interaction.
+*   **`useUsageBatching.ts`** — buffers per-button tap counts locally and flushes to `bars/{barId}.buttonUsage` every 10s (and on unmount/backgrounding) instead of one write per tap.
+*   **`usePushNotifications.ts`** — wires up FCM (web/native) and native push listeners once per mount, device-scoped (not re-run on auth changes, which previously stacked duplicate handlers).
+*   **`useNag.ts`** — plays a periodic alert sound while there's an unclaimed, un-ignored request.
+*   **`usePwaInstallPrompt.ts`** — captures the browser's `beforeinstallprompt` event to drive a custom "Install App" button.
+*   **`useLatestRelease.ts`** — fetches the latest GitHub release APK download URL (for the in-app "update available" flow on Android).
 
-*   **`InputDialog.tsx`**:
-    *   A generic dialog for text input (searching brands, adding wells).
-    *   Supports "Create New" flow.
+## Utilities (`src/utils/`)
 
-*   **`WhoIsOnDialog.tsx`**:
-    *   Displays a list of currently active and off-clock users.
-
-*   **`SortableButton.tsx`**:
-    *   A wrapper component using `@dnd-kit` to make buttons draggable for reordering.
-
-*   **`ErrorBoundary.tsx`**:
-    *   Catches React render errors.
-    *   Displays a "Something went wrong" screen with diagnostic info.
-    *   Provides a "Copy Debug Info" button for reporting issues.
+*   **`bottleRecognition.ts`** — `recognizeBottleText` (tesseract.js OCR) and `matchBrand` (fuzzy-matches recognized text against a candidate brand list via exact/substring/edit-distance scoring, with a length-ratio guard so a short generic OCR fragment can't confidently misidentify an unrelated bottle).
+*   **`color.ts`** — hex color parsing and contrast-ratio computation, used by `ThemeEditor` to keep custom brand colors legible.
+*   **`async.ts`** — small async helpers (debounce/retry primitives) shared across `BarSearch` and elsewhere.
+*   **`debug.ts`** — builds the diagnostic report `ErrorBoundary`'s "Copy Debug Info" button copies to the clipboard. Extend this when adding new critical infrastructure (env vars, storage requirements) — see [AGENTS.md](../AGENTS.md).
 
 ## Material Web Integration
 
-We use **Material Web** (Google's WC implementation) for all leaf UI elements.
-*   `md-filled-button`
-*   `md-outlined-button`
-*   `md-text-button`
-*   `md-filled-text-field`
-*   `md-icon`
-*   `md-dialog`
-*   `md-list`, `md-list-item`
-*   `md-circular-progress`
-*   `md-switch`
-*   `md-checkbox`
-*   `md-radio`
-
-These are custom elements. React interacts with them by setting props (attributes) and handling standard events (though sometimes needing refs for complex events).
+Custom elements (declared in `src/vite-env.d.ts`) used throughout: `md-filled-button`, `md-outlined-button`, `md-text-button`, `md-filled-tonal-button`, `md-filled-text-field`, `md-icon`, `md-icon-button`, `md-dialog` (wrapped, see `MdDialog.tsx` above), `md-list`/`md-list-item`, `md-menu`/`md-menu-item`, `md-circular-progress`, `md-switch`, `md-checkbox`, `md-radio`. React interacts with these by setting props/attributes and handling standard events; each component file imports the specific element modules it uses to register them.
 
 ## State Management
 
-*   **Local UI State**: Handled by `useState` (e.g., dialog open/close, search text).
-*   **Shared Data**: Handled by **Firestore Subscriptions**. We do *not* use a global state store like Redux. The Firestore `onSnapshot` listeners in `App.tsx` act as the single source of truth, updating local state variables (`requests`, `users`) whenever the backend changes.
+*   **Local UI state**: `useState` (dialog open/close, form fields, search text).
+*   **Shared data**: Firestore subscriptions. There is no Redux/Zustand/etc. — the `onSnapshot` listeners in `App.tsx` and the feature hooks above are the single source of truth; local state variables are just their latest delivered snapshot.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,78 +1,131 @@
 # Data Model
 
-BarBacker uses **Cloud Firestore**, a NoSQL document database. The data is structured into root-level collections.
+BarBacker uses **Cloud Firestore** (NoSQL documents) plus a small amount of **Firebase Storage** (photos/logos). This doc describes every collection, its fields, and who can read/write it. TypeScript types for most of these live in `src/types.ts` — treat that file as the source of truth for shape, and `firestore.rules`/`storage.rules` as the source of truth for access.
 
-## Collections
+A note on the security model: server-side access is enforced by a per-bar **privilege role** (`'Staff' | 'Manager' | 'Owner'`), stamped as a custom claim on the user's Firebase Auth ID token by the `onUserRoleChange` Cloud Function and read by `firestore.rules`/`storage.rules` as `request.auth.token.bars[barId]`. This is distinct from a member's **job title** (`Bartender`, `Barback`, etc.), which is purely a UI/notification concern. See [ARCHITECTURE.md](ARCHITECTURE.md) for how the claim gets there and its staleness tradeoffs.
 
-### 1. `bars` (Root)
-Stores information about each bar location.
+## Root collections
 
-*   **Document ID**: `string` (OSM ID or generated timestamp ID)
-*   **Fields**:
-    *   `name`: `string` - The display name of the bar.
-    *   `address`, `city`, `state`, `zip`, `phone`: `string` - Location details.
-    *   `status`: `'verified' | 'temporary'` - Verification status.
-    *   `type`: `'bar' | 'restaurant'` - Business type.
-    *   `buttons`: `ButtonConfig[]` - Custom button configuration (overrides defaults).
-    *   `beerInventory`: `Map<string, string[]>` - Map of Brand -> Types (e.g., "Bud Light" -> ["Bottle", "Draft"]).
-    *   `wells`: `string[]` - List of well names (e.g., "Well 1", "Patio").
-    *   `hiddenButtonIds`: `string[]` - List of IDs of buttons to hide from the dashboard.
-    *   `buttonUsage`: `Map<string, number>` - Counter for button clicks (for sorting).
-    *   `customOrders`: `Map<string, string[]>` - Custom sort order for buttons.
+### `users/{uid}`
+Global, self-only account document — not bar-scoped.
 
-### 2. `bars/{barId}/users` (Sub-collection)
-Stores user profiles specific to a bar.
+| Field | Type | Notes |
+|---|---|---|
+| `joinedBars` | `string[]` | Bar IDs this account has joined. Capped at 50 by `firestore.rules` (`onUserRoleChange` does an unbounded read per entry, so this doubles as a cost-amplification guard). |
+| `ntfyTopic` | `string` | Auto-generated (`barbacker-<random>`) on first login by `useMyBars.ts`. The single source of truth for this account's iOS push topic — server-side fanout (`onRequestCreated`) reads it from here, never from a per-bar doc. |
 
-*   **Document ID**: `uid` (Firebase Auth ID)
-*   **Fields**:
-    *   `displayName`: `string` - User's chosen name.
-    *   `role`: `string` - 'Bartender', 'Barback', 'Manager', etc.
-    *   `status`: `'active' | 'off_clock' | 'pending'` - Current working status.
-    *   `joinedAt`: `Timestamp` - When they joined the bar.
-    *   `lastSeen`: `Timestamp` - Last activity timestamp.
-    *   `email`: `string` - User email.
-    *   `notificationPreferences`: `string[]` - List of button IDs this user wants alerts for.
-    *   `ntfyTopic`: `string` - The generated topic for iOS notifications (e.g., `barbacker-{uid}`).
+Read/write: self only.
 
-### 3. `bars/{barId}/notices` (Sub-collection)
-Stores bulletin board messages.
+### `requests/{requestId}`
+Top-level collection (not nested under a bar) so a device only ever needs one listener regardless of how many bars it's a member of; every doc carries its own `barId`.
 
-*   **Document ID**: `auto-generated`
-*   **Fields**:
-    *   `text`: `string` - The message content.
-    *   `authorId`: `string` - UID of the poster.
-    *   `authorName`: `string` - Name of the poster.
-    *   `timestamp`: `Timestamp` - Creation time.
+| Field | Type | Notes |
+|---|---|---|
+| `barId` | `string` | Which bar this request belongs to. Immutable after create. |
+| `label` | `string` | e.g. `"ICE: Well 1"`, `"BEER: Jameson"`, or free text for a custom/"(Ask Me)" request. 1–500 chars. |
+| `requesterId` | `string` | Caller's uid — must match `request.auth.uid`. |
+| `requesterName`, `requesterRole` | `string` | Snapshotted from the caller's own per-bar user doc at write time (not client-asserted — see security notes below). |
+| `status` | `'pending' \| 'claimed'` | |
+| `timestamp` | `Timestamp` | Must be the `serverTimestamp()` sentinel. |
+| `lastNotification` | `Timestamp` | Used by the scheduled nag job to throttle re-notifies; must also be `serverTimestamp()` on create. |
+| `buttonId` | `string?` | The top-level button id this request resolved to (e.g. `restock_beer`), if any. Drives notification-preference filtering server-side; absent for free-text requests, which notify everyone as a safety default. |
+| `claimedBy`, `claimerName`, `claimedAt` | | Set on claim. |
+| `photoUrl` | `string?` | Set by the bottle scanner's "Send Alert" action. Regex-constrained server-side to this bar's own `bottlePhotos` Storage path — see the security note in `firestore.rules` about why a bare type check wasn't enough. |
 
-### 4. `bars/{barId}/tokens` (Sub-collection)
-Stores FCM tokens for push notifications.
+**Security**: create requires membership in the target bar and binds `requesterName`/`requesterRole` to the caller's real per-bar profile (can't be forged to impersonate someone else in the push/ntfy fanout). The only client-side updates are claim (`pending → claimed`) and unclaim (`claimed → pending`, claimer only) — Firestore's single-document write serialization is what actually prevents two people claiming the same request at once, no client transaction needed. Delete is allowed for the requester or Manager+.
 
-*   **Document ID**: `uid`
-*   **Fields**:
-    *   `token`: `string` - The FCM registration token.
-    *   `updated`: `Timestamp` - Last update time.
+## `bars/{barId}` (root)
 
-### 5. `requests` (Root)
-Stores all active and past requests. Note: This is a root collection to allow for easier querying across bars if needed in the future, though currently filtered by `barId`.
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | |
+| `ownerId` | `string` | Set once at creation, immutable. Lets the bar's creator self-assign `Owner` on join since there's no existing Owner to promote them. |
+| `status` | `'verified' \| 'temporary'` | |
+| `type` | `'bar' \| 'restaurant'?` | |
+| `address`, `city`, `state`, `zip`, `phone` | `string?` | |
+| `osmId`, `osmType` | `string?` | OpenStreetMap identity — the *pair* is the unique key, not `osmId` alone. |
+| `buttons` | `ButtonConfig[]?` | Custom buttons, merged with `DEFAULT_BUTTONS` client-side. |
+| `beerInventory` | `Record<string, string[]>?` | Brand → types, e.g. `{"Jameson": ["Bottle"]}`. Also where bottle-scanner-recognized spirits get filed (see [COMPONENTS.md](COMPONENTS.md)#BottleScanner for the known "spirits labeled as beer" simplification). |
+| `wells`, `hiddenButtonIds` | `string[]?` | |
+| `buttonUsage` | `Record<string, number>?` | Tap counts, drives "most used" sort. Any bar member (not just Manager+) can bump this. |
+| `customOrders` | `Record<string, string[]>?` | Custom sort order per nav context. |
+| `subscription` | `'free' \| 'premium'?` | Gates theme, POS, calendar, private 86'd entries, bottle scanner. No billing flow exists yet — nothing writes this field at all today; it's set manually. |
+| `joinPolicy` | `'open' \| 'approval'?` | Default `open`. `approval` requires a Manager to flip a joining member from `pending` to `active`. |
+| `theme` | `BarTheme?` | `{ primaryColor, accentColor, logoUrl?, fontFamily? }` |
 
-*   **Document ID**: `auto-generated`
-*   **Fields**:
-    *   `barId`: `string` - The ID of the bar this request belongs to.
-    *   `label`: `string` - The text of the request (e.g., "ICE: Well 1").
-    *   `requesterId`: `string` - UID of the sender.
-    *   `requesterName`: `string` - Name of the sender.
-    *   `requesterRole`: `string` - Role of the sender.
-    *   `status`: `'pending' | 'claimed'` - Current state.
-    *   `timestamp`: `Timestamp` - Creation time.
-    *   `claimedBy`: `string` (optional) - UID of the claimer.
-    *   `claimerName`: `string` (optional) - Name of the claimer.
-    *   `claimedAt`: `Timestamp` (optional) - When it was claimed.
-    *   `lastNotification`: `Timestamp` - Used to throttle repeat notifications.
+**Security**: readable by any signed-in user (bar search). Only Manager+ can update it, and `ownerId`/`subscription` are pinned immutable on every update regardless of role (ownership transfer only via `ownershipClaims`; subscription has no legitimate write path client-side at all).
 
-## Security Rules (Implicit)
+### `bars/{barId}/users/{uid}`
+Per-bar membership/profile.
 
-*   **Read**: Generally allowed for authenticated users who are members of the bar.
-*   **Write**:
-    *   `requests`: Allowed for any active user in the bar.
-    *   `bars`: Restricted (mostly managed by logic or initial creation).
-    *   `users`: Users can update their own status/preferences. Managers (logic-side) can approve users.
+| Field | Type | Notes |
+|---|---|---|
+| `role` | `'Staff' \| 'Manager' \| 'Owner'` | **Privilege tier** — what the custom claim mirrors. |
+| `jobTitle` | `string?` | **Job function** — `Bartender`, `Barback`, `Server`, `Security`, `Runner`, or `Staff` (the fallback `onInviteConsumed` uses for an invited member with no title picked yet). Distinct field from `role`. |
+| `displayName`, `email` | `string?` | |
+| `status` | `'active' \| 'off_clock' \| 'pending' \| 'rejected'` | |
+| `joinedAt`, `lastSeen` | `Timestamp` | |
+| `notificationPreferences` | `string[]?` | List of button ids this member wants alerts for; defaults from `ROLE_NOTIFICATION_DEFAULTS[jobTitle]` (see `src/constants.ts`) if unset. |
+
+**Security**: role is never client-writable except at self-create time, where it can only be `'Staff'` — or `'Owner'` if `bars/{barId}.ownerId` already equals the caller (i.e., they created the bar). `status` on create must match the bar's `joinPolicy` (`active` for `open`, `pending` for `approval`); the bar's own creator always gets `active` regardless. Self-write after that is limited to a handful of operational fields, and `status` can only toggle `active ↔ off_clock` on your own doc (can't self-approve out of `pending`/`rejected`). Promotions/approvals/kicks go through the Manager+ update branch (can't touch existing Owners or promote to Owner) or the Owner branch (can do anything to non-Owners, or relinquish their own role).
+
+### `bars/{barId}/tokens/{uid}`
+FCM push token. `{ token, updated }`. Strictly self read/write.
+
+### `bars/{barId}/chat/{messageId}`
+Team chat (Phase 2). Replaces the old `notices` bulletin board.
+
+| Field | Type | Notes |
+|---|---|---|
+| `text` | `string` | Immutable once posted — `update` is scoped to only the pin fields below. |
+| `authorId`, `authorName`, `authorRole` | | Snapshotted from the caller's own profile at post time, same anti-spoofing pattern as `requests`. |
+| `timestamp` | `Timestamp` | Must be `serverTimestamp()`. |
+| `pinned` | `boolean` | Pinned messages drive the dashboard marquee. Only Manager+ can pin. |
+| `pinnedBy`, `pinnedAt` | | |
+
+Any bar member can post and delete their own message; Manager+ can delete anyone's and pin/unpin.
+
+### `bars/{barId}/eightySixed/{entryId}`
+The 86'd list.
+
+| Field | Type | Notes |
+|---|---|---|
+| `patronName` | `string` | |
+| `submittedBy`, `submitterName` | | Bound to the caller, like chat's author fields. |
+| `reason` | `string?` | Private entries only. |
+| `visibility` | `'public' \| 'private'` | Public: any member with a role can read. Private: Manager+ only, and gated behind `subscription == 'premium'` (or admin) at create time. |
+| `timestamp` | `Timestamp` | |
+
+Only Manager+ can create/delete; no update path exists (entries are immutable once filed — delete and recreate instead).
+
+### `bars/{barId}/invites/{inviteId}`
+`{ email, role, createdBy, createdByName, createdAt, consumed, consumedBy?, consumedAt? }`. Manager+ creates; the invitee (matched by verified email) can read their own and consume it — a strict one-way `consumed: false → true` transition naming themselves as `consumedBy`. `onInviteConsumed` (Cloud Function) grants the invite's role on consumption.
+
+### `bars/{barId}/ownershipClaims/{claimId}`
+`{ barId, claimantId, claimantName, justification?, status: 'pending'|'approved'|'rejected', createdAt }`. Writes are Cloud-Function-only (`fileOwnershipClaim`, `reviewOwnershipClaim`); readable by Manager+ or the claimant themselves.
+
+### POS integration (Phase 3)
+*   `bars/{barId}/posConnection/{provider}` — `{ provider, connected, merchantId?, error?, connectedAt?, lastSyncedAt?, lastSyncedCount? }`. Status only, Manager+-readable, Cloud-Function-write-only.
+*   `bars/{barId}/posSecrets/{provider}` — encrypted OAuth tokens. No client access at all, in either direction — split into its own collection specifically so a client read of `posConnection` can never leak a credential.
+*   `bars/{barId}/menu/{itemId}` — `{ id, name, price (cents), category?, provider, syncedAt? }`, synced in by `posSyncMenu`. Readable by any bar member; write is Cloud-Function-only.
+*   `posOAuthStates/{state}` (root) — ephemeral OAuth CSRF-state tokens for the Square connect flow. No client access; short-lived, deleted by `oauthCallback`.
+
+### Calendar (Phase 4)
+*   `bars/{barId}/events/{eventId}` — `{ title, start, end (ISO 8601), description?, type: 'shift'|'booking'|'event'|string, assignedTo? (uids), externalId?, externalProvider? ('google' | 'ical:<hash>'), lastSyncedAt?, deletedAt? }`. Manager+ can create/edit/delete **local** events only — anything with `externalProvider` set was written by a Cloud Function via the Admin SDK (Google inbound sync or an iCal poll) and is read-only client-side.
+*   `bars/{barId}/calendarConnection/{provider}` / `calendarSecrets/{provider}` — same status/secret split as POS, same reasoning.
+*   `bars/{barId}/icalFeed/{doc}` — the opaque token in this bar's outbound iCal feed URL. Manager+-readable; only `rotateICalFeedToken` writes it.
+*   `bars/{barId}/icalSubscriptions/{subId}` — `{ url, createdBy, createdAt, lastPolledAt?, lastError? }`, an external `.ics` URL a Manager+ has subscribed the bar's calendar to. Client can create/delete; only the scheduled poller writes `lastPolledAt`/`lastError`.
+*   `calendarOAuthStates/{state}` (root) — same pattern as `posOAuthStates`, for the Google Calendar connect flow.
+
+## Firebase Storage
+
+| Path | Who can write | Notes |
+|---|---|---|
+| `bars/{barId}/logo.<ext>` | Manager+ of that bar (or admin) | Bar branding. Readable by any signed-in user — logos aren't sensitive. Max 2MB, must be an image `contentType`. |
+| `bottlePhotos/{barId}/{fileName}` | Any member of that bar | Uploaded by the bottle scanner's "Send Alert" action. Unlike the logo, **read** is also scoped to bar membership — this is per-bar content, not public branding, and the download URL never expires. Max 5MB. |
+
+`contentType` checks above are a UX nicety, not a security boundary — Storage rules can't inspect actual file bytes, only the client-supplied header.
+
+## Notification model
+
+Both the server-side fanout (`onRequestCreated`) and the scheduled nag job (`scripts/nag-bot.js`) apply the same eligibility logic (`functions/src/notifyEligibility.ts` / its hand-kept JS mirror): a member is notified if they're `active`, not the requester, and either the request has no resolvable `buttonId` (free text — notify everyone as a safety default) or their `notificationPreferences` (falling back to `ROLE_NOTIFICATION_DEFAULTS[jobTitle]`, see `src/constants.ts`) includes it. `BREAK` requests always notify everyone regardless of preferences, matched by exact `buttonId`, not a label substring.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,5 +1,30 @@
 # Deployment Guide
 
+## CI Overview
+
+Every workflow lives in `.github/workflows/`; details of the notable
+ones are in their own sections below. Quick reference:
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `rules-tests.yml` | push/PR to `main` | Firestore + Storage security-rules test suite (Firebase emulator) and Cloud Functions build+tests — this is the PR-side build/test signal for the whole repo. |
+| `build-mobile.yml` | push to `main`, `workflow_dispatch` | Builds and publishes the Android release APK (see "Android Deployment" below). Not run on PRs. |
+| `deploy.yml` | push to `main` | Builds and publishes the web app to GitHub Pages. |
+| `codeql.yml` | push/PR to `main`, weekly schedule | Static analysis (CodeQL) — `javascript-typescript` and `actions` (the workflow files themselves). Advanced setup, not GitHub's managed Default setup, specifically so triggers/concurrency are editable here. `java-kotlin`/`swift` are deliberately excluded: both are Capacitor's generated wrapper boilerplate with no real app logic, and CodeQL's `autobuild` can't build either without first running `npx cap sync`, which this workflow doesn't do. |
+| `nag.yml` | every 5 minutes | Runs `scripts/nag-bot.js` — re-notifies anyone who hasn't dismissed a matching pending request. |
+| `deduplicate.yml` | daily | Runs `scripts/deduplicate.js`. |
+| `enrich-bars.yml` | every 6 hours | Runs `scripts/enrich-bars.js`. |
+| `clear-cache.yml` | `workflow_dispatch` | Manual cache-clearing utility. |
+| `jules-issue-handler.yml` / `jules-branch-handler.yml` | issue opened / comment created | Hands work to the Jules autonomous coding agent. Gated to owner/member/collaborator-authored issues and comments (`author_association`) so an attacker-authored issue/comment can't trigger it. |
+
+`build-mobile.yml` and `codeql.yml` both apply a `concurrency` group
+(keyed on `head_ref || ref`, `cancel-in-progress: true`) so a rapid
+second push supersedes an in-flight run for the same ref instead of
+both running to completion — worth knowing if you're watching the
+Actions tab and see more runs than expected. `rules-tests.yml` has no
+such group as of this writing; a burst of pushes will run each to
+completion independently.
+
 ## Web Deployment (GitHub Pages)
 
 The web application is hosted on GitHub Pages, deployed automatically
@@ -122,15 +147,26 @@ The Android application is a Capacitor wrapper around the web app.
 *   Keystore file (for signing)
 
 ### Build Process (CI/CD)
-The `.github/workflows/build-mobile.yml` workflow runs on every push
-to any branch (for build/test signal on every commit) and on
-`workflow_dispatch` — there is no tag-based trigger at all. It
-computes its own version (`major.minor.patch.build`, from
-`version.properties` + commit count) and publishes that as a
-prerelease under a floating `latest-debug-v<major>.<minor>` tag it
-creates/force-moves itself, but ONLY when the push is to `main` and
-the build succeeded — every other branch just builds and tests
-without touching the public release.
+The `.github/workflows/build-mobile.yml` workflow runs on push to
+`main` and on `workflow_dispatch` only — there is no tag-based
+trigger, and (as of this writing) no PR-side run either: PR-side
+build/test coverage comes from `rules-tests.yml` instead (see "CI
+Overview" below), and this workflow's job is specifically the release
+pipeline, which only ever fires on `main` anyway. It computes its own
+version (`major.minor.patch.build`, from `version.properties` +
+commit count) and publishes that as a prerelease under a floating
+`latest-debug-v<major>.<minor>` tag it creates/force-moves itself.
+The concurrency group is keyed on `head_ref || ref` and cancels an
+in-progress run for the same ref, so a rapid second push to `main`
+supersedes rather than races the first.
+
+A step immediately before keystore generation reports (by name only,
+never value) whether each of the four `KEYSTORE_*` secrets below is
+actually set — useful for diagnosing "secret is definitely set but
+the build says it's missing" without guessing (usually a name
+mismatch or the secret having been added at the wrong scope —
+Environment secrets vs. Repository secrets — see that step's own
+comment in the workflow file).
 
 1.  **Environment Setup**: Installs Node, Java 21.
 2.  **Web Build**: Runs `npm run build`.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1,6 +1,6 @@
 # Scripts Documentation
 
-The `scripts/` directory contains Node.js scripts used for build automation and maintenance.
+The `scripts/` directory contains plain Node.js scripts used for build automation and scheduled maintenance — these are separate from the actual Cloud Functions backend (`functions/`, see [ARCHITECTURE.md](ARCHITECTURE.md) and [DATA_MODEL.md](DATA_MODEL.md)), which handles real-time notification fanout, OAuth, and its own scheduled jobs.
 
 ## `generate-sw.js`
 *   **Purpose**: Generates the `firebase-messaging-sw.js` service worker file.
@@ -13,15 +13,16 @@ The `scripts/` directory contains Node.js scripts used for build automation and 
 *   **How**: It reads individual fields from environment variables (e.g., `VITE_FIREBASE_PROJECT_ID`) and constructs the JSON file at `android/app/google-services.json`.
 
 ## `enrich-bars.js`
-*   **Purpose**: A utility script to backfill data or perform batch updates on Bar documents.
-*   **Usage**: Run manually to migrate data schemas (e.g., adding a default button configuration to all bars).
+*   **Purpose**: Backfills/normalizes `bars` documents (e.g. filling in missing fields from an OpenStreetMap lookup).
+*   **Runs**: Scheduled every 6 hours via `.github/workflows/enrich-bars.yml`, using `FIREBASE_SERVICE_ACCOUNT`. Also runnable manually (`workflow_dispatch`) or locally.
 
 ## `deduplicate.js`
-*   **Purpose**: A maintenance script to remove duplicate entries if they occur.
+*   **Purpose**: Finds and removes duplicate `bars` documents (e.g. two entries for the same venue created independently via search).
+*   **Runs**: Scheduled daily at 2 AM UTC via `.github/workflows/deduplicate.yml`, using `FIREBASE_SERVICE_ACCOUNT`. Also runnable manually or locally.
 
 ## `nag-bot.js`
-*   **Purpose**: A standalone bot script (likely run on a server) that monitors requests and sends reminders if they are not claimed.
-*   **Status**: Currently experimental/optional.
+*   **Purpose**: Re-notifies (FCM + `ntfy.sh`) anyone who hasn't dismissed a pending request that matches their notification preferences — the same eligibility logic as the server-side `onRequestCreated` Cloud Function (`shouldNagUserAbout` mirrors `notifyEligibility.ts`; kept manually in sync since nothing shares a build step between `scripts/` and `functions/`). Chunks its FCM sends at 400 tokens (under the SDK's 500 hard limit) and bumps each bar's `lastNotification` immediately after that bar's send attempt, not once at the end for every bar.
+*   **Runs**: Scheduled every 5 minutes via `.github/workflows/nag.yml`, using `FIREBASE_SERVICE_ACCOUNT`. Also runnable manually or locally — this is the primary reliability net for missed pushes, not an optional/experimental feature.
 
 ## `debug-test.cjs`
 *   **Purpose**: A CommonJS script for testing the debugging utilities in a standalone node environment.

--- a/docs/plans/2026-05-21-feature-set-purr-design.md
+++ b/docs/plans/2026-05-21-feature-set-purr-design.md
@@ -1,5 +1,16 @@
 # Feature Set Hardening + Build-Out — Design
 
+> **Status: all four phases shipped**, plus a subsequent multi-round
+> adversarial audit pass. This is the original design doc, kept for
+> historical context — for current status and what's actually open,
+> see [`future-features.md`](future-features.md); for the
+> as-implemented data model and architecture, see
+> [`../DATA_MODEL.md`](../DATA_MODEL.md) and
+> [`../ARCHITECTURE.md`](../ARCHITECTURE.md). Some specifics below
+> (e.g. the ownership-claim waterfall's exact steps) may have been
+> simplified during implementation — those docs, not this one, are
+> the source of truth for current behavior.
+
 **Date:** 2026-05-21
 **Scope:** Staff-side feature set only. Customer-facing ordering PWA deferred to a separate brainstorm.
 

--- a/docs/plans/2026-05-21-phase-1-hardening.md
+++ b/docs/plans/2026-05-21-phase-1-hardening.md
@@ -1,5 +1,14 @@
 # Phase 1 — Hardening Implementation Plan
 
+> **Status: shipped.** Kept for historical context; see
+> [`future-features.md`](future-features.md) for current status and
+> [`../DATA_MODEL.md`](../DATA_MODEL.md) for the as-implemented data
+> model. The ownership-claim flow that shipped
+> (`functions/src/ownershipClaims.ts`: `fileOwnershipClaim` /
+> `reviewOwnershipClaim`) is simpler than the five-step waterfall
+> sketched below — Manager+/Owner review only, no automated
+> OSM-contact/email-domain/dispute-window steps.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Land the role model, signup gating, user-management UI, hardened Firestore rules, custom-claims stamping, 86'd rules enforcement, and the full optional ownership-claim waterfall — the foundation every later phase depends on.

--- a/docs/plans/future-features.md
+++ b/docs/plans/future-features.md
@@ -17,17 +17,41 @@ backend and Cloud Functions. Worth revisiting if native performance/UI
 becomes a real requirement, or if there's a language/tooling reason to
 move off the web stack.
 
-## Also already tracked, not yet built
+## Status of the four-phase plan
 
-The four-phase plan in `2026-05-21-feature-set-purr-design.md` has Phase 1
-(hardening) effectively done as of the glee-audit rounds; Phases 2-4 are
-still fully unbuilt and each independent enough to pick up on its own:
+All four phases in `2026-05-21-feature-set-purr-design.md` have shipped:
 
-- **Phase 2** — real chat with pinned notices (replaces the 3-day rolling
-  notices marquee).
-- **Phase 3** — real POS integration (Square + Toast), OAuth + server-side
-  API calls.
-- **Phase 4** — two-way Google Calendar sync + inbound/outbound iCal.
+- **Phase 1** (hardening) — done as of the glee-audit rounds.
+- **Phase 2** (chat with pinned messages, replacing the old notices
+  marquee) — done; see `ChatPanel.tsx`, `useChat.ts`.
+- **Phase 3** (POS integration — Square + Toast, OAuth + server-side API
+  calls) — done for Square and Toast; see `POSSettings.tsx`, `usePOS.ts`,
+  `functions/src/pos/`. Several more providers are listed in the picker
+  (`POS_PROVIDERS` in `src/constants.ts`) but render "Coming soon" —
+  `functions/src/pos/stubs.ts` has the adapter scaffolding for wiring one
+  up.
+- **Phase 4** (two-way Google Calendar sync + inbound/outbound iCal) —
+  done; see `CalendarView.tsx`, `CalendarSettings.tsx`, `useCalendar.ts`,
+  `functions/src/calendar/`.
 
-And, per that doc, the customer-facing ordering PWA remains its own
-separate brainstorm, not yet started.
+The subsequent multi-round adversarial audit pass (privilege-escalation
+fixes, notification-fanout reliability, CI/CD hardening, UX gating
+consistency, and BottleScanner-specific bugs) is also done.
+
+Not yet started, per that doc: the customer-facing ordering PWA remains
+its own separate brainstorm.
+
+## Genuinely open items
+
+- **POS providers beyond Square/Toast** — Clover, Lightspeed, SpotOn,
+  TouchBistro, Revel, Lavu, Talech, Aloha are all listed but disabled.
+  Picking one up is a matter of building its adapter against the
+  `POSClient` interface (`functions/src/pos/types.ts`) and flipping its
+  entry in `POS_PROVIDER_STATUS`.
+- **Billing/subscription flow** — `bars/{barId}.subscription` gates
+  every premium feature (theme, calendar, POS, bottle scanner, private
+  86'd entries) but has no legitimate write path at all today; it's set
+  manually. No payment integration exists.
+- **iOS native build** — an `ios/` Capacitor project scaffold exists but
+  isn't part of the CI pipeline (no `build-ios.yml` equivalent to
+  `build-mobile.yml`) and hasn't been shipped anywhere.


### PR DESCRIPTION
## Summary

Every doc in the repo predated most of what's actually been built — chat, the 86'd list, the bottle scanner, calendar (two-way Google sync + iCal), POS integration, invites, ownership claims, custom theming, and the entire Cloud Functions backend that powers server-side notification fanout and third-party OAuth. Several also contained claims that were flatly wrong: README/ARCHITECTURE never mentioned Cloud Functions existed at all; DATA_MODEL was missing more than half the actual Firestore collections; `future-features.md` still said Phases 2-4 were "fully unbuilt" when all four, plus a full audit-and-fix pass on top, were done; `SECURITY.md` was an unfilled GitHub template with a placeholder version-number table that doesn't apply to a continuously-deployed app; `DEPLOYMENT.md`'s `build-mobile.yml` trigger description was stale as of this session's own CI fixes.

- **README.md**: full feature list (chat, 86'd list, bottle scanner, calendar, POS, theming, invites, ownership claims), corrected premium-gating and role-model claims, added a local-dev section.
- **docs/ARCHITECTURE.md**: added the Cloud Functions backend (every function categorized by trigger type, cross-checked against its actual `firebase-functions` import — see below), the custom-claims security model and its staleness tradeoff, KMS-encrypted OAuth token storage, and a CI/CD summary.
- **docs/DATA_MODEL.md**: rewritten from `firestore.rules` + `storage.rules` + `types.ts` as source of truth — every collection that exists today, field-by-field, with the security rule that governs each.
- **docs/COMPONENTS.md**: added every component and hook built since the original doc (ChatPanel, EightySixDialog, CalendarView/Settings, POSSettings, BottleScanner, ThemeEditor, MdDialog, the full `src/hooks/` directory), plus `src/utils/`.
- **docs/DEPLOYMENT.md**: fixed the `build-mobile.yml` trigger description (main-only now, not every branch) and added a CI overview table covering every workflow, including `codeql.yml` which had no documentation at all.
- **docs/SCRIPTS.md**: corrected `nag-bot.js` (called "experimental" — it's the primary reliability net for missed pushes, scheduled every 5 minutes) and `enrich-bars.js`/`deduplicate.js` (vague "if they occur"/"likely run on a server" — both are real scheduled jobs with known cadences).
- **SECURITY.md**: replaced the unfilled template with actual content — the real security model and a real vulnerability-reporting path.
- **docs/plans/future-features.md**: marked Phases 2-4 shipped, replaced with what's genuinely still open (POS providers beyond Square/Toast, no billing flow, no iOS CI).
- **docs/plans/*.md**: added a status banner to each pointing at current docs, since both are historical design docs that could otherwise read as still-pending plans.
- **AGENTS.md**: documented the `src/hooks/` convention (established but never written down), the `functions/` testing convention (test the extracted pure logic, not the trigger wiring), and the rules-testing convention (one positive + one negative test per rules change).

Every cross-reference and relative link was checked against the actual file tree; every Cloud Function's trigger-type claim was checked against its actual `firebase-functions` import, not assumed from memory — this caught two real mistakes in an earlier draft (`posConnectToast`/`posDisconnect`/etc. are `onCall`, not `onRequest`; `rotateICalFeedToken` is `onCall`, not `onSchedule`), both now correct.

## Test plan

- [x] All markdown code fences balanced
- [x] Every cross-referenced doc link resolves to a file that exists
- [x] Every Cloud Function trigger-type claim verified against its `firebase-functions` import
- N/A — docs-only change, no code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Update the repository documentation to accurately reflect the shipped product, backend architecture, security model, operational workflows, and remaining roadmap.

Enhancements:
- Bring the repository documentation in line with the shipped application, covering current features, architecture, data model, components, hooks, scripts, security practices, and development conventions.
- Document the Cloud Functions backend, custom-claims authorization model, encrypted third-party credentials, notification workflows, and CI/CD pipeline.
- Update historical plans and future-feature tracking to distinguish shipped phases from remaining work.

Documentation:
- Replace the placeholder security policy with the application's actual security model and vulnerability-reporting guidance.
- Correct stale deployment and scheduled-script documentation, including workflow triggers and job cadences.
- Add local development instructions and links to contributor and security documentation.