### PR TITLE
CMP client: chat, 86'd list, roster, and notification settings

### DIFF
--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -26,15 +26,21 @@ import com.hereliesaz.barbacker.data.AppContainer
 import com.hereliesaz.barbacker.data.BarBackerFirebase
 import com.hereliesaz.barbacker.data.createKeyValueStore
 import com.hereliesaz.barbacker.data.loadFirebaseConfig
+import com.hereliesaz.barbacker.ui.ActiveDialog
+import com.hereliesaz.barbacker.ui.AppUiState
 import com.hereliesaz.barbacker.ui.AppViewModel
 import com.hereliesaz.barbacker.ui.Screen
 import com.hereliesaz.barbacker.ui.screens.ApprovalPendingScreen
 import com.hereliesaz.barbacker.ui.screens.BarSelectionScreen
+import com.hereliesaz.barbacker.ui.screens.ChatPanel
 import com.hereliesaz.barbacker.ui.screens.CheckingInviteScreen
 import com.hereliesaz.barbacker.ui.screens.DashboardActions
 import com.hereliesaz.barbacker.ui.screens.DashboardScreen
+import com.hereliesaz.barbacker.ui.screens.EightySixDialog
+import com.hereliesaz.barbacker.ui.screens.NotificationSettingsDialog
 import com.hereliesaz.barbacker.ui.screens.RestoringScreen
 import com.hereliesaz.barbacker.ui.screens.RoleSelectionScreen
+import com.hereliesaz.barbacker.ui.screens.RosterDialog
 import com.hereliesaz.barbacker.ui.screens.SignInScreen
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 import com.hereliesaz.barbacker.ui.theme.BarBackerTheme
@@ -71,6 +77,9 @@ private fun BarBackerApp(container: AppContainer) {
             bars = container.bars,
             memberships = container.memberships,
             requests = container.requests,
+            chat = container.chat,
+            eightySix = container.eightySix,
+            ownershipClaims = container.ownershipClaims,
             store = container.store,
         )
     }
@@ -137,15 +146,77 @@ private fun BarBackerApp(container: AppContainer) {
                             onUnclaim = viewModel::unclaimRequest,
                             onCancel = viewModel::cancelRequest,
                             onIgnore = viewModel::ignoreRequest,
-                            // The roster dialog is not built yet; approvals
-                            // are reachable from the badge once it lands.
-                            onOpenRoster = {},
+                            onOpenRoster = { viewModel.openDialog(ActiveDialog.Roster) },
+                            onOpenChat = { viewModel.openDialog(ActiveDialog.Chat) },
+                            onOpenEightySix = { viewModel.openDialog(ActiveDialog.EightySix) },
+                            onOpenNotificationSettings = {
+                                viewModel.openDialog(ActiveDialog.NotificationSettings)
+                            },
                             onSwitchBar = viewModel::backToBarSelection,
+                            onGoOffClock = viewModel::goOffClock,
                         ),
                     )
                 }
+
+                // Overlays live outside the screen `when` so they compose
+                // above whichever screen is showing. In practice only the
+                // dashboard opens them.
+                DashboardDialogs(state = state, viewModel = viewModel)
             }
         }
+    }
+}
+
+@Composable
+private fun DashboardDialogs(state: AppUiState, viewModel: AppViewModel) {
+    when (state.activeDialog) {
+        ActiveDialog.None -> Unit
+
+        ActiveDialog.Chat -> ChatPanel(
+            messages = state.fullChatHistory,
+            hasMore = state.chatHasMore,
+            loadingMore = state.chatLoadingMore,
+            currentUserId = state.currentUser?.uid.orEmpty(),
+            isManagerPlus = state.isManagerPlus,
+            onLoadMore = viewModel::loadOlderChat,
+            onSend = viewModel::sendChatMessage,
+            onTogglePin = viewModel::toggleChatPin,
+            onDelete = viewModel::deleteChatMessage,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.EightySix -> EightySixDialog(
+            entries = state.eightySixEntries,
+            isPremium = state.isPremium,
+            isManagerPlus = state.isManagerPlus,
+            onAdd = viewModel::addEightySixEntry,
+            onDelete = viewModel::deleteEightySixEntry,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.Roster -> RosterDialog(
+            clockedIn = state.clockedInMembers,
+            offClock = state.offClockMembers,
+            pending = state.pendingMembers,
+            ownershipClaims = state.pendingOwnershipClaims,
+            isManagerPlus = state.isManagerPlus,
+            onApproveMember = viewModel::approveMember,
+            onRejectMember = viewModel::rejectMember,
+            onReviewClaim = viewModel::reviewOwnershipClaim,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.NotificationSettings -> NotificationSettingsDialog(
+            // The job title, falling back to the privilege tier — this is
+            // the key the defaults are stored under.
+            roleLabel = state.membership?.jobTitle?.wire
+                ?: state.membership?.role?.wire.orEmpty(),
+            currentPreferences = state.notificationPreferences,
+            buttons = state.buttons,
+            ntfyTopic = null,
+            onSave = viewModel::saveNotificationPreferences,
+            onClose = viewModel::closeDialog,
+        )
     }
 }
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -13,7 +13,10 @@ import com.hereliesaz.barbacker.logic.visibleRequests
 import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.model.ChatMessage
+import com.hereliesaz.barbacker.model.EightySixEntry
 import com.hereliesaz.barbacker.model.MemberStatus
+import com.hereliesaz.barbacker.model.OwnershipClaim
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.model.SubscriptionTier
 
@@ -74,6 +77,34 @@ data class AppUiState(
 
     /** A transient message for the user; cleared once shown. */
     val message: String? = null,
+
+    // --- Feature surfaces layered over the dashboard. ---
+
+    /**
+     * Which overlay is open, if any.
+     *
+     * One value rather than a boolean per dialog. The web client carries
+     * fourteen independent flags, which makes "two dialogs open at once"
+     * representable and has produced exactly that bug; here it cannot
+     * happen.
+     */
+    val activeDialog: ActiveDialog = ActiveDialog.None,
+
+    /** Pinned messages driving the marquee. Live whenever a bar is selected. */
+    val pinnedMessages: List<ChatMessage> = emptyList(),
+
+    /** Scrollback, oldest first. Only populated while the chat panel is open. */
+    val chatMessages: List<ChatMessage> = emptyList(),
+
+    /** Pages loaded by "load earlier", oldest first, prepended to [chatMessages]. */
+    val olderChatMessages: List<ChatMessage> = emptyList(),
+    val chatHasMore: Boolean = true,
+    val chatLoadingMore: Boolean = false,
+    val latestMessageAt: Long = 0L,
+    val chatLastReadAt: Long = 0L,
+
+    val eightySixEntries: List<EightySixEntry> = emptyList(),
+    val pendingOwnershipClaims: List<OwnershipClaim> = emptyList(),
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 
@@ -166,7 +197,44 @@ data class AppUiState(
         if (parent == null) sorted + CUSTOM_REQUEST_BUTTON else sorted
     }
 
+    /** Scrollback with earlier pages prepended, oldest first. */
+    val fullChatHistory: List<ChatMessage> by lazy { olderChatMessages + chatMessages }
+
+    /**
+     * Whether to show the unread dot.
+     *
+     * Suppressed while the panel is open, since anything arriving then is
+     * already on screen.
+     */
+    val chatHasUnread: Boolean
+        get() = activeDialog != ActiveDialog.Chat && latestMessageAt > chatLastReadAt
+
+    /**
+     * Whether this member may see private 86'd entries.
+     *
+     * Drives the QUERY, not a display filter — a member without it never
+     * requests private entries, so the reason text never reaches them.
+     */
+    val canSeePrivateEightySix: Boolean get() = isPremium && isManagerPlus
+
+    val clockedInMembers: List<BarUser> by lazy {
+        roster.filter { it.status == MemberStatus.Active }
+    }
+
+    val offClockMembers: List<BarUser> by lazy {
+        roster.filter { it.status == MemberStatus.OffClock }
+    }
+
     companion object {
         const val MAIN_CONTEXT_ID = "main"
     }
+}
+
+/** The overlays reachable from the dashboard. */
+enum class ActiveDialog {
+    None,
+    Chat,
+    EightySix,
+    Roster,
+    NotificationSettings,
 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -9,12 +9,17 @@ import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.REQUEST_WINDOW_MILLIS
 import com.hereliesaz.barbacker.REQUEST_WINDOW_REFRESH_MILLIS
 import com.hereliesaz.barbacker.currentTimeMillis
+import com.hereliesaz.barbacker.data.AccountProfile
 import com.hereliesaz.barbacker.data.AuthRepository
 import com.hereliesaz.barbacker.data.AuthState
 import com.hereliesaz.barbacker.data.BarRepository
+import com.hereliesaz.barbacker.data.CHAT_PAGE_SIZE
+import com.hereliesaz.barbacker.data.ChatRepository
+import com.hereliesaz.barbacker.data.EightySixRepository
 import com.hereliesaz.barbacker.data.KeyValueStore
 import com.hereliesaz.barbacker.data.MembershipRepository
 import com.hereliesaz.barbacker.data.NewBar
+import com.hereliesaz.barbacker.data.OwnershipClaimRepository
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.logWarning
@@ -24,9 +29,14 @@ import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarRole
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.model.ChatMessage
+import com.hereliesaz.barbacker.model.EightySixEntry
+import com.hereliesaz.barbacker.model.EightySixVisibility
 import com.hereliesaz.barbacker.model.JoinPolicy
 import com.hereliesaz.barbacker.model.MemberStatus
+import com.hereliesaz.barbacker.model.OwnershipClaim
 import com.hereliesaz.barbacker.model.Request
+import com.hereliesaz.barbacker.model.SubscriptionTier
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -52,6 +62,9 @@ class AppViewModel(
     private val bars: BarRepository,
     private val memberships: MembershipRepository,
     private val requests: RequestRepository,
+    private val chat: ChatRepository,
+    private val eightySix: EightySixRepository,
+    private val ownershipClaims: OwnershipClaimRepository,
     private val store: KeyValueStore,
 ) : ViewModel() {
 
@@ -66,6 +79,11 @@ class AppViewModel(
         val authError: String? = null,
         val isRegistering: Boolean = false,
         val message: String? = null,
+        val activeDialog: ActiveDialog = ActiveDialog.None,
+        val olderChatMessages: List<ChatMessage> = emptyList(),
+        val chatHasMore: Boolean = true,
+        val chatLoadingMore: Boolean = false,
+        val chatLastReadAt: Long = 0L,
     )
 
     /** The four bar-scoped subscriptions, resolved together. */
@@ -105,14 +123,69 @@ class AppViewModel(
         BarScope(bar, membership, roster, requestList)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BarScope())
 
+    // Gating inputs for the feature subscriptions, pulled out so each
+    // subscription re-establishes only when its OWN gate changes, rather
+    // than on every unrelated state emission.
+    @Suppress("OPT_IN_USAGE")
+    private val chatPanelOpen = localState
+        .map { it.activeDialog == ActiveDialog.Chat }
+        .distinctUntilChanged()
+
+    private val isManagerPlusFlow = barScope
+        .map { it.membership?.role?.isManagerPlus == true }
+        .distinctUntilChanged()
+
+    private val canSeePrivateEightySixFlow = combine(barScope, localState) { scope, local ->
+        val premium = local.isAdmin || scope.bar?.subscription == SubscriptionTier.Premium
+        premium && scope.membership?.role?.isManagerPlus == true
+    }.distinctUntilChanged()
+
+    /** Chat's three independent subscriptions, resolved together. */
+    private data class ChatScope(
+        val pinned: List<ChatMessage> = emptyList(),
+        val latestAt: Long = 0L,
+        val scrollback: List<ChatMessage> = emptyList(),
+    )
+
+    /** Everything layered over the dashboard. */
+    private data class FeatureScope(
+        val chat: ChatScope = ChatScope(),
+        val eightySix: List<EightySixEntry> = emptyList(),
+        val claims: List<OwnershipClaim> = emptyList(),
+        val account: AccountProfile = AccountProfile(),
+    )
+
+    @Suppress("OPT_IN_USAGE")
+    private val featureScope: StateFlow<FeatureScope> = combine(
+        combine(
+            barIdFlow.flatMapLatest { chat.pinnedFlow(it) },
+            barIdFlow.flatMapLatest { chat.latestMessageAtFlow(it) },
+            combine(barIdFlow, chatPanelOpen) { barId, open -> barId to open }
+                .flatMapLatest { (barId, open) -> chat.scrollbackFlow(barId, open) },
+        ) { pinned, latestAt, scrollback -> ChatScope(pinned, latestAt, scrollback) },
+        combine(barIdFlow, canSeePrivateEightySixFlow) { barId, canSeePrivate ->
+            barId to canSeePrivate
+        }.flatMapLatest { (barId, canSeePrivate) ->
+            eightySix.entriesFlow(barId, canSeePrivate)
+        },
+        combine(barIdFlow, isManagerPlusFlow) { barId, isManagerPlus -> barId to isManagerPlus }
+            .flatMapLatest { (barId, isManagerPlus) ->
+                ownershipClaims.pendingClaimsFlow(barId, isManagerPlus)
+            },
+        uidFlow.flatMapLatest { memberships.accountFlow(it) },
+    ) { chatScope, entries, claims, account ->
+        FeatureScope(chatScope, entries, claims, account)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FeatureScope())
+
     @Suppress("OPT_IN_USAGE")
     val state: StateFlow<AppUiState> = combine(
         auth.state,
         barIdFlow,
         barScope,
-        uidFlow.flatMapLatest { memberships.accountFlow(it) },
+        featureScope,
         localState,
-    ) { authState, barId, scope, account, local ->
+    ) { authState, barId, scope, features, local ->
+        val account = features.account
         AppUiState(
             auth = authState,
             barId = barId,
@@ -130,6 +203,16 @@ class AppViewModel(
             authError = local.authError,
             isRegistering = local.isRegistering,
             message = local.message,
+            activeDialog = local.activeDialog,
+            pinnedMessages = features.chat.pinned,
+            chatMessages = features.chat.scrollback,
+            olderChatMessages = local.olderChatMessages,
+            chatHasMore = local.chatHasMore,
+            chatLoadingMore = local.chatLoadingMore,
+            latestMessageAt = features.chat.latestAt,
+            chatLastReadAt = local.chatLastReadAt,
+            eightySixEntries = features.eightySix,
+            pendingOwnershipClaims = features.claims,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -138,6 +221,38 @@ class AppViewModel(
         watchAuthForAdminClaim()
         watchForPendingInvite()
         watchForAutoClockIn()
+        watchBarIdForChatReset()
+    }
+
+    /**
+     * Resets chat pagination and reloads the read watermark on a bar
+     * change.
+     *
+     * The paged-in history is local state, so nothing else clears it —
+     * without this, switching bars would leave the previous bar's older
+     * messages spliced above the new bar's scrollback.
+     */
+    private fun watchBarIdForChatReset() {
+        viewModelScope.launch {
+            barIdFlow.collect { barId ->
+                val lastRead = barId
+                    ?.let { store.getString(KeyValueStore.chatLastReadKey(it)) }
+                    // A malformed stored value must not become NaN-like
+                    // garbage: a bad parse that produced a huge number
+                    // would suppress the unread dot permanently.
+                    ?.toLongOrNull()
+                    ?: 0L
+                localState.update {
+                    it.copy(
+                        olderChatMessages = emptyList(),
+                        chatHasMore = true,
+                        chatLoadingMore = false,
+                        chatLastReadAt = lastRead,
+                        activeDialog = ActiveDialog.None,
+                    )
+                }
+            }
+        }
     }
 
     // --- Auth ----------------------------------------------------------
@@ -445,6 +560,191 @@ class AppViewModel(
             runCatching { memberships.reject(barId, uid) }.onFailure {
                 logWarning("Could not reject member", it)
                 showMessage("Failed to reject. Please try again.")
+            }
+        }
+    }
+
+    // --- Dialogs --------------------------------------------------------
+
+    fun openDialog(dialog: ActiveDialog) {
+        if (dialog == ActiveDialog.Chat) {
+            // Stamp the read watermark on open, which is what clears the
+            // unread dot. Clock-based rather than server-based on purpose:
+            // it is a per-device convenience, and a device with a skewed
+            // clock should not be able to mark a bar's chat read for anyone
+            // else.
+            val now = currentTimeMillis()
+            barIdFlow.value?.let { barId ->
+                store.putString(KeyValueStore.chatLastReadKey(barId), now.toString())
+            }
+            localState.update { it.copy(activeDialog = dialog, chatLastReadAt = now) }
+        } else {
+            localState.update { it.copy(activeDialog = dialog) }
+        }
+    }
+
+    fun closeDialog() = localState.update { it.copy(activeDialog = ActiveDialog.None) }
+
+    // --- Chat -----------------------------------------------------------
+
+    /**
+     * Posts a message, reporting failure to the caller rather than
+     * swallowing it.
+     *
+     * The composer clears only on success. A rules rejection must leave the
+     * typed text where the user can retry it, not silently discard what
+     * they wrote.
+     */
+    suspend fun sendChatMessage(text: String, pin: Boolean): Result<Unit> {
+        val current = state.value
+        val user = current.currentUser ?: return Result.failure(IllegalStateException("Not signed in"))
+        val barId = current.barId ?: return Result.failure(IllegalStateException("No bar selected"))
+        return runCatching {
+            chat.send(
+                barId = barId,
+                text = text,
+                authorId = user.uid,
+                // Both must match the caller's own membership document —
+                // the create rule compares them and rejects anything else.
+                authorName = current.membership?.displayName.orEmpty(),
+                authorRole = current.membership?.role?.wire.orEmpty(),
+                pin = pin,
+            )
+        }.onFailure { logWarning("Could not send chat message", it) }
+    }
+
+    fun toggleChatPin(messageId: String, pin: Boolean) {
+        val uid = state.value.currentUser?.uid ?: return
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching { chat.setPinned(barId, messageId, pin, uid) }.onFailure {
+                logWarning("Could not change pin state", it)
+                showMessage("Failed to update the pin. Please try again.")
+            }
+        }
+    }
+
+    fun deleteChatMessage(messageId: String) {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching { chat.delete(barId, messageId) }.onFailure {
+                logWarning("Could not delete chat message", it)
+                showMessage("Failed to delete. Please try again.")
+            }
+        }
+    }
+
+    fun loadOlderChat() {
+        val current = state.value
+        val barId = current.barId ?: return
+        val local = localState.value
+        if (local.chatLoadingMore || !local.chatHasMore) return
+
+        val oldest = current.fullChatHistory.firstOrNull()?.timestamp ?: return
+        localState.update { it.copy(chatLoadingMore = true) }
+
+        viewModelScope.launch {
+            try {
+                val page = chat.loadOlder(barId, oldest)
+
+                // Re-check the bar AFTER the await. A bar switch mid-fetch
+                // would otherwise splice one bar's history into another's
+                // scrollback — a top-of-function guard cannot catch this.
+                if (barIdFlow.value != barId) return@launch
+
+                localState.update {
+                    it.copy(
+                        olderChatMessages = page + it.olderChatMessages,
+                        // A short page means we reached the beginning.
+                        chatHasMore = page.size >= CHAT_PAGE_SIZE,
+                        chatLoadingMore = false,
+                    )
+                }
+            } catch (e: Exception) {
+                logWarning("Could not load earlier messages", e)
+                localState.update { it.copy(chatLoadingMore = false) }
+                showMessage("Couldn't load earlier messages.")
+            }
+        }
+    }
+
+    // --- 86'd list ------------------------------------------------------
+
+    suspend fun addEightySixEntry(
+        patronName: String,
+        reason: String?,
+        visibility: EightySixVisibility,
+    ): Result<Unit> {
+        val current = state.value
+        val user = current.currentUser ?: return Result.failure(IllegalStateException("Not signed in"))
+        val barId = current.barId ?: return Result.failure(IllegalStateException("No bar selected"))
+        return runCatching {
+            eightySix.add(
+                barId = barId,
+                patronName = patronName,
+                submittedBy = user.uid,
+                submitterName = current.membership?.displayName.orEmpty(),
+                reason = reason,
+                visibility = visibility,
+            )
+        }.onFailure { logWarning("Could not add 86'd entry", it) }
+    }
+
+    fun deleteEightySixEntry(entryId: String) {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching { eightySix.delete(barId, entryId) }.onFailure {
+                logWarning("Could not delete 86'd entry", it)
+                showMessage("Failed to delete entry. Please try again.")
+            }
+        }
+    }
+
+    // --- Ownership claims -----------------------------------------------
+
+    fun fileOwnershipClaim() {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            try {
+                ownershipClaims.file(barId)
+                showMessage("Ownership claim filed. A manager or the current owner needs to approve it.")
+            } catch (e: Exception) {
+                logWarning("Could not file ownership claim", e)
+                showMessage(e.message ?: "Failed to file ownership claim.")
+            }
+        }
+    }
+
+    fun reviewOwnershipClaim(claimId: String, approve: Boolean) {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            try {
+                ownershipClaims.review(barId, claimId, approve)
+            } catch (e: Exception) {
+                logWarning("Could not review ownership claim", e)
+                showMessage(e.message ?: "Failed to review ownership claim.")
+            }
+        }
+    }
+
+    // --- Notification preferences ---------------------------------------
+
+    /**
+     * Persists the member's paging preferences.
+     *
+     * Written before any local state changes, so a sign-out or bar switch
+     * mid-write cannot leave the UI showing preferences that never landed.
+     * The live membership listener supplies the new values on success.
+     */
+    fun saveNotificationPreferences(preferences: List<String>) {
+        val uid = state.value.currentUser?.uid ?: return
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching {
+                memberships.saveNotificationPreferences(barId, uid, preferences)
+            }.onFailure {
+                logWarning("Could not save notification preferences", it)
+                showMessage("Failed to save preferences. Please try again.")
             }
         }
     }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarBackerDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarBackerDialog.kt
@@ -1,0 +1,78 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+
+/**
+ * The shared shell for this app's dialogs: a titled surface with a content
+ * area and a trailing action row.
+ *
+ * Material3's `AlertDialog` is not used for the larger ones because it
+ * constrains its content height in ways the chat and roster panels fight —
+ * both need to fill most of the screen and scroll internally.
+ *
+ * Note the lifecycle difference from the web client this mirrors: there,
+ * every dialog stays mounted while closed and only toggles an `open`
+ * attribute, so a half-typed form survives a close and reopen. Here the
+ * caller composes the dialog conditionally, so its local state resets.
+ * That is the better default — a reopened form starting clean is less
+ * surprising than one holding a stale draft — but it is a real behavioural
+ * difference, not an oversight.
+ */
+@Composable
+fun BarBackerDialog(
+    title: String,
+    onDismiss: () -> Unit,
+    // RowScope-scoped so an action row can use `Modifier.weight` to push
+    // trailing buttons apart — several dialogs need a left-aligned
+    // secondary action beside right-aligned confirm/cancel.
+    actions: @Composable RowScope.() -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            color = BarBackerColors.SurfaceContainer,
+            shape = MaterialTheme.shapes.large,
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(
+                    text = title,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = BarBackerColors.Primary,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
+
+                content()
+
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    actions()
+                }
+            }
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ChatPanel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ChatPanel.kt
@@ -1,0 +1,393 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.model.ChatMessage
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/**
+ * The bar's chat.
+ *
+ * Any member can post. Manager+ can pin — pinned messages drive the
+ * dashboard marquee — and delete anyone's message; everyone can delete
+ * their own. Message text is immutable, and there is deliberately no edit
+ * affordance: `firestore.rules` restricts updates to the pin fields, so an
+ * edit button could only ever fail.
+ */
+@Composable
+fun ChatPanel(
+    messages: List<ChatMessage>,
+    hasMore: Boolean,
+    loadingMore: Boolean,
+    currentUserId: String,
+    isManagerPlus: Boolean,
+    onLoadMore: () -> Unit,
+    onSend: suspend (text: String, pin: Boolean) -> Result<Unit>,
+    onTogglePin: (messageId: String, pin: Boolean) -> Unit,
+    onDelete: (messageId: String) -> Unit,
+    onClose: () -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    var pinNext by remember { mutableStateOf(false) }
+    var sending by remember { mutableStateOf(false) }
+    var sendError by remember { mutableStateOf<String?>(null) }
+    var confirmDeleteId by remember { mutableStateOf<String?>(null) }
+
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    // "Stuck to the bottom" means the last message is actually visible.
+    // Autoscrolling unconditionally would yank the view away from someone
+    // scrolled up reading history every time a message arrives.
+    val stuckToBottom by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            last == null || last.index >= listState.layoutInfo.totalItemsCount - 2
+        }
+    }
+
+    LaunchedEffect(messages.size) {
+        if (messages.isNotEmpty() && stuckToBottom) {
+            listState.animateScrollToItem(messages.lastIndex)
+        }
+    }
+
+    fun send() {
+        if (text.isBlank() || sending) return
+        sending = true
+        sendError = null
+        scope.launch {
+            onSend(text, pinNext)
+                .onSuccess {
+                    // Cleared only after the write lands. On a rejection
+                    // the typed text stays where the user can retry it.
+                    text = ""
+                    pinNext = false
+                    if (messages.isNotEmpty()) listState.animateScrollToItem(messages.lastIndex)
+                }
+                .onFailure { sendError = it.message ?: "Failed to send. Please try again." }
+            sending = false
+        }
+    }
+
+    BarBackerDialog(
+        title = "Chat",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().height(480.dp)) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (hasMore) {
+                    item(key = "load-more") {
+                        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            TextButton(onClick = onLoadMore, enabled = !loadingMore) {
+                                Text(if (loadingMore) "Loading…" else "Load earlier messages")
+                            }
+                        }
+                    }
+                }
+
+                if (messages.isEmpty()) {
+                    item(key = "empty") {
+                        Text(
+                            text = "No messages yet. Say hello.",
+                            color = BarBackerColors.OnSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth().padding(top = 32.dp),
+                        )
+                    }
+                }
+
+                items(messages, key = { it.id }) { message ->
+                    MessageBubble(
+                        message = message,
+                        isOwn = message.authorId == currentUserId,
+                        isManagerPlus = isManagerPlus,
+                        onTogglePin = { onTogglePin(message.id, !message.pinned) },
+                        onRequestDelete = { confirmDeleteId = message.id },
+                    )
+                }
+            }
+
+            sendError?.let {
+                Text(
+                    text = it,
+                    color = BarBackerColors.Error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+            }
+
+            HorizontalDivider(color = BarBackerColors.Outline)
+            Spacer(Modifier.height(8.dp))
+
+            Row(
+                verticalAlignment = Alignment.Bottom,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    label = { Text("Message") },
+                    modifier = Modifier.weight(1f),
+                    maxLines = 4,
+                )
+
+                if (isManagerPlus) {
+                    IconButton(onClick = { pinNext = !pinNext }) {
+                        Icon(
+                            Icons.Filled.PushPin,
+                            contentDescription = if (pinNext) {
+                                "Message will be pinned"
+                            } else {
+                                "Pin this message"
+                            },
+                            tint = if (pinNext) {
+                                BarBackerColors.Pinned
+                            } else {
+                                BarBackerColors.OnSurfaceVariant
+                            },
+                        )
+                    }
+                }
+
+                Button(onClick = ::send, enabled = !sending) {
+                    Text(if (sending) "Sending…" else "Send")
+                }
+            }
+        }
+    }
+
+    confirmDeleteId?.let { id ->
+        AlertDialog(
+            onDismissRequest = { confirmDeleteId = null },
+            title = { Text("Delete Message?") },
+            text = { Text("This can't be undone.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onDelete(id)
+                        confirmDeleteId = null
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BarBackerColors.Error,
+                        contentColor = BarBackerColors.OnError,
+                    ),
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteId = null }) { Text("Cancel") }
+            },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+@Composable
+private fun MessageBubble(
+    message: ChatMessage,
+    isOwn: Boolean,
+    isManagerPlus: Boolean,
+    onTogglePin: () -> Unit,
+    onRequestDelete: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = if (isOwn) Alignment.End else Alignment.Start,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = message.authorName.ifBlank { "Unknown" },
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Medium,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+            // Blank for messages migrated from the old notices collection,
+            // which never captured a role — so no chip rather than an empty one.
+            if (message.authorRole.isNotBlank()) {
+                Text(
+                    text = message.authorRole.uppercase(),
+                    fontSize = 10.sp,
+                    color = BarBackerColors.OnSurfaceVariant,
+                    modifier = Modifier
+                        .background(BarBackerColors.SecondaryContainer, RoundedCornerShape(4.dp))
+                        .padding(horizontal = 5.dp, vertical = 2.dp),
+                )
+            }
+            if (message.pinned) {
+                Icon(
+                    Icons.Filled.PushPin,
+                    contentDescription = "Pinned",
+                    tint = BarBackerColors.Pinned,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .widthIn(max = 320.dp)
+                .background(
+                    if (message.pinned) {
+                        BarBackerColors.Pinned.copy(alpha = 0.15f)
+                    } else {
+                        BarBackerColors.SecondaryContainer
+                    },
+                    RoundedCornerShape(8.dp),
+                )
+                .then(
+                    if (message.pinned) {
+                        Modifier.border(
+                            1.dp,
+                            BarBackerColors.Pinned.copy(alpha = 0.5f),
+                            RoundedCornerShape(8.dp),
+                        )
+                    } else {
+                        Modifier
+                    },
+                )
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            Text(text = message.text, color = BarBackerColors.OnSurface)
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            if (isManagerPlus) {
+                TextButton(onClick = onTogglePin) {
+                    Text(if (message.pinned) "Unpin" else "Pin", fontSize = 12.sp)
+                }
+            }
+            if (isOwn || isManagerPlus) {
+                TextButton(onClick = onRequestDelete) {
+                    Text("Delete", fontSize = 12.sp, color = BarBackerColors.Error)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The dashboard's scrolling banner of pinned messages.
+ *
+ * Rendered only when something is pinned; an empty strip would just eat
+ * vertical space on a screen that has none to spare.
+ */
+@Composable
+fun PinnedMarquee(pinned: List<ChatMessage>, onClick: () -> Unit) {
+    if (pinned.isEmpty()) return
+
+    val listState = rememberLazyListState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(32.dp)
+            .background(BarBackerColors.Pinned.copy(alpha = 0.12f))
+            .clickable(onClick = onClick),
+    ) {
+        // A horizontally scrollable row rather than a CSS-style infinite
+        // marquee: an animation that never stops is hard to read and
+        // impossible to catch up with, whereas this can be flicked through
+        // and still auto-advances below.
+        androidx.compose.foundation.lazy.LazyRow(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            items(pinned, key = { it.id }) { message ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                ) {
+                    Icon(
+                        Icons.Filled.PushPin,
+                        contentDescription = null,
+                        tint = BarBackerColors.Pinned,
+                        modifier = Modifier.size(12.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = message.text,
+                        color = BarBackerColors.Pinned,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = "(${message.authorName})",
+                        color = BarBackerColors.Pinned.copy(alpha = 0.7f),
+                        fontSize = 11.sp,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+
+    HorizontalDivider(color = BarBackerColors.Pinned.copy(alpha = 0.3f))
+
+    // Advance one message at a time so a bar with several pinned notices
+    // cycles through them without anyone having to touch the screen.
+    LaunchedEffect(pinned.size) {
+        if (pinned.size <= 1) return@LaunchedEffect
+        var index = 0
+        while (true) {
+            kotlinx.coroutines.delay(4000)
+            index = (index + 1) % pinned.size
+            listState.animateScrollToItem(index)
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
@@ -26,14 +26,23 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SyncAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,6 +53,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -71,14 +83,20 @@ data class DashboardActions(
     val onCancel: (String) -> Unit,
     val onIgnore: (String) -> Unit,
     val onOpenRoster: () -> Unit,
+    val onOpenChat: () -> Unit,
+    val onOpenEightySix: () -> Unit,
+    val onOpenNotificationSettings: () -> Unit,
     val onSwitchBar: () -> Unit,
+    val onGoOffClock: () -> Unit,
 )
 
 @Composable
 fun DashboardScreen(state: AppUiState, actions: DashboardActions) {
     Surface(color = BarBackerColors.Background, modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            DashboardTopBar(state = state, onSwitchBar = actions.onSwitchBar)
+            DashboardTopBar(state = state, actions = actions)
+
+            PinnedMarquee(pinned = state.pinnedMessages, onClick = actions.onOpenChat)
 
             Box(modifier = Modifier.weight(1f)) {
                 ButtonGrid(state = state, onButtonTapped = actions.onButtonTapped)
@@ -97,14 +115,15 @@ fun DashboardScreen(state: AppUiState, actions: DashboardActions) {
 }
 
 @Composable
-private fun DashboardTopBar(state: AppUiState, onSwitchBar: () -> Unit) {
+private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
+    var menuOpen by remember { mutableStateOf(false) }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(BarBackerColors.Surface)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -115,27 +134,101 @@ private fun DashboardTopBar(state: AppUiState, onSwitchBar: () -> Unit) {
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            // Job title, falling back to the privilege tier — the two are
-            // different axes and the title is the more useful label.
-            Text(
-                text = state.membership?.jobTitle?.wire
-                    ?: state.membership?.role?.wire.orEmpty(),
-                style = MaterialTheme.typography.bodySmall,
-                color = BarBackerColors.OnSurfaceVariant,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // Job title, falling back to the privilege tier — the two
+                // are different axes and the title is the more useful label.
+                Text(
+                    text = state.membership?.jobTitle?.wire
+                        ?: state.membership?.role?.wire.orEmpty(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+                Text(
+                    text = " · ${state.barName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
 
-        Text(
-            text = state.barName,
-            fontWeight = FontWeight.Bold,
-            fontSize = 18.sp,
-            color = BarBackerColors.Primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+        Box {
+            IconButton(onClick = actions.onOpenChat) {
+                Icon(
+                    Icons.Filled.Forum,
+                    contentDescription = "Chat",
+                    tint = BarBackerColors.OnSurface,
+                )
+            }
+            if (state.chatHasUnread) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(6.dp)
+                        .size(10.dp)
+                        .background(BarBackerColors.Error, CircleShape),
+                )
+            }
+        }
 
-        TextButton(onClick = onSwitchBar) { Text("Switch") }
+        Box {
+            IconButton(onClick = { menuOpen = true }) {
+                Icon(
+                    Icons.Filled.MoreVert,
+                    contentDescription = "Menu",
+                    tint = BarBackerColors.OnSurface,
+                )
+            }
+            DropdownMenu(
+                expanded = menuOpen,
+                onDismissRequest = { menuOpen = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Who's On") },
+                    leadingIcon = { Icon(Icons.Filled.Group, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        actions.onOpenRoster()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("86'd List") },
+                    leadingIcon = { Icon(Icons.Filled.Block, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        actions.onOpenEightySix()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Pagers") },
+                    leadingIcon = { Icon(Icons.Filled.Settings, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        actions.onOpenNotificationSettings()
+                    },
+                )
+                HorizontalDivider(color = BarBackerColors.Outline)
+                DropdownMenuItem(
+                    text = { Text("Switch Bar") },
+                    leadingIcon = { Icon(Icons.Filled.SyncAlt, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        actions.onSwitchBar()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Clock Out") },
+                    leadingIcon = {
+                        Icon(Icons.Filled.PowerSettingsNew, contentDescription = null)
+                    },
+                    onClick = {
+                        menuOpen = false
+                        actions.onGoOffClock()
+                    },
+                )
+            }
+        }
     }
     HorizontalDivider(color = BarBackerColors.Outline)
 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/EightySixDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/EightySixDialog.kt
@@ -1,0 +1,317 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.model.EightySixEntry
+import com.hereliesaz.barbacker.model.EightySixVisibility
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/**
+ * The bar's barred-patron list.
+ *
+ * Every member with a role sees public entries. Manager+ can add and
+ * remove. Premium bars can additionally mark an entry private with a
+ * reason — and a non-qualifying reader never fetches those at all, so the
+ * reason text does not reach their device in the first place.
+ */
+@Composable
+fun EightySixDialog(
+    entries: List<EightySixEntry>,
+    isPremium: Boolean,
+    isManagerPlus: Boolean,
+    onAdd: suspend (patronName: String, reason: String?, visibility: EightySixVisibility) -> Result<Unit>,
+    onDelete: (entryId: String) -> Unit,
+    onClose: () -> Unit,
+) {
+    var showAddForm by remember { mutableStateOf(false) }
+    var patronName by remember { mutableStateOf("") }
+    var reason by remember { mutableStateOf("") }
+    var isPrivate by remember { mutableStateOf(false) }
+    var submitting by remember { mutableStateOf(false) }
+    var confirmDeleteId by remember { mutableStateOf<String?>(null) }
+    var addError by remember { mutableStateOf<String?>(null) }
+
+    val scope = rememberCoroutineScope()
+
+    fun resetForm() {
+        showAddForm = false
+        patronName = ""
+        reason = ""
+        isPrivate = false
+        addError = null
+    }
+
+    BarBackerDialog(
+        title = "86'd List (${entries.size})",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (!isPremium) {
+                Text(
+                    text = "Upgrade to Premium to add private notes and reasons.",
+                    color = BarBackerColors.Pinned,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            BarBackerColors.Pinned.copy(alpha = 0.12f),
+                            RoundedCornerShape(4.dp),
+                        )
+                        .padding(8.dp),
+                )
+            }
+
+            if (isManagerPlus && !showAddForm) {
+                FilledTonalButton(
+                    onClick = { showAddForm = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Filled.PersonAdd, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("Add Person")
+                }
+            }
+
+            if (isManagerPlus && showAddForm) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    OutlinedTextField(
+                        value = patronName,
+                        onValueChange = { patronName = it },
+                        label = { Text("Patron Name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+
+                    if (isPremium) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Switch(checked = isPrivate, onCheckedChange = { isPrivate = it })
+                            Text(
+                                text = "Private entry (hidden from non-managers)",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = BarBackerColors.OnSurface,
+                            )
+                        }
+
+                        // Only offered on a private entry: a reason on a
+                        // public one would be readable by every member, so
+                        // it is discarded rather than stored.
+                        if (isPrivate) {
+                            OutlinedTextField(
+                                value = reason,
+                                onValueChange = { reason = it },
+                                label = { Text("Reason (private)") },
+                                minLines = 2,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+
+                    addError?.let {
+                        Text(
+                            text = it,
+                            color = BarBackerColors.Error,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(onClick = ::resetForm) { Text("Cancel") }
+                        Spacer(Modifier.size(8.dp))
+                        Button(
+                            onClick = {
+                                if (patronName.isBlank() || submitting) return@Button
+                                submitting = true
+                                addError = null
+                                scope.launch {
+                                    onAdd(
+                                        patronName.trim(),
+                                        reason.trim().takeIf { it.isNotEmpty() },
+                                        if (isPrivate) {
+                                            EightySixVisibility.Private
+                                        } else {
+                                            EightySixVisibility.Public
+                                        },
+                                    )
+                                        .onSuccess { resetForm() }
+                                        .onFailure {
+                                            addError = "Failed to add entry. Please try again."
+                                        }
+                                    submitting = false
+                                }
+                            },
+                            enabled = patronName.isNotBlank() && !submitting,
+                        ) {
+                            Text(if (submitting) "Adding..." else "Add")
+                        }
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp)
+                    .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp)),
+            ) {
+                if (entries.isEmpty()) {
+                    Text(
+                        text = "No one on the 86'd list.",
+                        color = BarBackerColors.OnSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    )
+                } else {
+                    LazyColumn {
+                        items(entries, key = { it.id }) { entry ->
+                            EightySixRow(
+                                entry = entry,
+                                canDelete = isManagerPlus,
+                                onRequestDelete = { confirmDeleteId = entry.id },
+                            )
+                            HorizontalDivider(color = BarBackerColors.Outline)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    confirmDeleteId?.let { id ->
+        AlertDialog(
+            onDismissRequest = { confirmDeleteId = null },
+            title = { Text("Remove from 86'd List?") },
+            text = { Text("Are you sure you want to remove this person from the 86'd list?") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onDelete(id)
+                        confirmDeleteId = null
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BarBackerColors.Error,
+                        contentColor = BarBackerColors.OnError,
+                    ),
+                ) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteId = null }) { Text("Cancel") }
+            },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+@Composable
+private fun EightySixRow(
+    entry: EightySixEntry,
+    canDelete: Boolean,
+    onRequestDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // The lock icon and the reason line below are the only
+                // visual markers separating a private entry from a public one.
+                if (entry.visibility == EightySixVisibility.Private) {
+                    Icon(
+                        Icons.Filled.Lock,
+                        contentDescription = "Private entry",
+                        tint = BarBackerColors.Pinned,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.size(6.dp))
+                }
+                Text(
+                    text = entry.patronName,
+                    fontWeight = FontWeight.Medium,
+                    color = BarBackerColors.OnSurface,
+                )
+            }
+            Text(
+                text = "Submitted by ${entry.submitterName}",
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+            val reasonText = entry.reason
+            if (entry.visibility == EightySixVisibility.Private && !reasonText.isNullOrBlank()) {
+                Text(
+                    text = reasonText,
+                    fontSize = 12.sp,
+                    fontStyle = FontStyle.Italic,
+                    color = BarBackerColors.Pinned.copy(alpha = 0.8f),
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+        }
+
+        if (canDelete) {
+            IconButton(onClick = onRequestDelete) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = "Remove ${entry.patronName} from 86'd list",
+                    tint = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/NotificationSettingsDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/NotificationSettingsDialog.kt
@@ -1,0 +1,146 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
+import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.ui.iconForName
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+
+/**
+ * Which requests page this member, on this bar.
+ *
+ * @param roleLabel the member's job title, falling back to their privilege
+ *   tier. It is both what the intro line shows and the key "Reset to
+ *   Default" looks up — the defaults are keyed by job function, not by
+ *   privilege, because what you get paged for depends on what you do.
+ * @param buttons the bar's TOP-LEVEL buttons only. Sub-menu children are
+ *   not individually subscribable; a page for "GARNISH: LIMES" is routed
+ *   by its parent.
+ */
+@Composable
+fun NotificationSettingsDialog(
+    roleLabel: String,
+    currentPreferences: List<String>,
+    buttons: List<ButtonConfig>,
+    ntfyTopic: String?,
+    onSave: (List<String>) -> Unit,
+    onClose: () -> Unit,
+) {
+    // Seeded once per open. Every toggle is local until Save, so Cancel
+    // genuinely discards rather than leaving half-applied changes.
+    var preferences by remember { mutableStateOf(currentPreferences.toSet()) }
+
+    BarBackerDialog(
+        title = "Notification Settings",
+        onDismiss = onClose,
+        actions = {
+            TextButton(
+                onClick = {
+                    preferences = NOTIFICATION_DEFAULTS_BY_TITLE[roleLabel].orEmpty().toSet()
+                },
+            ) { Text("Reset to Default") }
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = onClose) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(
+                onClick = {
+                    onSave(preferences.toList())
+                    onClose()
+                },
+            ) { Text("Save") }
+        },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = if (roleLabel.isBlank()) {
+                    "Enable or disable notifications for yourself."
+                } else {
+                    "Enable or disable notifications for your role ($roleLabel)."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+
+            if (ntfyTopic != null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "iOS Alerts (ntfy)",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = BarBackerColors.OnSurface,
+                    )
+                    // Shown so it can be copied into the ntfy app by hand.
+                    // Subscribing via the ntfy:// deep link is not wired up
+                    // on this client yet.
+                    Text(
+                        text = ntfyTopic,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BarBackerColors.OnSurfaceVariant,
+                    )
+                }
+            }
+
+            LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 360.dp)) {
+                items(buttons, key = { it.id }) { button ->
+                    val enabled = button.id in preferences
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = iconForName(button.icon),
+                            contentDescription = null,
+                            tint = BarBackerColors.OnSurfaceVariant,
+                        )
+                        Spacer(Modifier.size(12.dp))
+                        Text(
+                            text = button.label,
+                            color = BarBackerColors.OnSurface,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Switch(
+                            checked = enabled,
+                            onCheckedChange = { checked ->
+                                preferences = if (checked) {
+                                    preferences + button.id
+                                } else {
+                                    preferences - button.id
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/RosterDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/RosterDialog.kt
@@ -1,0 +1,233 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.model.BarUser
+import com.hereliesaz.barbacker.model.OwnershipClaim
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+
+/**
+ * Who is on shift, plus — for Manager+ — the two review queues.
+ *
+ * The review sections and the "Clocked In" list behave differently when
+ * empty on purpose: an empty floor is worth stating, whereas an empty
+ * approval queue is just noise, so those sections vanish entirely.
+ */
+@Composable
+fun RosterDialog(
+    clockedIn: List<BarUser>,
+    offClock: List<BarUser>,
+    pending: List<BarUser>,
+    ownershipClaims: List<OwnershipClaim>,
+    isManagerPlus: Boolean,
+    onApproveMember: (String) -> Unit,
+    onRejectMember: (String) -> Unit,
+    onReviewClaim: (claimId: String, approve: Boolean) -> Unit,
+    onClose: () -> Unit,
+) {
+    BarBackerDialog(
+        title = "Who's On",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 460.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            if (isManagerPlus && pending.isNotEmpty()) {
+                RosterSection(
+                    title = "WAITING FOR APPROVAL (${pending.size})",
+                    titleColor = BarBackerColors.Pinned,
+                    borderColor = BarBackerColors.Pinned.copy(alpha = 0.5f),
+                ) {
+                    pending.forEachIndexed { index, member ->
+                        if (index > 0) HorizontalDivider(color = BarBackerColors.Outline)
+                        MemberRow(
+                            icon = Icons.Filled.HourglassEmpty,
+                            iconTint = BarBackerColors.Pinned,
+                            name = member.displayName ?: "Unknown",
+                            subtitle = member.jobTitle?.wire ?: member.role?.wire.orEmpty(),
+                        ) {
+                            // No confirmation on either action: both are
+                            // reversible — a rejected member can request
+                            // again, and an approved one can be removed.
+                            OutlinedButton(onClick = { onRejectMember(member.id) }) {
+                                Text("Reject")
+                            }
+                            Spacer(Modifier.size(8.dp))
+                            Button(onClick = { onApproveMember(member.id) }) { Text("Approve") }
+                        }
+                    }
+                }
+            }
+
+            if (isManagerPlus && ownershipClaims.isNotEmpty()) {
+                RosterSection(
+                    title = "OWNERSHIP CLAIMS (${ownershipClaims.size})",
+                    titleColor = Color(0xFF60A5FA),
+                    borderColor = Color(0xFF1E3A8A),
+                ) {
+                    ownershipClaims.forEachIndexed { index, claim ->
+                        if (index > 0) HorizontalDivider(color = BarBackerColors.Outline)
+                        MemberRow(
+                            icon = Icons.Filled.Verified,
+                            iconTint = Color(0xFF60A5FA),
+                            name = claim.claimantName.ifBlank { "Unknown" },
+                            subtitle = claim.justification.orEmpty(),
+                        ) {
+                            OutlinedButton(onClick = { onReviewClaim(claim.id, false) }) {
+                                Text("Reject")
+                            }
+                            Spacer(Modifier.size(8.dp))
+                            Button(onClick = { onReviewClaim(claim.id, true) }) { Text("Approve") }
+                        }
+                    }
+                }
+            }
+
+            RosterSection(
+                title = "CLOCKED IN (${clockedIn.size})",
+                titleColor = Color(0xFF4ADE80),
+                borderColor = BarBackerColors.Outline,
+            ) {
+                if (clockedIn.isEmpty()) {
+                    Text(
+                        text = "No one is clocked in.",
+                        color = BarBackerColors.OnSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    )
+                } else {
+                    clockedIn.forEachIndexed { index, member ->
+                        if (index > 0) HorizontalDivider(color = BarBackerColors.Outline)
+                        MemberRow(
+                            icon = Icons.Filled.Circle,
+                            iconTint = Color(0xFF22C55E),
+                            name = member.displayName ?: "Unknown",
+                            subtitle = member.jobTitle?.wire ?: member.role?.wire.orEmpty(),
+                        )
+                    }
+                }
+            }
+
+            if (offClock.isNotEmpty()) {
+                RosterSection(
+                    title = "OFF CLOCK (${offClock.size})",
+                    titleColor = BarBackerColors.OnSurfaceVariant,
+                    borderColor = BarBackerColors.Outline,
+                ) {
+                    offClock.forEachIndexed { index, member ->
+                        if (index > 0) HorizontalDivider(color = BarBackerColors.Outline)
+                        MemberRow(
+                            icon = Icons.Filled.RadioButtonUnchecked,
+                            iconTint = BarBackerColors.OnSurfaceVariant,
+                            name = member.displayName ?: "Unknown",
+                            subtitle = member.jobTitle?.wire ?: member.role?.wire.orEmpty(),
+                            dimmed = true,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RosterSection(
+    title: String,
+    titleColor: Color,
+    borderColor: Color,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = titleColor,
+            letterSpacing = 1.sp,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(1.dp, borderColor, RoundedCornerShape(8.dp)),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun MemberRow(
+    icon: ImageVector,
+    iconTint: Color,
+    name: String,
+    subtitle: String,
+    dimmed: Boolean = false,
+    trailing: @Composable (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(12.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = name,
+                color = if (dimmed) BarBackerColors.OnSurfaceVariant else BarBackerColors.OnSurface,
+                fontWeight = FontWeight.Medium,
+            )
+            if (subtitle.isNotBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+        }
+        trailing?.let {
+            Row(verticalAlignment = Alignment.CenterVertically) { it() }
+        }
+    }
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -16,4 +16,8 @@ class AppContainer(
     val bars: BarRepository = FirebaseBarRepository(firebase.firestore)
     val memberships: MembershipRepository = FirebaseMembershipRepository(firebase.firestore)
     val requests: RequestRepository = FirebaseRequestRepository(firebase.firestore)
+    val chat: ChatRepository = FirebaseChatRepository(firebase.firestore)
+    val eightySix: EightySixRepository = FirebaseEightySixRepository(firebase.firestore)
+    val ownershipClaims: OwnershipClaimRepository =
+        FirebaseOwnershipClaimRepository(firebase.firestore, firebase.functions)
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
@@ -7,6 +7,8 @@ import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.auth.auth
 import dev.gitlive.firebase.firestore.FirebaseFirestore
 import dev.gitlive.firebase.firestore.firestore
+import dev.gitlive.firebase.functions.FirebaseFunctions
+import dev.gitlive.firebase.functions.functions
 import dev.gitlive.firebase.initialize
 
 /**
@@ -49,6 +51,7 @@ class BarBackerFirebase private constructor(
     val app: FirebaseApp,
     val auth: FirebaseAuth,
     val firestore: FirebaseFirestore,
+    val functions: FirebaseFunctions,
 ) {
     companion object {
         /**
@@ -64,6 +67,10 @@ class BarBackerFirebase private constructor(
                 app = app,
                 auth = Firebase.auth(app),
                 firestore = Firebase.firestore(app),
+                // Default region (us-central1), matching where the web
+                // client's getFunctions(app) points and where the
+                // callables are actually deployed.
+                functions = Firebase.functions(app),
             )
         }
     }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/ChatRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/ChatRepository.kt
@@ -1,0 +1,216 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.model.ChatMessage
+import dev.gitlive.firebase.firestore.Direction
+import dev.gitlive.firebase.firestore.FieldValue
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.Timestamp
+import dev.gitlive.firebase.firestore.fromMilliseconds
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+
+/** How many messages one scrollback page holds. */
+const val CHAT_PAGE_SIZE: Int = 50
+
+/** Cap on pinned messages fed to the dashboard marquee. */
+const val CHAT_PINNED_LIMIT: Int = 50
+
+interface ChatRepository {
+    /**
+     * Pinned messages, newest pin first — the dashboard marquee's source.
+     *
+     * Live whenever a bar is selected, not only while the chat panel is
+     * open, because the marquee is on the dashboard.
+     */
+    fun pinnedFlow(barId: String?): Flow<List<ChatMessage>>
+
+    /**
+     * Timestamp of the most recent message, for the unread dot. Zero when
+     * there are none.
+     *
+     * A one-document query rather than reusing the scrollback listener, so
+     * the unread badge costs one document instead of fifty while the panel
+     * is closed.
+     */
+    fun latestMessageAtFlow(barId: String?): Flow<Long>
+
+    /**
+     * The most recent page of messages, oldest first.
+     *
+     * Only subscribe while the panel is actually open — [enabled] exists
+     * so the caller does not pay for fifty live documents all shift.
+     */
+    fun scrollbackFlow(barId: String?, enabled: Boolean): Flow<List<ChatMessage>>
+
+    /**
+     * One page older than [beforeMillis], oldest first.
+     *
+     * Pages by timestamp rather than a document cursor, matching the web
+     * client. The tradeoff is real: messages sharing an exact boundary
+     * timestamp can be skipped. It is preserved rather than "fixed"
+     * because both clients must page identically, and server timestamps
+     * colliding to the millisecond is vanishingly rare here.
+     */
+    suspend fun loadOlder(barId: String, beforeMillis: Long): List<ChatMessage>
+
+    /**
+     * Posts a message.
+     *
+     * [authorName] and [authorRole] must be the caller's own values from
+     * their membership document — `firestore.rules` compares them against
+     * it and rejects anything else, so they cannot be spoofed.
+     */
+    suspend fun send(
+        barId: String,
+        text: String,
+        authorId: String,
+        authorName: String,
+        authorRole: String,
+        pin: Boolean,
+    )
+
+    suspend fun setPinned(barId: String, messageId: String, pinned: Boolean, uid: String)
+
+    suspend fun delete(barId: String, messageId: String)
+}
+
+class FirebaseChatRepository(private val firestore: FirebaseFirestore) : ChatRepository {
+
+    @Serializable
+    private data class MessageWrite(
+        val text: String,
+        val authorId: String,
+        val authorName: String,
+        val authorRole: String,
+        val timestamp: Timestamp.ServerTimestamp,
+        val pinned: Boolean,
+        val pinnedBy: String? = null,
+        val pinnedAt: Timestamp.ServerTimestamp? = null,
+    )
+
+    override fun pinnedFlow(barId: String?): Flow<List<ChatMessage>> = flow {
+        emit(emptyList())
+        if (barId == null) return@flow
+        emitAll(
+            firestore.collection(Paths.barChat(barId))
+                .where { Fields.PINNED equalTo true }
+                .orderBy(Fields.PINNED_AT, Direction.DESCENDING)
+                .limit(CHAT_PINNED_LIMIT)
+                .snapshots
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toChatMessage() } },
+        )
+    }.catch { e ->
+        logWarning("Pinned chat listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override fun latestMessageAtFlow(barId: String?): Flow<Long> = flow {
+        emit(0L)
+        if (barId == null) return@flow
+        emitAll(
+            firestore.collection(Paths.barChat(barId))
+                .orderBy(Fields.TIMESTAMP, Direction.DESCENDING)
+                .limit(1)
+                .snapshots
+                .map { snapshot ->
+                    snapshot.documents.firstOrNull()?.timestampMillis(Fields.TIMESTAMP) ?: 0L
+                },
+        )
+    }.catch { e ->
+        logWarning("Latest-message listener failed for $barId", e)
+        emit(0L)
+    }
+
+    override fun scrollbackFlow(barId: String?, enabled: Boolean): Flow<List<ChatMessage>> = flow {
+        emit(emptyList())
+        if (barId == null || !enabled) return@flow
+        emitAll(
+            firestore.collection(Paths.barChat(barId))
+                .orderBy(Fields.TIMESTAMP, Direction.DESCENDING)
+                .limit(CHAT_PAGE_SIZE)
+                .snapshots
+                // Queried newest-first so the limit takes the most recent
+                // page, then reversed for display.
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toChatMessage() }.reversed() },
+        )
+    }.catch { e ->
+        logWarning("Chat scrollback listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override suspend fun loadOlder(barId: String, beforeMillis: Long): List<ChatMessage> =
+        firestore.collection(Paths.barChat(barId))
+            .where { Fields.TIMESTAMP lessThan Timestamp.fromMilliseconds(beforeMillis.toDouble()) }
+            .orderBy(Fields.TIMESTAMP, Direction.DESCENDING)
+            .limit(CHAT_PAGE_SIZE)
+            .get()
+            .documents
+            .mapNotNull { it.toChatMessage() }
+            .reversed()
+
+    override suspend fun send(
+        barId: String,
+        text: String,
+        authorId: String,
+        authorName: String,
+        authorRole: String,
+        pin: Boolean,
+    ) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        firestore.collection(Paths.barChat(barId)).add(
+            MessageWrite(
+                text = trimmed,
+                authorId = authorId,
+                authorName = authorName,
+                authorRole = authorRole,
+                timestamp = Timestamp.ServerTimestamp,
+                pinned = pin,
+                // Written atomically with the message when the composer's
+                // pin toggle is armed, so a pinned send never briefly
+                // appears unpinned in the marquee.
+                pinnedBy = if (pin) authorId else null,
+                pinnedAt = if (pin) Timestamp.ServerTimestamp else null,
+            ),
+        ) {
+            // Omits the pin fields entirely on an unpinned message; the
+            // create rule's field allowlist tolerates their absence but not
+            // a null value.
+            encodeDefaults = false
+        }
+    }
+
+    override suspend fun setPinned(
+        barId: String,
+        messageId: String,
+        pinned: Boolean,
+        uid: String,
+    ) {
+        val ref = firestore.document("${Paths.barChat(barId)}/$messageId")
+        if (pinned) {
+            ref.updateFields {
+                Fields.PINNED to true
+                "pinnedBy" to uid
+                Fields.PINNED_AT to Timestamp.ServerTimestamp
+            }
+        } else {
+            ref.updateFields {
+                Fields.PINNED to false
+                // Removed rather than nulled: the marquee query orders by
+                // pinnedAt, and a lingering value would keep sorting a
+                // message that is no longer pinned.
+                "pinnedBy" to FieldValue.delete
+                Fields.PINNED_AT to FieldValue.delete
+            }
+        }
+    }
+
+    override suspend fun delete(barId: String, messageId: String) {
+        firestore.document("${Paths.barChat(barId)}/$messageId").delete()
+    }
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/EightySixRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/EightySixRepository.kt
@@ -1,0 +1,116 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.EIGHTY_SIX_QUERY_LIMIT
+import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.model.EightySixEntry
+import com.hereliesaz.barbacker.model.EightySixVisibility
+import dev.gitlive.firebase.firestore.Direction
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.Timestamp
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+
+interface EightySixRepository {
+    /**
+     * The bar's barred-patron list, newest first.
+     *
+     * [canSeePrivate] changes the QUERY, not a client-side filter. A reader
+     * without the privilege never requests private entries at all, so the
+     * reason text never reaches their device — and the query does not fail
+     * against a rule it could not satisfy.
+     */
+    fun entriesFlow(barId: String?, canSeePrivate: Boolean): Flow<List<EightySixEntry>>
+
+    /**
+     * @param submitterName must be the caller's own per-bar display name;
+     *   `firestore.rules` compares it against their membership document.
+     * @param reason only meaningful on a private entry. A reason typed
+     *   against a public entry is discarded rather than stored, since a
+     *   public entry's reason would be readable by every member.
+     */
+    suspend fun add(
+        barId: String,
+        patronName: String,
+        submittedBy: String,
+        submitterName: String,
+        reason: String?,
+        visibility: EightySixVisibility,
+    )
+
+    suspend fun delete(barId: String, entryId: String)
+}
+
+class FirebaseEightySixRepository(
+    private val firestore: FirebaseFirestore,
+) : EightySixRepository {
+
+    @Serializable
+    private data class EntryWrite(
+        val patronName: String,
+        val submittedBy: String,
+        val submitterName: String,
+        val visibility: String,
+        val timestamp: Timestamp.ServerTimestamp,
+        val reason: String? = null,
+    )
+
+    override fun entriesFlow(
+        barId: String?,
+        canSeePrivate: Boolean,
+    ): Flow<List<EightySixEntry>> = flow {
+        emit(emptyList())
+        if (barId == null) return@flow
+
+        val collection = firestore.collection(Paths.barEightySixed(barId))
+        val query = if (canSeePrivate) {
+            collection
+        } else {
+            collection.where { Fields.VISIBILITY equalTo EightySixVisibility.Public.wire }
+        }
+
+        emitAll(
+            query
+                .orderBy(Fields.TIMESTAMP, Direction.DESCENDING)
+                .limit(EIGHTY_SIX_QUERY_LIMIT)
+                .snapshots
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toEightySixEntry() } },
+        )
+    }.catch { e ->
+        logWarning("86'd list listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override suspend fun add(
+        barId: String,
+        patronName: String,
+        submittedBy: String,
+        submitterName: String,
+        reason: String?,
+        visibility: EightySixVisibility,
+    ) {
+        val trimmed = patronName.trim()
+        if (trimmed.isEmpty()) return
+        firestore.collection(Paths.barEightySixed(barId)).add(
+            EntryWrite(
+                patronName = trimmed,
+                submittedBy = submittedBy,
+                submitterName = submitterName,
+                visibility = visibility.wire,
+                timestamp = Timestamp.ServerTimestamp,
+                reason = reason?.trim()?.takeIf {
+                    it.isNotEmpty() && visibility == EightySixVisibility.Private
+                },
+            ),
+        ) {
+            encodeDefaults = false
+        }
+    }
+
+    override suspend fun delete(barId: String, entryId: String) {
+        firestore.document("${Paths.barEightySixed(barId)}/$entryId").delete()
+    }
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/OwnershipClaimRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/OwnershipClaimRepository.kt
@@ -1,0 +1,78 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.model.ClaimStatus
+import com.hereliesaz.barbacker.model.OwnershipClaim
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+
+/**
+ * Ownership claims — someone asking to take over a bar, typically the real
+ * owner reclaiming an entry a bartender created ad hoc for one shift.
+ *
+ * Reads come from Firestore; every WRITE goes through a Cloud Function.
+ * `firestore.rules` denies client writes to this collection outright,
+ * because approving a claim reassigns `ownerId` and no client can be
+ * trusted with that.
+ */
+interface OwnershipClaimRepository {
+    /**
+     * Claims awaiting review. Empty unless [isManagerPlus] — Staff cannot
+     * read the collection, so subscribing would only produce a denial.
+     */
+    fun pendingClaimsFlow(barId: String?, isManagerPlus: Boolean): Flow<List<OwnershipClaim>>
+
+    /** Files a claim on behalf of the signed-in user. */
+    suspend fun file(barId: String)
+
+    /** Approves or rejects a claim. Manager+ or the current owner only. */
+    suspend fun review(barId: String, claimId: String, approve: Boolean)
+}
+
+class FirebaseOwnershipClaimRepository(
+    private val firestore: FirebaseFirestore,
+    private val functions: FirebaseFunctions,
+) : OwnershipClaimRepository {
+
+    @Serializable
+    private data class FileRequest(val barId: String)
+
+    @Serializable
+    private data class ReviewRequest(
+        val barId: String,
+        val claimId: String,
+        val approve: Boolean,
+    )
+
+    override fun pendingClaimsFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<List<OwnershipClaim>> = flow {
+        emit(emptyList())
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.collection(Paths.barOwnershipClaims(barId))
+                .where { Fields.STATUS equalTo ClaimStatus.Pending.wire }
+                .snapshots
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toOwnershipClaim(barId) } },
+        )
+    }.catch { e ->
+        logWarning("Ownership-claim listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override suspend fun file(barId: String) {
+        functions.httpsCallable("fileOwnershipClaim").invoke(FileRequest(barId))
+    }
+
+    override suspend fun review(barId: String, claimId: String, approve: Boolean) {
+        functions.httpsCallable("reviewOwnershipClaim")
+            .invoke(ReviewRequest(barId, claimId, approve))
+    }
+}

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -204,7 +204,13 @@ Working end to end:
 - The join flow, including invite consumption and approval-pending
 - The dashboard: request grid, sub-menu drill-down with synthesised
   children, sending pages, and claim / cancel / mute
-- Realtime updates for the bar config, membership, roster, and requests
+- Chat, with pinning, deletion, paged scrollback, the dashboard marquee,
+  and an unread badge
+- The 86'd list, including premium private entries
+- The roster, with the Manager+ approval and ownership-claim queues
+- Per-member notification preferences
+- Realtime updates for bar config, membership, roster, requests, chat,
+  the 86'd list, and ownership claims
 - Premium bar theming, with a readability check on the branded label
   colour
 
@@ -213,12 +219,14 @@ Not built yet — the PWA remains the complete client:
 - **OpenStreetMap bar search.** Needs an HTTP client this module does not
   carry yet. Joining a bar you are not already a member of currently
   happens through an invite link.
-- **Chat, the 86'd list, calendar, POS settings, and the bottle
-  scanner.** The domain models are ported; the screens are not.
+- **Calendar, POS settings, and the bottle scanner.** The domain models
+  are ported; the screens are not.
 - **Push notifications.** No FCM registration, so the nag loop and
-  server-side fanout do not reach this client.
+  server-side fanout do not reach this client. The notification-settings
+  screen shows the ntfy topic for manual subscription but has no
+  `ntfy://` deep link.
 - **Drag-to-reorder.** The grid honours a saved order; it cannot write one.
-- **The roster dialog.** The approvals badge renders but opens nothing.
+- **Bar management.** No invite form, button hiding, or inventory editing.
 - **Google and Apple sign-in.** Email/password only.
 
 One caveat worth stating plainly: the Firestore read and write paths


### PR DESCRIPTION
Four more surfaces on the Compose Multiplatform client, closing the gap between "the core paging loop works" and "you could work a shift on this."

## What's new

**Chat** — pinned marquee on the dashboard, unread badge, paged scrollback, pin/unpin for Manager+, delete for your own messages or anyone's if you manage. No edit affordance, because `firestore.rules` restricts updates to the pin fields; an edit button could only ever fail.

**86'd list** — public entries for anyone with a role, add/remove for Manager+, premium private entries with a reason.

**Roster** — clocked in, off clock, and the two Manager+ review queues. This also fills in the approvals badge the last PR left pointing at nothing.

**Notification settings** — per-member paging preferences, keyed by job title rather than privilege tier.

## Design decisions worth a look

**Chat uses three subscriptions, not one.** They have genuinely different lifetimes: pinned messages stay live while a bar is selected (the marquee is on the dashboard), a one-document query drives the unread dot, and the fifty-document scrollback mounts only while the panel is open. Collapsing them would mean paying for fifty live documents all shift just to render one badge.

**Paging re-checks the bar *after* its await.** A guard at the top of the function does not catch a bar switch that happens mid-fetch — that would splice one bar's history into another's scrollback.

**Private 86'd entries change the query, not a filter.** A reader without the privilege never requests them, so the reason text never reaches their device. A reason typed against a *public* entry is discarded rather than stored, since a public reason would be readable by every member.

**Ownership claims read from Firestore but write only through Cloud Functions.** Approving one reassigns `ownerId`, and the rules deny client writes to that collection outright.

**One deliberate departure from the web client:** dialog visibility is a single `ActiveDialog` value rather than a boolean per dialog. The web version carries fourteen independent flags, which makes "two dialogs open at once" representable — and has produced exactly that bug. Here it can't happen. The tradeoff: a dialog's local state resets on close rather than surviving until the next open. Better as a default, but a real behavioural difference, and it's documented in `BarBackerDialog`.

## Still not built

`docs/CMP.md` is updated. Remaining: OpenStreetMap bar search (needs an HTTP client), calendar, POS settings, the bottle scanner, push notifications, drag-to-reorder, bar management, and social sign-in.

The runtime caveat from the previous PR still stands and now covers more surface: these Firestore paths compile and are shaped to match the rules, but have not been exercised against a live project from this client.

## Verification

Clean build: Android APK ✅, desktop JAR ✅, shared suite **70 tests / 0 failures**, no warnings in project code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Complete the Compose Multiplatform dashboard surfaces needed for day-to-day bar operations.

New Features:
- Add dashboard chat with pinned-message marquee, unread indicators, paged history, moderation controls, and message posting.
- Add role-gated 86'd list management with premium private entries and reasons.
- Add roster views for clocked-in and off-clock members plus Manager+ approval and ownership-claim review queues.
- Add per-member notification preference settings keyed by job title. 

Bug Fixes:
- Connect the dashboard approvals badge and roster entry point to functional review workflows.

Enhancements:
- Structure dashboard overlays around a single active-dialog state and add realtime data subscriptions for the new surfaces.
- Route ownership-claim writes through Cloud Functions while retaining Firestore reads and query private 86'd entries only for authorized members.

Documentation:
- Update CMP documentation to mark chat, 86'd list, roster workflows, notification preferences, and their realtime data as implemented, while documenting remaining client limitations.