### PR TITLE
CMP client: bar search across OpenStreetMap and existing bars

### DIFF
--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -80,6 +80,7 @@ private fun BarBackerApp(container: AppContainer) {
             chat = container.chat,
             eightySix = container.eightySix,
             ownershipClaims = container.ownershipClaims,
+            placeSearch = container.placeSearch,
             store = container.store,
         )
     }
@@ -117,6 +118,11 @@ private fun BarBackerApp(container: AppContainer) {
                         email = state.currentUser?.email,
                         joinedBarIds = state.joinedBarIds,
                         barNames = state.barNames,
+                        searchResults = state.searchResults,
+                        isSearching = state.isSearching,
+                        searchFailed = state.searchFailed,
+                        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                        onSelectPlace = viewModel::selectPlace,
                         onSelectBar = viewModel::selectBar,
                         onCreateBar = viewModel::createAndSelectBar,
                         onSignOut = viewModel::signOut,

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -3,6 +3,7 @@ package com.hereliesaz.barbacker.ui
 import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
 import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.data.AuthState
+import com.hereliesaz.barbacker.data.PlaceResult
 import com.hereliesaz.barbacker.logic.ButtonLabelResolver
 import com.hereliesaz.barbacker.logic.dynamicChildrenOf
 import com.hereliesaz.barbacker.logic.effectiveNotificationPreferences
@@ -105,6 +106,13 @@ data class AppUiState(
 
     val eightySixEntries: List<EightySixEntry> = emptyList(),
     val pendingOwnershipClaims: List<OwnershipClaim> = emptyList(),
+
+    /** Place-search results, bars already in the system sorted first. */
+    val searchResults: List<PlaceResult> = emptyList(),
+    val isSearching: Boolean = false,
+
+    /** True only when BOTH search sources failed; a partial result is still shown. */
+    val searchFailed: Boolean = false,
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -20,6 +20,10 @@ import com.hereliesaz.barbacker.data.KeyValueStore
 import com.hereliesaz.barbacker.data.MembershipRepository
 import com.hereliesaz.barbacker.data.NewBar
 import com.hereliesaz.barbacker.data.OwnershipClaimRepository
+import com.hereliesaz.barbacker.data.PLACE_SEARCH_DEBOUNCE_MILLIS
+import com.hereliesaz.barbacker.data.PLACE_SEARCH_MIN_LENGTH
+import com.hereliesaz.barbacker.data.PlaceResult
+import com.hereliesaz.barbacker.data.PlaceSearchRepository
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.logWarning
@@ -37,7 +41,10 @@ import com.hereliesaz.barbacker.model.MemberStatus
 import com.hereliesaz.barbacker.model.OwnershipClaim
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.model.SubscriptionTier
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -65,6 +72,7 @@ class AppViewModel(
     private val chat: ChatRepository,
     private val eightySix: EightySixRepository,
     private val ownershipClaims: OwnershipClaimRepository,
+    private val placeSearch: PlaceSearchRepository,
     private val store: KeyValueStore,
 ) : ViewModel() {
 
@@ -84,6 +92,9 @@ class AppViewModel(
         val chatHasMore: Boolean = true,
         val chatLoadingMore: Boolean = false,
         val chatLastReadAt: Long = 0L,
+        val searchResults: List<PlaceResult> = emptyList(),
+        val isSearching: Boolean = false,
+        val searchFailed: Boolean = false,
     )
 
     /** The four bar-scoped subscriptions, resolved together. */
@@ -95,6 +106,7 @@ class AppViewModel(
     )
 
     private val barIdFlow = MutableStateFlow(store.getString(KeyValueStore.KEY_BAR_ID))
+    private val searchQuery = MutableStateFlow("")
     private val localState = MutableStateFlow(LocalState(ignoredIds = readIgnoredIds()))
 
     /**
@@ -213,6 +225,9 @@ class AppViewModel(
             chatLastReadAt = local.chatLastReadAt,
             eightySixEntries = features.eightySix,
             pendingOwnershipClaims = features.claims,
+            searchResults = local.searchResults,
+            isSearching = local.isSearching,
+            searchFailed = local.searchFailed,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -222,6 +237,81 @@ class AppViewModel(
         watchForPendingInvite()
         watchForAutoClockIn()
         watchBarIdForChatReset()
+        watchSearchQuery()
+    }
+
+    /**
+     * Debounces the place search and runs one lookup at a time.
+     *
+     * `collectLatest` is what makes this correct: it CANCELS the in-flight
+     * search when a newer query arrives, so a slow response from three
+     * keystrokes ago can never overwrite the current results. The web
+     * client achieves the same thing by hand with an "am I still the most
+     * recent run" token; structured concurrency gives it for free.
+     */
+    @Suppress("OPT_IN_USAGE")
+    private fun watchSearchQuery() {
+        viewModelScope.launch {
+            searchQuery
+                .debounce(PLACE_SEARCH_DEBOUNCE_MILLIS)
+                .collectLatest { query -> runPlaceSearch(query.trim()) }
+        }
+    }
+
+    private suspend fun runPlaceSearch(query: String) {
+        if (query.length < PLACE_SEARCH_MIN_LENGTH) {
+            localState.update {
+                it.copy(searchResults = emptyList(), isSearching = false, searchFailed = false)
+            }
+            return
+        }
+
+        localState.update {
+            it.copy(searchResults = emptyList(), isSearching = true, searchFailed = false)
+        }
+
+        // Both halves accumulate here and are republished as each lands, so
+        // whichever source answers first paints immediately instead of
+        // waiting on the slower one. Safe without synchronisation because
+        // viewModelScope is confined to the main dispatcher.
+        var existing = emptyList<PlaceResult>()
+        var osm = emptyList<PlaceResult>()
+        var existingFailed = false
+        var osmFailed = false
+
+        fun publish() {
+            // Bars already in the system sort first: joining one is always
+            // better than creating a duplicate from an OSM entry.
+            localState.update { it.copy(searchResults = existing + osm) }
+        }
+
+        coroutineScope {
+            launch {
+                placeSearch.searchExistingBars(query)
+                    .onSuccess { existing = it; publish() }
+                    .onFailure { existingFailed = true }
+            }
+            launch {
+                placeSearch.searchOpenStreetMap(query)
+                    .onSuccess { osm = it; publish() }
+                    .onFailure { osmFailed = true }
+            }
+        }
+
+        localState.update {
+            it.copy(
+                isSearching = false,
+                // Only a total failure is reported. If one source answered,
+                // the results are incomplete but still useful — and stale
+                // results from the previous query must not stay tappable.
+                searchFailed = existingFailed && osmFailed,
+                searchResults = if (existingFailed && osmFailed) emptyList() else it.searchResults,
+            )
+        }
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        searchQuery.value = query
     }
 
     /**
@@ -295,6 +385,33 @@ class AppViewModel(
     fun selectBar(barId: String) {
         localState.update { it.copy(justCreatedBar = false) }
         persistBarId(barId)
+    }
+
+    /**
+     * Enters a bar found by search.
+     *
+     * A bar already in the system is joined directly. An OpenStreetMap
+     * result is created first — but through [BarRepository.createIfAbsent],
+     * so two people searching the same venue at once end up in one bar
+     * rather than two, and only the genuine creator is treated as Owner.
+     */
+    fun selectPlace(place: PlaceResult) {
+        if (place.isExistingBar) {
+            selectBar(place.barId)
+            return
+        }
+        createAndSelectBar(
+            NewBar(
+                id = place.barId,
+                name = place.name,
+                // Nominatim's display_name is a full comma-separated
+                // address; the individual components are not broken out
+                // here, so it goes in whole rather than being guessed at.
+                address = place.displayName,
+                osmId = place.barId.substringAfterLast('_'),
+                osmType = place.barId.removePrefix("osm_").substringBeforeLast('_'),
+            ),
+        )
     }
 
     fun createAndSelectBar(newBar: NewBar) {

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarSelectionScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarSelectionScreen.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Store
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -38,24 +42,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.barbacker.currentTimeMillis
 import com.hereliesaz.barbacker.data.NewBar
+import com.hereliesaz.barbacker.data.PlaceResult
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 
 /**
  * Picks which bar to work at.
  *
- * Lists the bars you already belong to, and offers a create form for one
- * that is not in the system yet.
- *
- * Searching OpenStreetMap for a nearby venue — the third entry path in the
- * web client — is not wired up here yet; it needs an HTTP client this
- * module does not carry. Until it lands, joining an existing bar you are
- * not already a member of happens through an invite link.
+ * Three ways in, in descending order of preference: a bar you already
+ * belong to, a bar found by search (either one this app knows about or an
+ * OpenStreetMap venue), or a new one you create by hand.
  */
 @Composable
 fun BarSelectionScreen(
     email: String?,
     joinedBarIds: List<String>,
     barNames: Map<String, String>,
+    searchResults: List<PlaceResult>,
+    isSearching: Boolean,
+    searchFailed: Boolean,
+    onSearchQueryChanged: (String) -> Unit,
+    onSelectPlace: (PlaceResult) -> Unit,
     onSelectBar: (String) -> Unit,
     onCreateBar: (NewBar) -> Unit,
     onSignOut: () -> Unit,
@@ -115,6 +121,17 @@ fun BarSelectionScreen(
                 Spacer(Modifier.height(24.dp))
             }
 
+            BarSearchSection(
+                results = searchResults,
+                isSearching = isSearching,
+                searchFailed = searchFailed,
+                onQueryChanged = onSearchQueryChanged,
+                onSelectPlace = onSelectPlace,
+                modifier = Modifier.width(320.dp),
+            )
+
+            Spacer(Modifier.height(24.dp))
+
             CreateBarForm(onCreate = onCreateBar, modifier = Modifier.width(320.dp))
         }
     }
@@ -137,6 +154,110 @@ private fun BarRow(name: String, onClick: () -> Unit) {
             contentDescription = null,
             tint = BarBackerColors.OnSurfaceVariant,
         )
+    }
+}
+
+/**
+ * Finds a bar to join, searching this app's own bars and OpenStreetMap at
+ * once.
+ *
+ * Results paint progressively — whichever source answers first fills its
+ * half — because Nominatim is a rate-limited public service and can be
+ * slow, and there is no reason to make a local hit wait on it.
+ */
+@Composable
+private fun BarSearchSection(
+    results: List<PlaceResult>,
+    isSearching: Boolean,
+    searchFailed: Boolean,
+    onQueryChanged: (String) -> Unit,
+    onSelectPlace: (PlaceResult) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var query by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "FIND A BAR",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = BarBackerColors.OnSurfaceVariant,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+
+        OutlinedTextField(
+            value = query,
+            onValueChange = {
+                query = it
+                onQueryChanged(it)
+            },
+            label = { Text("Search by name") },
+            singleLine = true,
+            leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+            trailingIcon = {
+                if (isSearching) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        when {
+            searchFailed -> Text(
+                text = "Couldn't search right now. Check your connection, " +
+                    "or create the bar below.",
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.Error,
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+
+            results.isNotEmpty() -> Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = BarBackerColors.SurfaceContainer,
+                ),
+            ) {
+                results.forEachIndexed { index, place ->
+                    if (index > 0) HorizontalDivider(color = BarBackerColors.Outline)
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelectPlace(place) }
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Icon(
+                            imageVector = if (place.isExistingBar) {
+                                Icons.Filled.Store
+                            } else {
+                                Icons.Filled.Place
+                            },
+                            contentDescription = null,
+                            // A bar already in the system is the better
+                            // choice, so it is visually distinguished from
+                            // an OpenStreetMap entry that would create one.
+                            tint = if (place.isExistingBar) {
+                                BarBackerColors.Primary
+                            } else {
+                                BarBackerColors.OnSurfaceVariant
+                            },
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(text = place.name, color = BarBackerColors.OnSurface)
+                            Text(
+                                text = place.displayName,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = BarBackerColors.OnSurfaceVariant,
+                                maxLines = 2,
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/cmp/gradle/libs.versions.toml
+++ b/cmp/gradle/libs.versions.toml
@@ -33,6 +33,10 @@ androidxActivity = "1.9.3"
 # existing PWA rather than becoming a Compose/Wasm target.
 gitliveFirebase = "2.6.0"
 
+# HTTP, for the OpenStreetMap place lookup. Engines differ per platform:
+# OkHttp on Android, CIO on desktop, Darwin on iOS.
+ktor = "3.5.2"
+
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
@@ -49,6 +53,13 @@ firebase-auth = { module = "dev.gitlive:firebase-auth", version.ref = "gitliveFi
 firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = "gitliveFirebase" }
 firebase-storage = { module = "dev.gitlive:firebase-storage", version.ref = "gitliveFirebase" }
 firebase-functions = { module = "dev.gitlive:firebase-functions", version.ref = "gitliveFirebase" }
+
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/cmp/shared/build.gradle.kts
+++ b/cmp/shared/build.gradle.kts
@@ -44,10 +44,27 @@ kotlin {
             api(libs.firebase.firestore)
             implementation(libs.firebase.storage)
             implementation(libs.firebase.functions)
+
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+
+        val desktopMain by getting
+        desktopMain.dependencies {
+            implementation(libs.ktor.client.cio)
+        }
+
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.android.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.barbacker.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+
+actual fun createHttpClient(): HttpClient = HttpClient(OkHttp) { configureForPlaceSearch() }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -20,4 +20,13 @@ class AppContainer(
     val eightySix: EightySixRepository = FirebaseEightySixRepository(firebase.firestore)
     val ownershipClaims: OwnershipClaimRepository =
         FirebaseOwnershipClaimRepository(firebase.firestore, firebase.functions)
+
+    /**
+     * One client for the whole process. Ktor clients own a connection pool
+     * and a dispatcher, so creating one per search would leak both.
+     */
+    private val httpClient = createHttpClient()
+
+    val placeSearch: PlaceSearchRepository =
+        DefaultPlaceSearchRepository(firebase.firestore, httpClient)
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.barbacker.data
+
+import io.ktor.client.HttpClient
+
+/**
+ * Builds the platform's HTTP client.
+ *
+ * Ktor has no single engine that works everywhere — OkHttp on Android, CIO
+ * on the JVM, Darwin on iOS — so the engine choice is the one thing that
+ * has to be per-platform. Everything configured on top of it (JSON,
+ * timeouts, the user agent) is shared.
+ */
+expect fun createHttpClient(): HttpClient

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PlaceSearchRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PlaceSearchRepository.kt
@@ -1,0 +1,164 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Minimum query length before a lookup fires. Two characters match half
+ * the map and waste a request against a rate-limited public service.
+ */
+const val PLACE_SEARCH_MIN_LENGTH: Int = 3
+
+/** How long to sit on keystrokes before searching. */
+const val PLACE_SEARCH_DEBOUNCE_MILLIS: Long = 500
+
+/** Cap on the "bars we already know about" half of the results. */
+private const val EXISTING_BAR_LIMIT = 5
+
+/**
+ * The high private-use codepoint Firestore prefix queries conventionally
+ * end at. `startAt(q)` through `endAt(q + sentinel)` is how you spell
+ * `LIKE 'q%'`: U+F8FF sorts after any ordinary character, so the range
+ * covers every string beginning with the query.
+ */
+private const val PREFIX_QUERY_SENTINEL = "\uF8FF"
+
+/**
+ * A place a user can turn into a bar: either one this app already knows
+ * about, or an OpenStreetMap result.
+ */
+data class PlaceResult(
+    /**
+     * The document id this place would become.
+     *
+     * For an existing bar, its actual id. For an OSM result,
+     * `osm_<type>_<id>` — the type is part of the key because `osm_id` is
+     * only unique WITHIN an element type, so two unrelated venues can
+     * share one.
+     */
+    val barId: String,
+    val name: String,
+    val displayName: String,
+    /** True when this row came from our own Firestore, not from OSM. */
+    val isExistingBar: Boolean,
+)
+
+interface PlaceSearchRepository {
+    /**
+     * Searches OpenStreetMap for matching venues.
+     *
+     * Failure is returned rather than thrown so the caller can tell a
+     * partial result (one source down) from a total one, and only clear
+     * the list in the latter case.
+     */
+    suspend fun searchOpenStreetMap(query: String): Result<List<PlaceResult>>
+
+    /** Prefix-searches bars this app already has. */
+    suspend fun searchExistingBars(query: String): Result<List<PlaceResult>>
+}
+
+class DefaultPlaceSearchRepository(
+    private val firestore: FirebaseFirestore,
+    private val httpClient: HttpClient,
+) : PlaceSearchRepository {
+
+    @Serializable
+    private data class NominatimResult(
+        @SerialName("osm_id") val osmId: Long? = null,
+        @SerialName("osm_type") val osmType: String? = null,
+        @SerialName("display_name") val displayName: String = "",
+        val name: String? = null,
+    )
+
+    override suspend fun searchOpenStreetMap(query: String): Result<List<PlaceResult>> =
+        runCatching {
+            val response: List<NominatimResult> = httpClient
+                .get("https://nominatim.openstreetmap.org/search") {
+                    parameter("format", "json")
+                    // The literal " bar" suffix steers a plain name toward
+                    // drinking establishments; without it, a common venue
+                    // name returns mostly streets.
+                    parameter("q", "$query bar")
+                }
+                .body()
+
+            response.mapNotNull { result ->
+                val osmId = result.osmId ?: return@mapNotNull null
+                val type = result.osmType ?: "unknown"
+                PlaceResult(
+                    barId = "osm_${type}_$osmId",
+                    name = result.name?.takeIf { it.isNotBlank() }
+                        ?: result.displayName.substringBefore(","),
+                    displayName = result.displayName,
+                    isExistingBar = false,
+                )
+            }
+        }.onFailure { logWarning("OpenStreetMap lookup failed", it) }
+
+    override suspend fun searchExistingBars(query: String): Result<List<PlaceResult>> =
+        runCatching {
+            firestore.collection(Paths.BARS)
+                .orderBy("name")
+                // The *FieldValues form rather than the vararg overloads,
+                // which GitLive has deprecated.
+                .startAtFieldValues { add(query) }
+                .endAtFieldValues { add(query + PREFIX_QUERY_SENTINEL) }
+                .limit(EXISTING_BAR_LIMIT)
+                .get()
+                .documents
+                .mapNotNull { snapshot ->
+                    val name = snapshot.field<String>("name") ?: return@mapNotNull null
+                    val city = snapshot.field<String>("city").orEmpty()
+                    val state = snapshot.field<String>("state").orEmpty()
+                    PlaceResult(
+                        barId = snapshot.id,
+                        name = name,
+                        displayName = listOf(name, "$city $state".trim())
+                            .filter { it.isNotBlank() }
+                            .joinToString(", "),
+                        isExistingBar = true,
+                    )
+                }
+        }.onFailure { logWarning("Existing-bar lookup failed", it) }
+}
+
+/**
+ * Shared HTTP client configuration.
+ *
+ * The user agent is not optional politeness: Nominatim's usage policy
+ * requires an identifying one and blocks requests that omit it. The
+ * timeouts matter too — a public service that hangs must not leave the
+ * search spinner up indefinitely.
+ */
+internal fun HttpClientConfig<*>.configureForPlaceSearch() {
+    install(ContentNegotiation) {
+        json(
+            Json {
+                // Nominatim returns far more fields than we model, and adds
+                // more over time.
+                ignoreUnknownKeys = true
+                isLenient = true
+            },
+        )
+    }
+    install(HttpTimeout) {
+        requestTimeoutMillis = 10_000
+        connectTimeoutMillis = 5_000
+    }
+    defaultRequest {
+        header("User-Agent", "BarBacker/0.6 (+https://github.com/HereLiesAz/BarBacker)")
+    }
+}

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.desktop.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.barbacker.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+
+actual fun createHttpClient(): HttpClient = HttpClient(CIO) { configureForPlaceSearch() }

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/HttpClientFactory.ios.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.barbacker.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+
+actual fun createHttpClient(): HttpClient = HttpClient(Darwin) { configureForPlaceSearch() }

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -200,7 +200,8 @@ fails if it is lost:
 Working end to end:
 
 - Email sign-in and registration, with session restore
-- Bar selection from your joined bars, and creating a new bar
+- Bar selection: your joined bars, a debounced search across both this
+  app's bars and OpenStreetMap, and a create form
 - The join flow, including invite consumption and approval-pending
 - The dashboard: request grid, sub-menu drill-down with synthesised
   children, sending pages, and claim / cancel / mute
@@ -216,9 +217,6 @@ Working end to end:
 
 Not built yet — the PWA remains the complete client:
 
-- **OpenStreetMap bar search.** Needs an HTTP client this module does not
-  carry yet. Joining a bar you are not already a member of currently
-  happens through an invite link.
 - **Calendar, POS settings, and the bottle scanner.** The domain models
   are ported; the screens are not.
 - **Push notifications.** No FCM registration, so the nag loop and


### PR DESCRIPTION
Fills the last gap in bar selection on the Compose Multiplatform client: you can now find a venue by name, rather than only reaching one through an invite link or creating it by hand.

## How it works

Searches **two sources at once** and paints each half as it lands. Nominatim is a rate-limited public service that can be slow, and there's no reason to make a local hit wait on it. Bars already in the system sort first — joining one is always better than creating a duplicate from an OSM entry.

## Design decisions worth a look

**Cancellation is structural, not hand-rolled.** `collectLatest` over a debounced query flow cancels the in-flight search the moment a newer query arrives, so a slow response from three keystrokes ago can't overwrite current results. The web client does this with an "am I still the most recent run" token; structured concurrency gives it for free.

**Only a *total* failure clears the list.** If one source answered, the results are incomplete but still useful. If neither did, stale results from the previous query must not stay on screen and tappable.

**OSM ids carry the element type.** A result becomes `osm_<type>_<id>`, because `osm_id` is only unique *within* a type — two unrelated venues can otherwise collide on the same bar id. Creation goes through `createIfAbsent`, so two people searching the same venue at once land in one bar rather than two, and only the genuine creator becomes Owner.

**The user agent isn't optional politeness.** Nominatim's usage policy requires an identifying one and blocks requests without it.

## Dependencies

Adds Ktor, with the engine chosen per platform — OkHttp on Android, CIO on desktop, Darwin on iOS. That's the only per-platform piece; JSON, timeouts, and the user agent are shared.

Uses GitLive's `startAtFieldValues`/`endAtFieldValues` rather than the deprecated vararg overloads, with the U+F8FF prefix sentinel that makes `startAt(q)`..`endAt(q + sentinel)` mean `LIKE 'q%'`.

## Verification

Clean build: Android APK ✅, desktop JAR ✅, shared suite **70 tests / 0 failures**, no warnings in project code.

The standing runtime caveat applies here too, and more sharply than usual: the Nominatim call and the Firestore prefix query compile but have not been exercised against the live services from this client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx)_

## Summary by Sourcery

Enable CMP users to find and select bars by name from local data or OpenStreetMap.

New Features:
- Add bar selection search across existing app bars and OpenStreetMap venues, with progressive results and direct selection or creation.

Enhancements:
- Prioritize existing bars and handle debounced, cancellable searches with partial-result and total-failure states.

Build:
- Add Ktor HTTP client dependencies with platform-specific engines for Android, desktop, and iOS.

Documentation:
- Update CMP documentation to mark bar search as working and remove it from the unbuilt feature list.