### PR TITLE
CMP client: push, the alert loop, bar management, and two wrong-by-construction bugs

### DIFF
--- a/cmp/composeApp/build.gradle.kts
+++ b/cmp/composeApp/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.uiTooling)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.core.ktx)
         }
     }
 }

--- a/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/BarBackerApplication.kt
+++ b/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/BarBackerApplication.kt
@@ -1,5 +1,44 @@
 package com.hereliesaz.barbacker
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
 
-class BarBackerApplication : Application()
+/**
+ * The channel the server-side fanout and the nag cron target.
+ *
+ * The id must match what those senders set, or Android drops the
+ * notification's high-priority treatment and it arrives silently — which
+ * for a paging app is indistinguishable from not arriving at all.
+ */
+private const val URGENT_ALERTS_CHANNEL_ID = "urgent_alerts"
+
+class BarBackerApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        createUrgentAlertsChannel()
+    }
+
+    private fun createUrgentAlertsChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        val channel = NotificationChannel(
+            URGENT_ALERTS_CHANNEL_ID,
+            "Urgent Alerts",
+            // HIGH so pages heads-up over whatever is on screen. A bar
+            // request that waits for someone to pull down the shade is a
+            // request that did not work.
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Requests from the floor that need someone now."
+            enableVibration(true)
+            vibrationPattern = longArrayOf(0, 500, 200, 500)
+        }
+        // Creating an existing channel is a no-op, so this is safe on every
+        // launch — and a user's own changes to the channel are preserved.
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/MainActivity.kt
+++ b/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/MainActivity.kt
@@ -1,17 +1,44 @@
 package com.hereliesaz.barbacker
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 
 class MainActivity : ComponentActivity() {
+
+    /**
+     * Android 13+ requires an explicit grant before any notification can be
+     * posted. Nothing is done with the answer beyond letting the system
+     * record it: a refusal still leaves the in-app alert loop working, so
+     * the app stays usable either way.
+     */
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        askForNotificationPermissionIfNeeded()
         // applicationContext, not the Activity: the container it builds
         // outlives this Activity across configuration changes, and holding
         // an Activity reference there would leak it on every rotation.
         setContent { App(platformContext = applicationContext) }
+    }
+
+    private fun askForNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 }

--- a/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.android.kt
+++ b/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.android.kt
@@ -1,0 +1,97 @@
+package com.hereliesaz.barbacker.ui
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import com.hereliesaz.barbacker.data.MAX_LOGO_BYTES
+import com.hereliesaz.barbacker.data.PickedImage
+import com.hereliesaz.barbacker.data.pickedImageOrNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+actual fun rememberImagePicker(
+    onPicked: (PickedImage) -> Unit,
+    onError: (String) -> Unit,
+): ImagePickerLauncher {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    // rememberUpdatedState so the launcher registered on first composition
+    // still calls the CURRENT callbacks. Without it the picker would post
+    // its result into whichever lambda existed when the dialog opened,
+    // which is a stale closure over the theme editor's earlier state.
+    val picked by rememberUpdatedState(onPicked)
+    val failed by rememberUpdatedState(onError)
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent(),
+    ) { uri ->
+        // A null Uri is a cancel, not a failure.
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            val outcome = withContext(Dispatchers.IO) {
+                runCatching { context.readPickedImage(uri) }
+            }
+            outcome.fold(
+                onSuccess = { result ->
+                    when (result) {
+                        is ReadResult.Ok -> picked(result.image)
+                        is ReadResult.Failed -> failed(result.message)
+                    }
+                },
+                // Typically a SecurityException: the content Uri's grant is
+                // scoped to the activity result and dies with a
+                // configuration change mid-read.
+                onFailure = { failed("Could not read that image.") },
+            )
+        }
+    }
+
+    return remember(launcher) { ImagePickerLauncher { launcher.launch("image/*") } }
+}
+
+private sealed interface ReadResult {
+    data class Ok(val image: PickedImage) : ReadResult
+    data class Failed(val message: String) : ReadResult
+}
+
+private fun Context.readPickedImage(uri: Uri): ReadResult {
+    var displayName: String? = null
+    var declaredSize: Long = -1
+    contentResolver.query(
+        uri,
+        arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE),
+        null,
+        null,
+        null,
+    )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+            if (!cursor.isNull(0)) displayName = cursor.getString(0)
+            if (!cursor.isNull(1)) declaredSize = cursor.getLong(1)
+        }
+    }
+
+    // Checked before the read, not after: the provider's reported size is
+    // advisory, but when it is present it spares us pulling a 40MB
+    // panorama into memory only to reject it.
+    if (declaredSize > MAX_LOGO_BYTES) return ReadResult.Failed("Logo must be under 2MB.")
+
+    val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        ?: return ReadResult.Failed("Could not read that image.")
+
+    if (bytes.size > MAX_LOGO_BYTES) return ReadResult.Failed("Logo must be under 2MB.")
+
+    val image = pickedImageOrNull(bytes, displayName, contentResolver.getType(uri))
+        ?: return ReadResult.Failed("Logo must be a PNG, JPG, WebP, or SVG.")
+    return ReadResult.Ok(image)
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -63,6 +63,7 @@ fun App(platformContext: Any? = null) {
         AppContainer(
             firebase = BarBackerFirebase.initialize(config, platformContext),
             store = createKeyValueStore(platformContext),
+            platformContext = platformContext,
         )
     }
 
@@ -81,6 +82,8 @@ private fun BarBackerApp(container: AppContainer) {
             eightySix = container.eightySix,
             ownershipClaims = container.ownershipClaims,
             placeSearch = container.placeSearch,
+            pushTokens = container.pushTokens,
+            alerter = container.alerter,
             store = container.store,
         )
     }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -31,6 +31,7 @@ import com.hereliesaz.barbacker.ui.AppUiState
 import com.hereliesaz.barbacker.ui.AppViewModel
 import com.hereliesaz.barbacker.ui.Screen
 import com.hereliesaz.barbacker.ui.screens.ApprovalPendingScreen
+import com.hereliesaz.barbacker.ui.screens.BarManagerDialog
 import com.hereliesaz.barbacker.ui.screens.BarSelectionScreen
 import com.hereliesaz.barbacker.ui.screens.ChatPanel
 import com.hereliesaz.barbacker.ui.screens.CheckingInviteScreen
@@ -44,6 +45,7 @@ import com.hereliesaz.barbacker.ui.screens.RestoringScreen
 import com.hereliesaz.barbacker.ui.screens.RoleSelectionScreen
 import com.hereliesaz.barbacker.ui.screens.RosterDialog
 import com.hereliesaz.barbacker.ui.screens.SignInScreen
+import com.hereliesaz.barbacker.ui.screens.ThemeEditorDialog
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 import com.hereliesaz.barbacker.ui.theme.BarBackerTheme
 
@@ -83,6 +85,7 @@ private fun BarBackerApp(container: AppContainer) {
             chat = container.chat,
             eightySix = container.eightySix,
             ownershipClaims = container.ownershipClaims,
+            storage = container.storage,
             placeSearch = container.placeSearch,
             pushTokens = container.pushTokens,
             alerter = container.alerter,
@@ -163,8 +166,11 @@ private fun BarBackerApp(container: AppContainer) {
                             onOpenNotificationSettings = {
                                 viewModel.openDialog(ActiveDialog.NotificationSettings)
                             },
+                            onOpenBarManager = { viewModel.openDialog(ActiveDialog.BarManager) },
+                            onOpenThemeEditor = { viewModel.openDialog(ActiveDialog.ThemeEditor) },
                             onSwitchBar = viewModel::backToBarSelection,
                             onGoOffClock = viewModel::goOffClock,
+                            onReorder = viewModel::saveButtonOrder,
                         ),
                     )
                 }
@@ -243,6 +249,25 @@ private fun DashboardDialogs(state: AppUiState, viewModel: AppViewModel) {
             buttons = state.buttons,
             ntfyTopic = null,
             onSave = viewModel::saveNotificationPreferences,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.BarManager -> BarManagerDialog(
+            barName = state.barName,
+            allButtons = state.manageableButtons,
+            hiddenButtonIds = state.hiddenButtonIds,
+            isPremium = state.isPremium,
+            isManagerPlus = state.isManagerPlus,
+            onHideButton = viewModel::hideButton,
+            onUnhideButton = viewModel::unhideButton,
+            onInvite = viewModel::sendInvite,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.ThemeEditor -> ThemeEditorDialog(
+            currentTheme = state.bar?.theme,
+            onSave = viewModel::saveTheme,
+            onUploadLogo = viewModel::uploadLogo,
             onClose = viewModel::closeDialog,
         )
     }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -37,7 +37,9 @@ import com.hereliesaz.barbacker.ui.screens.CheckingInviteScreen
 import com.hereliesaz.barbacker.ui.screens.DashboardActions
 import com.hereliesaz.barbacker.ui.screens.DashboardScreen
 import com.hereliesaz.barbacker.ui.screens.EightySixDialog
+import com.hereliesaz.barbacker.ui.screens.InputPromptDialog
 import com.hereliesaz.barbacker.ui.screens.NotificationSettingsDialog
+import com.hereliesaz.barbacker.ui.screens.QuantityPromptDialog
 import com.hereliesaz.barbacker.ui.screens.RestoringScreen
 import com.hereliesaz.barbacker.ui.screens.RoleSelectionScreen
 import com.hereliesaz.barbacker.ui.screens.RosterDialog
@@ -171,6 +173,23 @@ private fun BarBackerApp(container: AppContainer) {
                 // above whichever screen is showing. In practice only the
                 // dashboard opens them.
                 DashboardDialogs(state = state, viewModel = viewModel)
+
+                // Prompts sit above the dialogs: a brand prompt can be
+                // opened from inside a sub-menu, not only from the grid.
+                state.inputPrompt?.let { prompt ->
+                    InputPromptDialog(
+                        prompt = prompt,
+                        onSubmit = viewModel::submitPrompt,
+                        onDismiss = viewModel::dismissPrompt,
+                    )
+                }
+                state.quantityPrompt?.let { prompt ->
+                    QuantityPromptDialog(
+                        prompt = prompt,
+                        onSubmit = viewModel::submitQuantity,
+                        onDismiss = viewModel::dismissPrompt,
+                    )
+                }
             }
         }
     }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -119,6 +119,19 @@ data class AppUiState(
 
     /** An open quantity stepper, if any. */
     val quantityPrompt: QuantityPrompt? = null,
+
+    /**
+     * Orders a drag has committed but the bar document has not confirmed,
+     * keyed by grid context id.
+     *
+     * Without this the grid snaps back to the old arrangement between the
+     * finger lifting and the write's snapshot arriving — brief, but exactly
+     * the moment a manager is watching to see whether the drag took. The
+     * view model drops each entry once the server agrees, and on a rejected
+     * write, so a failed reorder does not leave the grid showing an order
+     * nobody saved.
+     */
+    val pendingOrders: Map<String, List<String>> = emptyMap(),
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 
@@ -178,11 +191,37 @@ data class AppUiState(
     /** The approvals badge is hidden from Staff, for whom it opens nothing actionable. */
     val showApprovalsBadge: Boolean get() = isManagerPlus && pendingMembers.isNotEmpty()
 
-    private val hiddenButtonIds: Set<String>
+    val hiddenButtonIds: Set<String>
         get() = bar?.hiddenButtonIds?.toSet().orEmpty()
 
     /** The grid context currently on screen: a parent button id, or "main". */
     val currentContextId: String get() = navStack.lastOrNull()?.id ?: MAIN_CONTEXT_ID
+
+    /** Saved orders, with any locally committed drag taking precedence. */
+    private val effectiveOrders: Map<String, List<String>>
+        get() = bar?.customOrders.orEmpty() + pendingOrders
+
+    /**
+     * What the manage screen lists: every configured button, hidden or
+     * not, plus a stand-in for each hidden `brand_` tile.
+     *
+     * Brand tiles are synthesised from `beerInventory` at render time and
+     * never appear in the stored `buttons` array — so 86'ing one (which
+     * hides `brand_<name>`) would otherwise leave it absent from both
+     * halves of this screen, with no path back even on premium.
+     */
+    val manageableButtons: List<ButtonConfig> by lazy {
+        val sorted = sortButtons(
+            buttons = buttons,
+            contextId = MAIN_CONTEXT_ID,
+            customOrders = effectiveOrders,
+            buttonUsage = bar?.buttonUsage.orEmpty(),
+        )
+        val hiddenBrands = hiddenButtonIds
+            .filter { it.startsWith("brand_") }
+            .map { ButtonConfig(id = it, label = it.removePrefix("brand_")) }
+        sorted + hiddenBrands
+    }
 
     /**
      * The tiles to render, hidden ones removed and the rest ordered.
@@ -205,7 +244,7 @@ data class AppUiState(
         val sorted = sortButtons(
             buttons = source.filterNot { it.id in hiddenButtonIds },
             contextId = currentContextId,
-            customOrders = bar?.customOrders.orEmpty(),
+            customOrders = effectiveOrders,
             buttonUsage = bar?.buttonUsage.orEmpty(),
         )
         if (parent == null) sorted + CUSTOM_REQUEST_BUTTON else sorted
@@ -304,4 +343,6 @@ enum class ActiveDialog {
     EightySix,
     Roster,
     NotificationSettings,
+    BarManager,
+    ThemeEditor,
 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -113,6 +113,12 @@ data class AppUiState(
 
     /** True only when BOTH search sources failed; a partial result is still shown. */
     val searchFailed: Boolean = false,
+
+    /** An open free-text prompt, if any. */
+    val inputPrompt: InputPrompt? = null,
+
+    /** An open quantity stepper, if any. */
+    val quantityPrompt: QuantityPrompt? = null,
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 
@@ -237,6 +243,59 @@ data class AppUiState(
         const val MAIN_CONTEXT_ID = "main"
     }
 }
+
+/**
+ * What a free-text prompt is collecting.
+ *
+ * These back the synthesised "+ ADD …" tiles and the CUSTOM tile. Those
+ * are grid buttons with no children, so without an explicit prompt they
+ * fall through to the submit path and page the floor with their own label
+ * — "ICE: + ADD WELL" — instead of asking for input.
+ */
+enum class InputKind {
+    /** A new beer brand for the bar's inventory. */
+    Brand,
+
+    /** A new type (Bottle, Draft, …) under an existing brand. */
+    Type,
+
+    /** A new well/station name. */
+    Well,
+
+    /** Free text sent as a one-off request. */
+    CustomRequest,
+}
+
+data class InputPrompt(
+    val kind: InputKind,
+    val initialValue: String = "",
+    /** The brand a new type belongs to. Only set for [InputKind.Type]. */
+    val parentBrand: String? = null,
+    /** Offered as tap-to-fill; the field stays free-text either way. */
+    val suggestions: List<String> = emptyList(),
+) {
+    val title: String
+        get() = when (kind) {
+            InputKind.Brand -> "Add Brand"
+            InputKind.Type -> "Add Type"
+            InputKind.Well -> "Add Well"
+            InputKind.CustomRequest -> "Custom Request"
+        }
+
+    val label: String
+        get() = when (kind) {
+            InputKind.Brand -> "Brand name"
+            InputKind.Type -> "Type (Bottle, Draft, …)"
+            InputKind.Well -> "Well name"
+            InputKind.CustomRequest -> "What do you need?"
+        }
+}
+
+/** The numeric stepper behind a beer type's "Other" quantity option. */
+data class QuantityPrompt(
+    /** The breadcrumb the chosen number is appended to. */
+    val contextLabel: String,
+)
 
 /** The overlays reachable from the dashboard. */
 enum class ActiveDialog {

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -20,6 +20,7 @@ import com.hereliesaz.barbacker.data.BarRepository
 import com.hereliesaz.barbacker.data.CHAT_PAGE_SIZE
 import com.hereliesaz.barbacker.data.ChatRepository
 import com.hereliesaz.barbacker.data.EightySixRepository
+import com.hereliesaz.barbacker.data.InvitableRole
 import com.hereliesaz.barbacker.data.KeyValueStore
 import com.hereliesaz.barbacker.data.MembershipRepository
 import com.hereliesaz.barbacker.data.NewBar
@@ -27,10 +28,12 @@ import com.hereliesaz.barbacker.data.OwnershipClaimRepository
 import com.hereliesaz.barbacker.data.PLACE_SEARCH_DEBOUNCE_MILLIS
 import com.hereliesaz.barbacker.data.PLACE_SEARCH_MIN_LENGTH
 import com.hereliesaz.barbacker.data.PlaceResult
+import com.hereliesaz.barbacker.data.PickedImage
 import com.hereliesaz.barbacker.data.PlaceSearchRepository
 import com.hereliesaz.barbacker.data.PushTokenProvider
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
+import com.hereliesaz.barbacker.data.StorageRepository
 import com.hereliesaz.barbacker.logWarning
 import com.hereliesaz.barbacker.logic.ButtonTap
 import com.hereliesaz.barbacker.logic.classifyTap
@@ -38,6 +41,7 @@ import com.hereliesaz.barbacker.logic.hasOutstandingAlerts
 import com.hereliesaz.barbacker.logic.requestLabelFor
 import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarRole
+import com.hereliesaz.barbacker.model.BarTheme
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonConfig
 import com.hereliesaz.barbacker.model.ChatMessage
@@ -79,6 +83,7 @@ class AppViewModel(
     private val chat: ChatRepository,
     private val eightySix: EightySixRepository,
     private val ownershipClaims: OwnershipClaimRepository,
+    private val storage: StorageRepository,
     private val placeSearch: PlaceSearchRepository,
     private val pushTokens: PushTokenProvider,
     private val alerter: Alerter,
@@ -106,6 +111,7 @@ class AppViewModel(
         val searchFailed: Boolean = false,
         val inputPrompt: InputPrompt? = null,
         val quantityPrompt: QuantityPrompt? = null,
+        val pendingOrders: Map<String, List<String>> = emptyMap(),
     )
 
     /** The four bar-scoped subscriptions, resolved together. */
@@ -241,6 +247,7 @@ class AppViewModel(
             searchFailed = local.searchFailed,
             inputPrompt = local.inputPrompt,
             quantityPrompt = local.quantityPrompt,
+            pendingOrders = local.pendingOrders,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -253,6 +260,36 @@ class AppViewModel(
         watchSearchQuery()
         watchForPushRegistration()
         startNagLoop()
+        watchBarForSettledOrders()
+    }
+
+    /**
+     * Retires an optimistic order once the bar document carries it.
+     *
+     * Without this, a locally committed order shadows the document
+     * forever — so a second manager reordering the same grid from another
+     * device would appear to have no effect here, permanently.
+     */
+    private fun watchBarForSettledOrders() {
+        viewModelScope.launch {
+            barScope
+                .map { it.bar?.customOrders }
+                .distinctUntilChanged()
+                .collect { saved ->
+                    if (saved == null) return@collect
+                    localState.update { local ->
+                        if (local.pendingOrders.isEmpty()) return@update local
+                        val settled = local.pendingOrders.filterNot { (context, order) ->
+                            saved[context] == order
+                        }
+                        if (settled.size == local.pendingOrders.size) {
+                            local
+                        } else {
+                            local.copy(pendingOrders = settled)
+                        }
+                    }
+                }
+        }
     }
 
     /**
@@ -920,6 +957,89 @@ class AppViewModel(
         }
     }
 
+    // --- Bar management -------------------------------------------------
+
+    /**
+     * Persists the order a drag settled on, for the grid context that was
+     * on screen when it started.
+     *
+     * The new order is applied locally first so the tiles stay where the
+     * finger left them, and rolled back if the write is rejected — which
+     * is the whole failure mode worth handling here, since `customOrders`
+     * lives on the bar document and only Manager+ may write it.
+     */
+    fun saveButtonOrder(order: List<String>) {
+        val barId = barIdFlow.value ?: return
+        val contextId = state.value.currentContextId
+        if (order.isEmpty()) return
+
+        localState.update { it.copy(pendingOrders = it.pendingOrders + (contextId to order)) }
+        viewModelScope.launch {
+            runCatching { bars.saveCustomOrder(barId, contextId, order) }.onFailure {
+                logWarning("Could not save the button order", it)
+                localState.update { local ->
+                    local.copy(pendingOrders = local.pendingOrders - contextId)
+                }
+                showMessage("Failed to save the new order. Only managers can reorder buttons.")
+            }
+        }
+    }
+
+    fun hideButton(buttonId: String) {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching { bars.hideButton(barId, buttonId) }.onFailure {
+                logWarning("Could not hide $buttonId", it)
+                showMessage("Failed to remove the button. Please try again.")
+            }
+        }
+    }
+
+    fun unhideButton(buttonId: String) {
+        val barId = barIdFlow.value ?: return
+        viewModelScope.launch {
+            runCatching { bars.unhideButton(barId, buttonId) }.onFailure {
+                logWarning("Could not restore $buttonId", it)
+                showMessage("Failed to restore the button. Please try again.")
+            }
+        }
+    }
+
+    /**
+     * Invites someone by email.
+     *
+     * Only writes the invite. The membership document is created by the
+     * `onInviteConsumed` Cloud Function, because an invite can grant
+     * Manager and a client is not trusted to hand out that role.
+     */
+    suspend fun sendInvite(email: String, role: InvitableRole): Result<Unit> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        val user = state.value.currentUser
+            ?: return Result.failure(IllegalStateException("Signed out"))
+        return runCatching {
+            memberships.sendInvite(
+                barId = barId,
+                email = email,
+                role = role,
+                createdBy = user.uid,
+                createdByName = state.value.membership?.displayName.orEmpty(),
+            )
+        }.onFailure { logWarning("Could not send an invite to $barId", it) }
+    }
+
+    suspend fun saveTheme(theme: BarTheme): Result<Unit> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        return runCatching { bars.saveTheme(barId, theme) }
+            .onFailure { logWarning("Could not save the theme", it) }
+    }
+
+    /** Uploads a logo and returns its download URL; does not save the theme. */
+    suspend fun uploadLogo(image: PickedImage): Result<String> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        return runCatching { storage.uploadBarLogo(barId, image) }
+            .onFailure { logWarning("Could not upload a logo for $barId", it) }
+    }
+
     // --- Dialogs --------------------------------------------------------
 
     fun openDialog(dialog: ActiveDialog) {
@@ -1196,11 +1316,27 @@ class AppViewModel(
     private fun persistBarId(barId: String) {
         store.putString(KeyValueStore.KEY_BAR_ID, barId)
         barIdFlow.value = barId
+        forgetPendingOrders()
     }
 
     private fun clearBarSelection() {
         store.putString(KeyValueStore.KEY_BAR_ID, null)
         barIdFlow.value = null
+        forgetPendingOrders()
+    }
+
+    /**
+     * Drops optimistic grid orders on every bar change.
+     *
+     * They are keyed by grid context — "main", "ice" — not by bar, so a
+     * pending "main" left over from the last bar would shadow the new
+     * one's saved order on a shared tablet, and go on shadowing it because
+     * the server value it is waiting to match belongs to a different bar.
+     */
+    private fun forgetPendingOrders() {
+        localState.update {
+            if (it.pendingOrders.isEmpty()) it else it.copy(pendingOrders = emptyMap())
+        }
     }
 
     private fun readIgnoredIds(): Set<String> =

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -3,6 +3,8 @@ package com.hereliesaz.barbacker.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.barbacker.ASK_ME_SUFFIX
+import com.hereliesaz.barbacker.DEFAULT_BEERS
+import com.hereliesaz.barbacker.LABEL_SEPARATOR
 import com.hereliesaz.barbacker.INVITE_CHECK_TIMEOUT_MILLIS
 import com.hereliesaz.barbacker.Alerter
 import com.hereliesaz.barbacker.MAX_IGNORED_IDS
@@ -30,7 +32,8 @@ import com.hereliesaz.barbacker.data.PushTokenProvider
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.logWarning
-import com.hereliesaz.barbacker.logic.dynamicChildrenOf
+import com.hereliesaz.barbacker.logic.ButtonTap
+import com.hereliesaz.barbacker.logic.classifyTap
 import com.hereliesaz.barbacker.logic.hasOutstandingAlerts
 import com.hereliesaz.barbacker.logic.requestLabelFor
 import com.hereliesaz.barbacker.model.Bar
@@ -101,6 +104,8 @@ class AppViewModel(
         val searchResults: List<PlaceResult> = emptyList(),
         val isSearching: Boolean = false,
         val searchFailed: Boolean = false,
+        val inputPrompt: InputPrompt? = null,
+        val quantityPrompt: QuantityPrompt? = null,
     )
 
     /** The four bar-scoped subscriptions, resolved together. */
@@ -234,6 +239,8 @@ class AppViewModel(
             searchResults = local.searchResults,
             isSearching = local.isSearching,
             searchFailed = local.searchFailed,
+            inputPrompt = local.inputPrompt,
+            quantityPrompt = local.quantityPrompt,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -606,18 +613,191 @@ class AppViewModel(
      */
     fun onButtonTapped(button: ButtonConfig) {
         val current = state.value
-        val children = dynamicChildrenOf(
-            button = button,
-            wells = current.bar?.wells.orEmpty(),
-            beerInventory = current.bar?.beerInventory.orEmpty(),
-        )
-        if (children.isNotEmpty()) {
-            localState.update { it.copy(navStack = it.navStack + button) }
-        } else {
-            submitRequest(requestLabelFor(current.navStack + button))
-            clearNavStack()
+        val inventory = current.bar?.beerInventory.orEmpty()
+        val wells = current.bar?.wells.orEmpty()
+
+        // Routed through the shared classifier so the "+ ADD …" and
+        // CUSTOM tiles cannot silently fall through to the submit path —
+        // see ClassifyTapTest.
+        when (classifyTap(button, wells, inventory)) {
+            ButtonTap.PromptForWell -> {
+                localState.update {
+                    it.copy(
+                        inputPrompt = InputPrompt(
+                            kind = InputKind.Well,
+                            // Pre-filled with the next number, since wells
+                            // are almost always numbered in order.
+                            initialValue = "Well #${wells.size + 1}",
+                        ),
+                    )
+                }
+                return
+            }
+
+            ButtonTap.PromptForBrand -> {
+                localState.update {
+                    it.copy(
+                        inputPrompt = InputPrompt(
+                            kind = InputKind.Brand,
+                            suggestions = (DEFAULT_BEERS + inventory.keys).distinct(),
+                        ),
+                    )
+                }
+                return
+            }
+
+            ButtonTap.PromptForType -> {
+                // The brand is whatever menu we descended through to get
+                // here; its LABEL is the inventory key.
+                val brand = current.navStack.lastOrNull()?.label ?: return
+                localState.update {
+                    it.copy(
+                        inputPrompt = InputPrompt(
+                            kind = InputKind.Type,
+                            parentBrand = brand,
+                            suggestions = inventory.values.flatten().distinct(),
+                        ),
+                    )
+                }
+                return
+            }
+
+            ButtonTap.PromptForQuantity -> {
+                localState.update {
+                    it.copy(
+                        quantityPrompt = QuantityPrompt(
+                            contextLabel = requestLabelFor(current.navStack),
+                        ),
+                    )
+                }
+                return
+            }
+
+            ButtonTap.PromptForCustomRequest -> {
+                localState.update { it.copy(inputPrompt = InputPrompt(InputKind.CustomRequest)) }
+                return
+            }
+
+            ButtonTap.Descend -> {
+                localState.update { it.copy(navStack = it.navStack + button) }
+                return
+            }
+
+            ButtonTap.Submit -> {
+                submitRequest(requestLabelFor(current.navStack + button))
+                clearNavStack()
+                return
+            }
         }
     }
+
+    fun dismissPrompt() =
+        localState.update { it.copy(inputPrompt = null, quantityPrompt = null) }
+
+    /**
+     * Applies whatever the open prompt was collecting.
+     *
+     * Inventory writes land BEFORE the local navigation moves, and a
+     * failure returns early. Navigating first would drop the user into a
+     * brand or type menu that does not exist on the server — every request
+     * sent from it would reference something no one else can see.
+     */
+    fun submitPrompt(value: String) {
+        val prompt = localState.value.inputPrompt ?: return
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) return
+
+        val barId = barIdFlow.value ?: return
+        val inventory = state.value.bar?.beerInventory.orEmpty()
+        val wells = state.value.bar?.wells.orEmpty()
+
+        when (prompt.kind) {
+            InputKind.Brand -> {
+                // Already stocked: just walk into it rather than failing a
+                // duplicate write and stranding the user.
+                if (inventory.containsKey(trimmed)) {
+                    dismissPrompt()
+                    descendInto(ButtonConfig(id = "brand_$trimmed", label = trimmed))
+                    return
+                }
+                viewModelScope.launch {
+                    runCatching { bars.addBrand(barId, trimmed) }
+                        .onSuccess {
+                            dismissPrompt()
+                            descendInto(ButtonConfig(id = "brand_$trimmed", label = trimmed))
+                        }
+                        .onFailure {
+                            logWarning("Could not add brand", it)
+                            showMessage("Failed to add brand. Only managers can edit the beer inventory.")
+                        }
+                }
+            }
+
+            InputKind.Type -> {
+                val brand = prompt.parentBrand ?: return
+                if (inventory[brand]?.contains(trimmed) == true) {
+                    dismissPrompt()
+                    descendInto(
+                        ButtonConfig(id = "type_${brand}_$trimmed", label = trimmed),
+                    )
+                    return
+                }
+                viewModelScope.launch {
+                    runCatching { bars.addType(barId, brand, trimmed) }
+                        .onSuccess {
+                            dismissPrompt()
+                            descendInto(
+                                ButtonConfig(id = "type_${brand}_$trimmed", label = trimmed),
+                            )
+                        }
+                        .onFailure {
+                            logWarning("Could not add type", it)
+                            showMessage("Failed to add type. Only managers can edit the beer inventory.")
+                        }
+                }
+            }
+
+            InputKind.Well -> {
+                if (wells.contains(trimmed)) {
+                    dismissPrompt()
+                    submitRequest("ICE$LABEL_SEPARATOR$trimmed")
+                    clearNavStack()
+                    return
+                }
+                viewModelScope.launch {
+                    runCatching { bars.addWell(barId, trimmed) }
+                        .onSuccess {
+                            dismissPrompt()
+                            // Adding a well is only ever done because ice is
+                            // wanted there now, so the page goes out with it.
+                            submitRequest("ICE$LABEL_SEPARATOR$trimmed")
+                            clearNavStack()
+                        }
+                        .onFailure {
+                            logWarning("Could not add well", it)
+                            showMessage("Failed to add well. Only managers can edit wells.")
+                        }
+                }
+            }
+
+            InputKind.CustomRequest -> {
+                dismissPrompt()
+                submitRequest(trimmed)
+                clearNavStack()
+            }
+        }
+    }
+
+    /** Sends the chosen quantity appended to the trail that opened the stepper. */
+    fun submitQuantity(quantity: Int) {
+        val prompt = localState.value.quantityPrompt ?: return
+        dismissPrompt()
+        submitRequest("${prompt.contextLabel}$LABEL_SEPARATOR$quantity")
+        clearNavStack()
+    }
+
+    private fun descendInto(button: ButtonConfig) =
+        localState.update { it.copy(navStack = it.navStack + button) }
 
     fun navigateBack() = localState.update { it.copy(navStack = it.navStack.dropLast(1)) }
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.barbacker.ASK_ME_SUFFIX
 import com.hereliesaz.barbacker.INVITE_CHECK_TIMEOUT_MILLIS
+import com.hereliesaz.barbacker.Alerter
 import com.hereliesaz.barbacker.MAX_IGNORED_IDS
+import com.hereliesaz.barbacker.NAG_INTERVAL_MILLIS
 import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.REQUEST_WINDOW_MILLIS
 import com.hereliesaz.barbacker.REQUEST_WINDOW_REFRESH_MILLIS
@@ -24,10 +26,12 @@ import com.hereliesaz.barbacker.data.PLACE_SEARCH_DEBOUNCE_MILLIS
 import com.hereliesaz.barbacker.data.PLACE_SEARCH_MIN_LENGTH
 import com.hereliesaz.barbacker.data.PlaceResult
 import com.hereliesaz.barbacker.data.PlaceSearchRepository
+import com.hereliesaz.barbacker.data.PushTokenProvider
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.logWarning
 import com.hereliesaz.barbacker.logic.dynamicChildrenOf
+import com.hereliesaz.barbacker.logic.hasOutstandingAlerts
 import com.hereliesaz.barbacker.logic.requestLabelFor
 import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarRole
@@ -73,6 +77,8 @@ class AppViewModel(
     private val eightySix: EightySixRepository,
     private val ownershipClaims: OwnershipClaimRepository,
     private val placeSearch: PlaceSearchRepository,
+    private val pushTokens: PushTokenProvider,
+    private val alerter: Alerter,
     private val store: KeyValueStore,
 ) : ViewModel() {
 
@@ -238,6 +244,59 @@ class AppViewModel(
         watchForAutoClockIn()
         watchBarIdForChatReset()
         watchSearchQuery()
+        watchForPushRegistration()
+        startNagLoop()
+    }
+
+    /**
+     * Registers this device's push token once the member is active in a bar.
+     *
+     * Gated on ACTIVE rather than merely present: a pending member must not
+     * be paged for a bar that has not admitted them yet, and the rules
+     * would reject the write anyway.
+     *
+     * The matching de-registration lives in [goOffClock] and
+     * [MembershipRepository.leave] — deleting the token document is what
+     * actually stops the pages, and leaving it behind means the nag cron
+     * keeps waking a phone whose shift ended.
+     */
+    private fun watchForPushRegistration() {
+        viewModelScope.launch {
+            if (!pushTokens.isSupported) return@launch
+            combine(barIdFlow, uidFlow, barScope.map { it.membership?.status }) {
+                    barId, uid, status ->
+                Triple(barId, uid, status)
+            }.distinctUntilChanged().collect { (barId, uid, status) ->
+                if (barId == null || uid == null || status != MemberStatus.Active) {
+                    return@collect
+                }
+                val token = pushTokens.currentToken() ?: return@collect
+                runCatching { memberships.registerPushToken(barId, uid, token) }
+                    .onFailure { logWarning("Could not register the push token", it) }
+            }
+        }
+    }
+
+    /**
+     * Sounds an alert while un-muted pages are outstanding.
+     *
+     * This is the in-app half of paging, and it is what actually works on
+     * the tablet sitting open behind the bar — the case push handles worst.
+     * Muted requests are excluded, which is the whole point of muting; the
+     * loop would otherwise keep sounding for a page someone deliberately
+     * set aside.
+     */
+    private fun startNagLoop() {
+        viewModelScope.launch {
+            while (true) {
+                delay(NAG_INTERVAL_MILLIS)
+                val current = state.value
+                if (current.screen != Screen.Dashboard) continue
+                if (hasOutstandingAlerts(current.visibleRequests, current.ignoredIds)) {
+                    alerter.alert()
+                }
+            }
+        }
     }
 
     /**

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.kt
@@ -1,0 +1,28 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+import com.hereliesaz.barbacker.data.PickedImage
+
+/** Opens the platform's file chooser. Safe to call more than once. */
+fun interface ImagePickerLauncher {
+    fun launch()
+}
+
+/**
+ * A file chooser scoped to images, wired to the calling composable's
+ * lifetime.
+ *
+ * Cancelling calls neither callback: a user backing out of the chooser has
+ * not failed at anything, and a "no image selected" toast for a deliberate
+ * cancel is noise.
+ *
+ * [onError] carries a message meant for the user, not a log line — the
+ * three platforms fail differently (a revoked content Uri, an unreadable
+ * path, a format nobody accepts) and the caller shows whichever text
+ * arrives here.
+ */
+@Composable
+expect fun rememberImagePicker(
+    onPicked: (PickedImage) -> Unit,
+    onError: (String) -> Unit,
+): ImagePickerLauncher

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ReorderableGrid.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ReorderableGrid.kt
@@ -1,0 +1,287 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.grid.LazyGridItemInfo
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * How long a press has to hold still before it becomes a drag.
+ *
+ * Matched to the web client's `TouchSensor` activation delay. It is a
+ * deliberate trade: shorter and a bartender reaching across the bar sends
+ * a page they meant to drag; longer and reordering feels broken.
+ */
+private const val PICKUP_DELAY_MILLIS = 250L
+
+/** Pixels per frame of auto-scroll while dragging against an edge. */
+private const val AUTO_SCROLL_SPEED = 14f
+
+/** How close to an edge the finger has to be before the grid scrolls. */
+private const val AUTO_SCROLL_EDGE = 120f
+
+/**
+ * Drag-to-reorder for a [androidx.compose.foundation.lazy.grid.LazyVerticalGrid].
+ *
+ * The gesture is deliberately not built out of `detectDragGesturesAfterLongPress`
+ * plus a `clickable` tile. Those two land in the same gesture arena, and
+ * which one wins depends on whether the tile's click handler consumed the
+ * press first — so the drag either never starts or steals every tap,
+ * depending on Compose's version. Watching the **initial** pointer pass
+ * instead means this sees the press before the tile does, stays out of the
+ * way until the pickup delay elapses, and only then consumes — at which
+ * point the tile's own click handler and the grid's scroll both correctly
+ * see a cancelled gesture.
+ */
+@Stable
+class GridReorderState internal constructor(internal val gridState: LazyGridState) {
+
+    internal var onMove: (from: Int, to: Int) -> Unit = { _, _ -> }
+    internal var onCommit: () -> Unit = {}
+    internal var onCancel: () -> Unit = {}
+    internal var canReorder: (index: Int) -> Boolean = { true }
+
+    /** The key of the tile being dragged, or null. */
+    var draggingKey: Any? by mutableStateOf(null)
+        private set
+
+    private var draggingIndex = -1
+
+    /** Where inside the tile the finger landed, so it stays under it. */
+    private var grabOffset = Offset.Zero
+
+    /** Whether this drag has actually changed the order. */
+    private var moved = false
+
+    /** Pointer position in the grid's own coordinates. */
+    private var pointer by mutableStateOf(Offset.Zero)
+
+    internal val isDragging: Boolean get() = draggingKey != null
+
+    internal fun onDragStart(position: Offset) {
+        val item = itemAt(position) ?: return
+        if (!canReorder(item.index)) return
+        draggingKey = item.key
+        draggingIndex = item.index
+        grabOffset = position - item.offset.toOffset()
+        pointer = position
+        moved = false
+    }
+
+    internal fun onDrag(delta: Offset) {
+        if (!isDragging) return
+        pointer += delta
+        retarget()
+    }
+
+    /**
+     * Re-checks what the finger is over.
+     *
+     * Called on every pointer move and on every auto-scroll frame — while
+     * the grid scrolls under a stationary finger the tile beneath it keeps
+     * changing, and without this the drag would only ever swap when the
+     * user also moved.
+     */
+    internal fun retarget() {
+        if (!isDragging) return
+        val target = itemAt(pointer) ?: return
+        if (target.index == draggingIndex || !canReorder(target.index)) return
+        onMove(draggingIndex, target.index)
+        draggingIndex = target.index
+        moved = true
+    }
+
+    internal fun onDragEnd() {
+        val changed = moved
+        reset()
+        if (changed) onCommit()
+    }
+
+    /**
+     * A cancelled drag must not persist.
+     *
+     * The reorder has already been applied to the on-screen list as the
+     * finger moved, so the caller needs the callback to put it back —
+     * otherwise the grid keeps an order nobody saved, and the next remote
+     * snapshot would yank it back with no explanation.
+     */
+    internal fun onDragCancel() {
+        val changed = moved
+        reset()
+        if (changed) onCancel()
+    }
+
+    private fun reset() {
+        draggingKey = null
+        draggingIndex = -1
+        moved = false
+    }
+
+    /** Draw-phase offset for the tile with [key]; zero for every other tile. */
+    internal fun translationFor(key: Any): Offset {
+        if (key != draggingKey) return Offset.Zero
+        // Read fresh from the layout rather than cached at pickup: the grid
+        // can auto-scroll mid-drag, which moves the tile's slot while the
+        // finger stays put.
+        val info = gridState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == key }
+            ?: return Offset.Zero
+        return pointer - grabOffset - info.offset.toOffset()
+    }
+
+    /** Vertical scroll to apply this frame, or 0 when the finger is clear of the edges. */
+    internal fun autoScrollDelta(): Float {
+        if (!isDragging) return 0f
+        val height = gridState.layoutInfo.viewportSize.height
+        if (height <= 0) return 0f
+        return when {
+            pointer.y < AUTO_SCROLL_EDGE -> -AUTO_SCROLL_SPEED
+            pointer.y > height - AUTO_SCROLL_EDGE -> AUTO_SCROLL_SPEED
+            else -> 0f
+        }
+    }
+
+    private fun itemAt(position: Offset): LazyGridItemInfo? =
+        gridState.layoutInfo.visibleItemsInfo.firstOrNull { item ->
+            position.x >= item.offset.x &&
+                position.x <= item.offset.x + item.size.width &&
+                position.y >= item.offset.y &&
+                position.y <= item.offset.y + item.size.height
+        }
+}
+
+private fun androidx.compose.ui.unit.IntOffset.toOffset() = Offset(x.toFloat(), y.toFloat())
+
+/**
+ * @param onMove applies a swap to the list the grid is rendering. Called
+ *   many times per drag, as the finger crosses each tile.
+ * @param onCommit persists the order the drag settled on.
+ * @param onCancel restores the order from before the drag.
+ * @param canReorder whether the item at this index may be picked up or
+ *   displaced. The render-time tiles ("+ ADD …", CUSTOM) say no — see
+ *   [com.hereliesaz.barbacker.logic.SYNTHETIC_BUTTON_IDS].
+ */
+@Composable
+fun rememberGridReorderState(
+    gridState: LazyGridState,
+    onMove: (from: Int, to: Int) -> Unit,
+    onCommit: () -> Unit,
+    onCancel: () -> Unit,
+    canReorder: (index: Int) -> Boolean,
+): GridReorderState {
+    val state = remember(gridState) { GridReorderState(gridState) }
+
+    // The callbacks are re-read through rememberUpdatedState so a drag in
+    // flight uses the CURRENT list, not the one captured when the state
+    // object was first created.
+    val currentOnMove by rememberUpdatedState(onMove)
+    val currentOnCommit by rememberUpdatedState(onCommit)
+    val currentOnCancel by rememberUpdatedState(onCancel)
+    val currentCanReorder by rememberUpdatedState(canReorder)
+
+    state.onMove = { from, to -> currentOnMove(from, to) }
+    state.onCommit = { currentOnCommit() }
+    state.onCancel = { currentOnCancel() }
+    state.canReorder = { index -> currentCanReorder(index) }
+
+    LaunchedEffect(state, state.draggingKey) {
+        if (state.draggingKey == null) return@LaunchedEffect
+        while (true) {
+            val delta = state.autoScrollDelta()
+            if (delta != 0f) {
+                gridState.scrollBy(delta)
+                state.retarget()
+            }
+            withFrameNanos { }
+        }
+    }
+
+    return state
+}
+
+/** Attaches the pickup gesture. Apply to the grid itself, not to its items. */
+fun Modifier.reorderable(state: GridReorderState): Modifier =
+    this.pointerInput(state) {
+        awaitEachGesture {
+            // requireUnconsumed = false, on the initial pass: the tile's
+            // own click handler will consume this press, and we still need
+            // to see it.
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            val slop = viewConfiguration.touchSlop
+
+            // Timing out is the SUCCESS case here — it means the finger
+            // stayed down and still for the whole pickup delay. Any
+            // non-null result is a tap or the start of a scroll.
+            val abandoned = withTimeoutOrNull(PICKUP_DELAY_MILLIS) {
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Initial)
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: return@withTimeoutOrNull Unit
+                    if (!change.pressed) return@withTimeoutOrNull Unit
+                    if ((change.position - down.position).getDistance() > slop) {
+                        return@withTimeoutOrNull Unit
+                    }
+                }
+                @Suppress("UNREACHABLE_CODE")
+                Unit
+            }
+            if (abandoned != null) return@awaitEachGesture
+
+            state.onDragStart(down.position)
+            if (!state.isDragging) return@awaitEachGesture
+
+            var completed = true
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                val change = event.changes.firstOrNull { it.id == down.id }
+                if (change == null) {
+                    completed = false
+                    break
+                }
+                if (!change.pressed) {
+                    // The release is consumed too. A pickup that never
+                    // moved would otherwise still reach the tile's click
+                    // handler on the way up, so holding a tile for a
+                    // moment and letting go would page the floor.
+                    change.consume()
+                    break
+                }
+                state.onDrag(change.positionChange())
+                // Consumed in the initial pass so neither the tile's click
+                // handler nor the grid's own scroll acts on the same move.
+                change.consume()
+            }
+
+            if (completed) state.onDragEnd() else state.onDragCancel()
+        }
+    }
+
+/** Attaches the lift-and-follow rendering. Apply to each item, keyed as the grid keys it. */
+fun Modifier.reorderableItem(state: GridReorderState, key: Any): Modifier =
+    this.zIndex(if (state.draggingKey == key) 1f else 0f)
+        .graphicsLayer {
+            val offset = state.translationFor(key)
+            translationX = offset.x
+            translationY = offset.y
+            if (state.draggingKey == key) {
+                scaleX = 1.05f
+                scaleY = 1.05f
+                alpha = 0.9f
+            }
+        }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarManagerDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BarManagerDialog.kt
@@ -1,0 +1,333 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.text.KeyboardOptions
+import com.hereliesaz.barbacker.data.InvitableRole
+import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.ui.iconForName
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/**
+ * Manager tooling for one bar: which tiles the floor sees, and who else
+ * gets in.
+ *
+ * Hiding is a soft delete — the button keeps its usage counts and its
+ * place in any saved order, and comes back untouched if it is restored.
+ * Restoring is premium-gated, which is why the confirmation says so
+ * plainly rather than presenting hiding as reversible.
+ */
+@Composable
+fun BarManagerDialog(
+    barName: String,
+    allButtons: List<ButtonConfig>,
+    hiddenButtonIds: Set<String>,
+    isPremium: Boolean,
+    isManagerPlus: Boolean,
+    onHideButton: (String) -> Unit,
+    onUnhideButton: (String) -> Unit,
+    onInvite: suspend (email: String, role: InvitableRole) -> Result<Unit>,
+    onClose: () -> Unit,
+) {
+    var confirmHideId by remember { mutableStateOf<String?>(null) }
+
+    val activeButtons = allButtons.filterNot { it.id in hiddenButtonIds }
+    val hiddenButtons = allButtons.filter { it.id in hiddenButtonIds }
+
+    BarBackerDialog(
+        title = "Manage $barName",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Hiding a button removes it from every device at this " +
+                    "bar. Its history stays in the database.",
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 280.dp)
+                    .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp)),
+            ) {
+                if (activeButtons.isEmpty()) {
+                    Text(
+                        text = "No active buttons.",
+                        color = BarBackerColors.OnSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    )
+                } else {
+                    LazyColumn {
+                        items(activeButtons, key = { it.id }) { button ->
+                            ManagedButtonRow(
+                                button = button,
+                                // Manager+ only: writes to the bar document
+                                // are rejected for anyone else, so a visible
+                                // control here would only ever produce a
+                                // confusing "failed, try again".
+                                action = if (isManagerPlus) {
+                                    ManagedButtonAction(
+                                        icon = Icons.Filled.Close,
+                                        description = "Remove ${button.label}",
+                                        onClick = { confirmHideId = button.id },
+                                    )
+                                } else {
+                                    null
+                                },
+                            )
+                            HorizontalDivider(color = BarBackerColors.Outline)
+                        }
+                    }
+                }
+            }
+
+            if (isManagerPlus) {
+                InviteForm(onInvite = onInvite)
+            }
+
+            if (isManagerPlus && isPremium && hiddenButtons.isNotEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 200.dp)
+                        .border(1.dp, BarBackerColors.Error, RoundedCornerShape(8.dp)),
+                ) {
+                    Text(
+                        text = "RESTORABLE BUTTONS (PREMIUM)",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = BarBackerColors.Error,
+                        letterSpacing = 1.sp,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BarBackerColors.Error.copy(alpha = 0.12f))
+                            .padding(8.dp),
+                    )
+                    LazyColumn {
+                        items(hiddenButtons, key = { it.id }) { button ->
+                            ManagedButtonRow(
+                                button = button,
+                                action = ManagedButtonAction(
+                                    icon = Icons.Filled.Restore,
+                                    description = "Restore ${button.label}",
+                                    onClick = { onUnhideButton(button.id) },
+                                ),
+                            )
+                            HorizontalDivider(color = BarBackerColors.Outline)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    confirmHideId?.let { id ->
+        AlertDialog(
+            onDismissRequest = { confirmHideId = null },
+            title = { Text("Remove Button?") },
+            text = {
+                Text(
+                    "It will disappear from every device at this bar, and " +
+                        "restoring it requires Premium.",
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onHideButton(id)
+                        confirmHideId = null
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BarBackerColors.Error,
+                        contentColor = BarBackerColors.OnError,
+                    ),
+                ) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmHideId = null }) { Text("Cancel") }
+            },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+private data class ManagedButtonAction(
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val description: String,
+    val onClick: () -> Unit,
+)
+
+@Composable
+private fun ManagedButtonRow(button: ButtonConfig, action: ManagedButtonAction?) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = iconForName(button.icon),
+            contentDescription = null,
+            tint = BarBackerColors.OnSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Text(
+            text = button.label,
+            color = BarBackerColors.OnSurface,
+            modifier = Modifier.weight(1f),
+        )
+        if (action != null) {
+            IconButton(onClick = action.onClick) {
+                Icon(
+                    imageVector = action.icon,
+                    contentDescription = action.description,
+                    tint = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InviteForm(onInvite: suspend (String, InvitableRole) -> Result<Unit>) {
+    var email by remember { mutableStateOf("") }
+    var role by remember { mutableStateOf(InvitableRole.Staff) }
+    var sending by remember { mutableStateOf(false) }
+    var message by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "INVITE STAFF",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = BarBackerColors.OnSurfaceVariant,
+            letterSpacing = 1.sp,
+        )
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = {
+                email = it
+                message = null
+            },
+            label = { Text("Email") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Email,
+                // Autocapitalisation would fight the lowercasing the
+                // invite lookup depends on, and look like a typo besides.
+                capitalization = KeyboardCapitalization.None,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            InvitableRole.entries.forEach { option ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.selectable(
+                        selected = role == option,
+                        onClick = { role = option },
+                    ),
+                ) {
+                    RadioButton(selected = role == option, onClick = { role = option })
+                    Text(option.wire, color = BarBackerColors.OnSurface)
+                }
+            }
+        }
+
+        Button(
+            onClick = {
+                val address = email.trim()
+                if (address.isEmpty() || sending) return@Button
+                sending = true
+                message = null
+                scope.launch {
+                    onInvite(address, role)
+                        .onSuccess {
+                            email = ""
+                            message = "Invite sent to ${address.lowercase()}."
+                        }
+                        .onFailure { message = "Failed to send invite. Please try again." }
+                    sending = false
+                }
+            },
+            enabled = email.isNotBlank() && !sending,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (sending) "Sending..." else "Send Invite")
+        }
+
+        message?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+        }
+
+        Text(
+            text = "They're added automatically the next time they open this " +
+                "bar while signed in with that email.",
+            fontSize = 10.sp,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -25,6 +26,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -34,8 +36,10 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Store
 import androidx.compose.material.icons.filled.SyncAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -66,10 +70,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.barbacker.logic.isButtonPending
+import com.hereliesaz.barbacker.logic.isReorderable
+import com.hereliesaz.barbacker.logic.moveItem
+import com.hereliesaz.barbacker.logic.persistableOrder
 import com.hereliesaz.barbacker.model.ButtonConfig
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.ui.AppUiState
 import com.hereliesaz.barbacker.ui.iconForName
+import com.hereliesaz.barbacker.ui.rememberGridReorderState
+import com.hereliesaz.barbacker.ui.reorderable
+import com.hereliesaz.barbacker.ui.reorderableItem
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 import com.hereliesaz.barbacker.ui.theme.LocalBarAccent
 
@@ -86,8 +96,12 @@ data class DashboardActions(
     val onOpenChat: () -> Unit,
     val onOpenEightySix: () -> Unit,
     val onOpenNotificationSettings: () -> Unit,
+    val onOpenBarManager: () -> Unit,
+    val onOpenThemeEditor: () -> Unit,
     val onSwitchBar: () -> Unit,
     val onGoOffClock: () -> Unit,
+    /** The ids of the current grid context, in the order a drag settled on. */
+    val onReorder: (List<String>) -> Unit,
 )
 
 @Composable
@@ -99,7 +113,19 @@ fun DashboardScreen(state: AppUiState, actions: DashboardActions) {
             PinnedMarquee(pinned = state.pinnedMessages, onClick = actions.onOpenChat)
 
             Box(modifier = Modifier.weight(1f)) {
-                ButtonGrid(state = state, onButtonTapped = actions.onButtonTapped)
+                ButtonGrid(
+                    buttons = state.currentButtons,
+                    // Gated rather than left to fail: `customOrders` lives
+                    // on the bar document, which firestore.rules restricts
+                    // to Manager+. The web client lets anyone drag and
+                    // alerts on the rejected write; a gesture that does
+                    // nothing is better than one that appears to work and
+                    // then silently reverts.
+                    canReorder = state.isManagerPlus,
+                    pendingFor = { isButtonPending(it.label, state.visibleRequests) },
+                    onButtonTapped = actions.onButtonTapped,
+                    onReorder = actions.onReorder,
+                )
 
                 // Drawn over the grid rather than replacing it, so the
                 // breadcrumb reads as a drill-down and backing out does not
@@ -208,6 +234,27 @@ private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
                         actions.onOpenNotificationSettings()
                     },
                 )
+                DropdownMenuItem(
+                    text = { Text("Manage Bar") },
+                    leadingIcon = { Icon(Icons.Filled.Store, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        actions.onOpenBarManager()
+                    },
+                )
+                // Premium branding, Manager+ only — matching the web
+                // client, where a Staff member has no write access to the
+                // bar document the theme lives on.
+                if (state.isPremium && state.isManagerPlus) {
+                    DropdownMenuItem(
+                        text = { Text("Customize Theme") },
+                        leadingIcon = { Icon(Icons.Filled.Palette, contentDescription = null) },
+                        onClick = {
+                            menuOpen = false
+                            actions.onOpenThemeEditor()
+                        },
+                    )
+                }
                 HorizontalDivider(color = BarBackerColors.Outline)
                 DropdownMenuItem(
                     text = { Text("Switch Bar") },
@@ -233,27 +280,68 @@ private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
     HorizontalDivider(color = BarBackerColors.Outline)
 }
 
+/**
+ * The tile grid, drag-to-reorder included.
+ *
+ * [dragOrder] holds the arrangement the finger is currently describing.
+ * While it is non-null it wins over [buttons], so each swap is visible the
+ * moment the finger crosses a tile; on commit it is handed to
+ * [onReorder] and dropped, and the view model's optimistic copy of the new
+ * order takes over from there.
+ */
 @Composable
-private fun ButtonGrid(state: AppUiState, onButtonTapped: (ButtonConfig) -> Unit) {
+private fun ButtonGrid(
+    buttons: List<ButtonConfig>,
+    canReorder: Boolean,
+    pendingFor: (ButtonConfig) -> Boolean,
+    onButtonTapped: (ButtonConfig) -> Unit,
+    onReorder: (List<String>) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(16.dp),
+) {
+    val gridState = rememberLazyGridState()
+    var dragOrder by remember { mutableStateOf<List<ButtonConfig>?>(null) }
+    val rendered = dragOrder ?: buttons
+
+    val reorderState = rememberGridReorderState(
+        gridState = gridState,
+        onMove = { from, to -> dragOrder = (dragOrder ?: buttons).moveItem(from, to) },
+        onCommit = {
+            dragOrder?.let { onReorder(persistableOrder(it)) }
+            dragOrder = null
+        },
+        // Nothing is written, and dropping the local arrangement puts the
+        // grid straight back to whatever the bar document says.
+        onCancel = { dragOrder = null },
+        canReorder = { index -> rendered.getOrNull(index)?.isReorderable() == true },
+    )
+
     LazyVerticalGrid(
+        state = gridState,
         columns = GridCells.Fixed(2),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+        contentPadding = contentPadding,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.then(if (canReorder) Modifier.reorderable(reorderState) else Modifier),
     ) {
-        items(state.currentButtons, key = { it.id }) { button ->
+        items(rendered, key = { it.id }) { button ->
             ButtonTile(
                 button = button,
-                pending = isButtonPending(button.label, state.visibleRequests),
+                pending = pendingFor(button),
                 onClick = { onButtonTapped(button) },
+                modifier = Modifier.reorderableItem(reorderState, button.id),
             )
         }
     }
 }
 
 @Composable
-private fun ButtonTile(button: ButtonConfig, pending: Boolean, onClick: () -> Unit) {
+private fun ButtonTile(
+    button: ButtonConfig,
+    pending: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val accent = LocalBarAccent.current
 
     // The pulse is the whole point of the pending state: a bartender
@@ -273,7 +361,7 @@ private fun ButtonTile(button: ButtonConfig, pending: Boolean, onClick: () -> Un
         colors = CardDefaults.cardColors(
             containerColor = if (pending) BarBackerColors.Error else accent.tile,
         ),
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(120.dp)
             .alpha(if (pending) pulse else 1f),
@@ -351,20 +439,18 @@ private fun SubMenuOverlay(state: AppUiState, actions: DashboardActions) {
 
             HorizontalDivider(color = BarBackerColors.Outline, modifier = Modifier.padding(vertical = 12.dp))
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+            // Sub-menus are reorderable too, and each keeps its own order —
+            // `customOrders` is keyed by context id, so the wells under ICE
+            // sort independently of the main grid.
+            ButtonGrid(
+                buttons = state.currentButtons,
+                canReorder = state.isManagerPlus,
+                pendingFor = { false },
+                onButtonTapped = actions.onButtonTapped,
+                onReorder = actions.onReorder,
+                contentPadding = PaddingValues(0.dp),
                 modifier = Modifier.heightIn(max = 420.dp),
-            ) {
-                items(state.currentButtons, key = { it.id }) { button ->
-                    ButtonTile(
-                        button = button,
-                        pending = false,
-                        onClick = { actions.onButtonTapped(button) },
-                    )
-                }
-            }
+            )
 
             Spacer(Modifier.height(12.dp))
             OutlinedButton(

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/PromptDialogs.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/PromptDialogs.kt
@@ -1,0 +1,184 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.ui.InputPrompt
+import com.hereliesaz.barbacker.ui.QuantityPrompt
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+
+/**
+ * Collects free text for the synthesised "+ ADD …" and CUSTOM tiles.
+ *
+ * Suggestions are tap-to-fill rather than a closed picker: the field stays
+ * free-text so a bar can stock something the built-in list has never heard
+ * of, which is most of them.
+ */
+@Composable
+fun InputPromptDialog(
+    prompt: InputPrompt,
+    onSubmit: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var value by remember(prompt) { mutableStateOf(prompt.initialValue) }
+
+    val matching = remember(value, prompt.suggestions) {
+        if (value.isBlank()) {
+            prompt.suggestions.take(8)
+        } else {
+            prompt.suggestions
+                .filter { it.contains(value, ignoreCase = true) && !it.equals(value, true) }
+                .take(8)
+        }
+    }
+
+    BarBackerDialog(
+        title = prompt.title,
+        onDismiss = onDismiss,
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(
+                onClick = { onSubmit(value) },
+                enabled = value.isNotBlank(),
+            ) { Text("Add") }
+        },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it },
+                label = { Text(prompt.label) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (matching.isNotEmpty()) {
+                Text(
+                    text = "SUGGESTIONS",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+                LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 220.dp)) {
+                    items(matching, key = { it }) { suggestion ->
+                        Text(
+                            text = suggestion,
+                            color = BarBackerColors.OnSurface,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { value = suggestion }
+                                .padding(vertical = 10.dp, horizontal = 8.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A numeric stepper for the "Other" quantity option under a beer type.
+ *
+ * Stepper rather than a text field: the answer is nearly always a small
+ * number, and this is tapped on a tablet by someone holding a bottle in
+ * their other hand.
+ */
+@Composable
+fun QuantityPromptDialog(
+    prompt: QuantityPrompt,
+    onSubmit: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var quantity by remember(prompt) { mutableStateOf(1) }
+
+    BarBackerDialog(
+        title = "Select Quantity",
+        onDismiss = onDismiss,
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(onClick = { onSubmit(quantity) }) { Text("Send") }
+        },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (prompt.contextLabel.isNotBlank()) {
+                Text(
+                    text = prompt.contextLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 12.dp),
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                modifier = Modifier.padding(vertical = 12.dp),
+            ) {
+                FilledTonalIconButton(
+                    // Floors at one: zero of something is not a request.
+                    onClick = { quantity = maxOf(1, quantity - 1) },
+                    enabled = quantity > 1,
+                ) {
+                    Icon(Icons.Filled.Remove, contentDescription = "One fewer")
+                }
+
+                Text(
+                    text = quantity.toString(),
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = BarBackerColors.Primary,
+                    modifier = Modifier
+                        .background(
+                            BarBackerColors.SecondaryContainer,
+                            RoundedCornerShape(12.dp),
+                        )
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+
+                FilledTonalIconButton(onClick = { quantity += 1 }) {
+                    Icon(Icons.Filled.Add, contentDescription = "One more")
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ThemeEditorDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ThemeEditorDialog.kt
@@ -1,0 +1,419 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.text.KeyboardOptions
+import com.hereliesaz.barbacker.data.PickedImage
+import com.hereliesaz.barbacker.logic.contrastColorFor
+import com.hereliesaz.barbacker.model.BarTheme
+import com.hereliesaz.barbacker.ui.rememberImagePicker
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import com.hereliesaz.barbacker.ui.theme.parseHexColor
+import kotlinx.coroutines.launch
+
+/** The stock pair, and what "Reset" goes back to. */
+private const val DEFAULT_PRIMARY = "#FFFFFF"
+private const val DEFAULT_ACCENT = "#1E1E1E"
+private const val DEFAULT_FONT = "system-ui, sans-serif"
+
+/**
+ * The same four options the web client offers, stored as the CSS stack it
+ * writes, so a font chosen in either client survives a round trip through
+ * the other. What this client can actually render from them is narrower —
+ * see `familyFor` in Theme.kt.
+ */
+private val FONT_OPTIONS = listOf(
+    "System Default" to DEFAULT_FONT,
+    "Roboto" to "Roboto, sans-serif",
+    "Inter" to "Inter, sans-serif",
+    "Playfair Display" to "\"Playfair Display\", serif",
+)
+
+/**
+ * A palette to tap, since there is no platform colour picker in Compose
+ * Multiplatform and a hex field alone is a poor way to choose a colour on
+ * a phone behind a bar. The field stays, for a brand colour that has to be
+ * exact.
+ */
+private val SWATCHES = listOf(
+    "#FFFFFF", "#000000", "#1E1E1E", "#EF4444",
+    "#F97316", "#EAB308", "#22C55E", "#3B82F6",
+    "#8B5CF6", "#EC4899", "#14B8A6", "#A16207",
+)
+
+/**
+ * Premium branding for one bar.
+ *
+ * The preview is not decoration — it is the only place the accent colour
+ * and its derived label colour appear together before the change reaches
+ * every device on the floor.
+ */
+@Composable
+fun ThemeEditorDialog(
+    currentTheme: BarTheme?,
+    onSave: suspend (BarTheme) -> Result<Unit>,
+    onUploadLogo: suspend (PickedImage) -> Result<String>,
+    onClose: () -> Unit,
+) {
+    var primaryColor by remember { mutableStateOf(currentTheme?.primaryColor ?: DEFAULT_PRIMARY) }
+    var accentColor by remember { mutableStateOf(currentTheme?.accentColor ?: DEFAULT_ACCENT) }
+    var fontFamily by remember { mutableStateOf(currentTheme?.fontFamily ?: DEFAULT_FONT) }
+    var logoUrl by remember { mutableStateOf(currentTheme?.logoUrl) }
+    var uploading by remember { mutableStateOf(false) }
+    var saving by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var confirmReset by remember { mutableStateOf(false) }
+
+    val scope = rememberCoroutineScope()
+
+    val pickLogo = rememberImagePicker(
+        onPicked = { image ->
+            uploading = true
+            error = null
+            scope.launch {
+                onUploadLogo(image)
+                    .onSuccess { logoUrl = it }
+                    .onFailure { error = "Failed to upload the logo." }
+                uploading = false
+            }
+        },
+        onError = { error = it },
+    )
+
+    fun save(theme: BarTheme, thenClose: Boolean) {
+        if (saving) return
+        saving = true
+        error = null
+        scope.launch {
+            onSave(theme)
+                .onSuccess { if (thenClose) onClose() }
+                .onFailure { error = "Failed to save the theme. Please try again." }
+            saving = false
+        }
+    }
+
+    BarBackerDialog(
+        title = "Customize Theme",
+        onDismiss = onClose,
+        actions = {
+            TextButton(onClick = { confirmReset = true }, enabled = !saving) { Text("Reset") }
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = onClose) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(
+                onClick = {
+                    save(
+                        BarTheme(
+                            primaryColor = primaryColor,
+                            accentColor = accentColor,
+                            // Omitted rather than written as null when
+                            // there is no logo — `firestore.rules` uses
+                            // hasOnly(), and an explicit null is a
+                            // different shape from an absent key.
+                            logoUrl = logoUrl,
+                            fontFamily = fontFamily,
+                        ),
+                        thenClose = true,
+                    )
+                },
+                enabled = !saving && !uploading,
+            ) {
+                Text(if (saving) "Saving..." else "Save")
+            }
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 460.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            ColorField(
+                label = "Primary Color",
+                hint = "Headings and filled buttons",
+                value = primaryColor,
+                onValueChange = { primaryColor = it },
+            )
+
+            ColorField(
+                label = "Accent Color",
+                hint = "The request tiles themselves",
+                value = accentColor,
+                onValueChange = { accentColor = it },
+            )
+
+            FontPicker(selected = fontFamily, onSelect = { fontFamily = it })
+
+            LogoRow(
+                logoUrl = logoUrl,
+                uploading = uploading,
+                onUpload = { pickLogo.launch() },
+                onRemove = { logoUrl = null },
+            )
+
+            ThemePreview(
+                primaryColor = primaryColor,
+                accentColor = accentColor,
+                hasLogo = logoUrl != null,
+            )
+
+            error?.let {
+                Text(
+                    text = it,
+                    color = BarBackerColors.Error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+
+    if (confirmReset) {
+        AlertDialog(
+            onDismissRequest = { confirmReset = false },
+            title = { Text("Reset theme?") },
+            text = { Text("This removes all custom branding, including the logo.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        confirmReset = false
+                        primaryColor = DEFAULT_PRIMARY
+                        accentColor = DEFAULT_ACCENT
+                        fontFamily = DEFAULT_FONT
+                        logoUrl = null
+                        // Saved immediately rather than left staged: a
+                        // "Reset" that only clears the form and still needs
+                        // a Save reads as already done.
+                        save(
+                            BarTheme(
+                                primaryColor = DEFAULT_PRIMARY,
+                                accentColor = DEFAULT_ACCENT,
+                            ),
+                            thenClose = true,
+                        )
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BarBackerColors.Error,
+                        contentColor = BarBackerColors.OnError,
+                    ),
+                ) { Text("Reset") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmReset = false }) { Text("Cancel") }
+            },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+@Composable
+private fun ColorField(
+    label: String,
+    hint: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(label, color = BarBackerColors.OnSurface)
+                Text(
+                    text = hint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .background(
+                        parseHexColor(value) ?: BarBackerColors.SurfaceContainerHigh,
+                        RoundedCornerShape(6.dp),
+                    )
+                    .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(6.dp)),
+            )
+        }
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text("Hex") },
+            singleLine = true,
+            isError = parseHexColor(value) == null,
+            // Hex digits are case-insensitive, but auto-capitalising the
+            // whole field turns "#fff" into "#Fff" mid-typing, which looks
+            // like the field is fighting you.
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            SWATCHES.take(6).forEach { swatch -> Swatch(swatch, onValueChange) }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            SWATCHES.drop(6).forEach { swatch -> Swatch(swatch, onValueChange) }
+        }
+    }
+}
+
+@Composable
+private fun Swatch(hex: String, onPick: (String) -> Unit) {
+    Box(
+        modifier = Modifier
+            .size(28.dp)
+            .background(parseHexColor(hex) ?: Color.Transparent, CircleShape)
+            .border(1.dp, BarBackerColors.Outline, CircleShape)
+            .clickable { onPick(hex) },
+    )
+}
+
+@Composable
+private fun FontPicker(selected: String, onSelect: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    val label = FONT_OPTIONS.firstOrNull { it.second == selected }?.first ?: "Custom"
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text("Font", color = BarBackerColors.OnSurface, modifier = Modifier.weight(1f))
+        Box {
+            OutlinedButton(onClick = { expanded = true }) { Text(label) }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                FONT_OPTIONS.forEach { (name, stack) ->
+                    DropdownMenuItem(
+                        text = { Text(name) },
+                        onClick = {
+                            expanded = false
+                            onSelect(stack)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogoRow(
+    logoUrl: String?,
+    uploading: Boolean,
+    onUpload: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Logo", color = BarBackerColors.OnSurface)
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedButton(onClick = onUpload, enabled = !uploading) {
+                Text(if (uploading) "Uploading..." else if (logoUrl == null) "Upload" else "Replace")
+            }
+            if (logoUrl != null && !uploading) {
+                TextButton(onClick = onRemove) { Text("Remove") }
+            }
+        }
+
+        // The URL rather than the image: rendering a remote image needs an
+        // image-loading library this build does not carry, and showing a
+        // broken frame would be worse than showing the address of the file
+        // that was actually uploaded.
+        Text(
+            text = logoUrl ?: "No logo set.",
+            style = MaterialTheme.typography.bodySmall,
+            color = BarBackerColors.OnSurfaceVariant,
+            maxLines = 2,
+        )
+        Text(
+            text = "PNG, JPG, WebP, or SVG. Max 2MB.",
+            fontSize = 10.sp,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ThemePreview(primaryColor: String, accentColor: String, hasLogo: Boolean) {
+    val tile = parseHexColor(accentColor) ?: BarBackerColors.SecondaryContainer
+    // Derived exactly as BarBackerTheme derives it, so what is previewed
+    // here is what the floor will see rather than an approximation.
+    val tileLabel = parseHexColor(contrastColorFor(accentColor)) ?: BarBackerColors.OnSurface
+    val primary = parseHexColor(primaryColor) ?: BarBackerColors.Primary
+    val onPrimary = parseHexColor(contrastColorFor(primaryColor)) ?: BarBackerColors.OnPrimary
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "PREVIEW",
+            style = MaterialTheme.typography.labelSmall,
+            color = BarBackerColors.OnSurfaceVariant,
+            letterSpacing = 1.sp,
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(tile, RoundedCornerShape(6.dp))
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (hasLogo) {
+                Box(modifier = Modifier.size(24.dp).background(tileLabel, CircleShape))
+            }
+            Text("ICE", color = tileLabel, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = {},
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = primary,
+                    contentColor = onPrimary,
+                ),
+            ) { Text("Filled") }
+            OutlinedButton(onClick = {}) { Text("Outlined", color = primary) }
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/theme/Theme.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/theme/Theme.kt
@@ -3,15 +3,16 @@ package com.hereliesaz.barbacker.ui.theme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.barbacker.logic.contrastColorFor
 import com.hereliesaz.barbacker.model.BarTheme
-import kotlin.math.pow
 
 /**
  * The stock palette, ported from the Material 3 dark tokens in
@@ -83,10 +84,9 @@ private val BarBackerColorScheme = darkColorScheme(
  * Colours a premium bar can override.
  *
  * Exposed as a composition local rather than folded into the
- * [MaterialTheme] scheme because these are not semantic M3 roles — they
- * are two specific surfaces (the grid tile and its label) that a venue
- * brands, and mapping them onto `primary`/`secondary` would repaint
- * unrelated controls.
+ * [MaterialTheme] scheme because the label colour is not a semantic M3
+ * role — it is a derived value, computed from the tile it sits on, and
+ * there is nowhere in a `ColorScheme` that means that.
  */
 data class BarAccent(
     val tile: Color,
@@ -109,6 +109,15 @@ val LocalBarAccent = staticCompositionLocalOf { BarAccent.Default }
  * deliberate: a bar that lapses out of premium must revert to stock
  * colours rather than keep displaying branding it no longer pays for, and
  * its saved theme stays on the document so re-subscribing restores it.
+ *
+ * Which colour lands where is not a free choice — the same theme document
+ * is read by the PWA, and the two clients sit on the same bar. Matching
+ * `useBarTheme.ts` exactly:
+ *  - `accentColor` is the grid tile background (`secondaryContainer`), and
+ *    the label on it is whichever of black/white is readable. Never the
+ *    other brand colour: a red brand on a red tile is invisible.
+ *  - `primaryColor` is the M3 `primary` role — headings, filled buttons —
+ *    with its own contrast colour as `onPrimary`.
  */
 @Composable
 fun BarBackerTheme(
@@ -116,28 +125,82 @@ fun BarBackerTheme(
     isPremium: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val accent = if (isPremium && barTheme != null) {
-        val tile = parseHexColor(barTheme.primaryColor) ?: BarBackerColors.SecondaryContainer
-        // The label colour is not the bar's accent taken at face value —
-        // it is whichever of black/white is actually readable on the tile.
-        // Honouring an arbitrary accent here is how you end up with a
-        // dark-red label on a dark-red tile.
-        val label = parseHexColor(barTheme.accentColor)
-            ?.takeIf { hasSufficientContrast(it, tile) }
-            ?: Color(parseHex(contrastColorFor(barTheme.primaryColor)))
-        BarAccent(tile = tile, label = label)
-    } else {
-        BarAccent.Default
-    }
+    val themed = barTheme.takeIf { isPremium }
+
+    val accent = themed?.let {
+        val tile = parseHexColor(it.accentColor) ?: return@let null
+        BarAccent(tile = tile, label = Color(parseHex(contrastColorFor(it.accentColor))))
+    } ?: BarAccent.Default
+
+    val colorScheme = themed?.let {
+        val primary = parseHexColor(it.primaryColor)
+        BarBackerColorScheme.copy(
+            primary = primary ?: BarBackerColorScheme.primary,
+            onPrimary = if (primary != null) {
+                Color(parseHex(contrastColorFor(it.primaryColor)))
+            } else {
+                BarBackerColorScheme.onPrimary
+            },
+            secondaryContainer = accent.tile,
+            onSecondaryContainer = accent.label,
+        )
+    } ?: BarBackerColorScheme
 
     CompositionLocalProvider(LocalBarAccent provides accent) {
         MaterialTheme(
-            colorScheme = BarBackerColorScheme,
+            colorScheme = colorScheme,
             shapes = BarBackerShapes,
+            typography = typographyFor(themed?.fontFamily),
             content = content,
         )
     }
 }
+
+/**
+ * Maps a stored CSS font stack onto the closest generic family.
+ *
+ * The web client stores an actual CSS `font-family` string, so the value
+ * has to round-trip untouched or a manager who set a font in one client
+ * would see it silently rewritten by the other. What this cannot do is
+ * render Inter or Playfair Display faithfully — neither is bundled — so a
+ * serif stack becomes the platform serif and everything else the platform
+ * default. Dropping a real font resource in here is the only change
+ * needed to make it exact.
+ */
+private fun familyFor(fontFamily: String?): FontFamily = when {
+    fontFamily == null -> FontFamily.Default
+    fontFamily.contains("serif", ignoreCase = true) &&
+        !fontFamily.contains("sans-serif", ignoreCase = true) -> FontFamily.Serif
+    fontFamily.contains("monospace", ignoreCase = true) -> FontFamily.Monospace
+    else -> FontFamily.Default
+}
+
+@Composable
+private fun typographyFor(fontFamily: String?): Typography {
+    val family = familyFor(fontFamily)
+    if (family == FontFamily.Default) return DefaultTypography
+    return with(DefaultTypography) {
+        Typography(
+            displayLarge = displayLarge.copy(fontFamily = family),
+            displayMedium = displayMedium.copy(fontFamily = family),
+            displaySmall = displaySmall.copy(fontFamily = family),
+            headlineLarge = headlineLarge.copy(fontFamily = family),
+            headlineMedium = headlineMedium.copy(fontFamily = family),
+            headlineSmall = headlineSmall.copy(fontFamily = family),
+            titleLarge = titleLarge.copy(fontFamily = family),
+            titleMedium = titleMedium.copy(fontFamily = family),
+            titleSmall = titleSmall.copy(fontFamily = family),
+            bodyLarge = bodyLarge.copy(fontFamily = family),
+            bodyMedium = bodyMedium.copy(fontFamily = family),
+            bodySmall = bodySmall.copy(fontFamily = family),
+            labelLarge = labelLarge.copy(fontFamily = family),
+            labelMedium = labelMedium.copy(fontFamily = family),
+            labelSmall = labelSmall.copy(fontFamily = family),
+        )
+    }
+}
+
+private val DefaultTypography = Typography()
 
 /** Parses `#RGB`, `#RRGGBB`, or the same without the hash. Null if unparseable. */
 internal fun parseHexColor(hex: String): Color? {
@@ -148,26 +211,12 @@ internal fun parseHexColor(hex: String): Color? {
     return Color(0xFF000000L or value)
 }
 
+/**
+ * Parses a value already known to be a valid hex colour.
+ *
+ * Only ever fed the output of [contrastColorFor], which returns `#FFFFFF`
+ * or `#000000` — the zero fallback is unreachable in practice and exists
+ * so a future caller cannot make this throw.
+ */
 private fun parseHex(hex: String): Long =
     0xFF000000L or (hex.removePrefix("#").toLongOrNull(16) ?: 0L)
-
-/**
- * WCAG contrast ratio of at least 4.5:1, the threshold for body text.
- * Used to reject a branded label colour that would be unreadable on the
- * branded tile rather than rendering it anyway.
- */
-internal fun hasSufficientContrast(foreground: Color, background: Color): Boolean {
-    val lf = relativeLuminance(foreground)
-    val lb = relativeLuminance(background)
-    val lighter = maxOf(lf, lb)
-    val darker = minOf(lf, lb)
-    return (lighter + 0.05) / (darker + 0.05) >= 4.5
-}
-
-private fun relativeLuminance(color: Color): Double {
-    fun channel(c: Float): Double {
-        val v = c.toDouble()
-        return if (v <= 0.03928) v / 12.92 else ((v + 0.055) / 1.055).pow(2.4)
-    }
-    return 0.2126 * channel(color.red) + 0.7152 * channel(color.green) + 0.0722 * channel(color.blue)
-}

--- a/cmp/composeApp/src/desktopMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.desktop.kt
+++ b/cmp/composeApp/src/desktopMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.desktop.kt
@@ -1,0 +1,88 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import com.hereliesaz.barbacker.data.LOGO_EXTENSIONS
+import com.hereliesaz.barbacker.data.MAX_LOGO_BYTES
+import com.hereliesaz.barbacker.data.pickedImageOrNull
+import com.hereliesaz.barbacker.data.PickedImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.swing.JFileChooser
+import javax.swing.filechooser.FileNameExtensionFilter
+
+@Composable
+actual fun rememberImagePicker(
+    onPicked: (PickedImage) -> Unit,
+    onError: (String) -> Unit,
+): ImagePickerLauncher {
+    val scope = rememberCoroutineScope()
+    val picked by rememberUpdatedState(onPicked)
+    val failed by rememberUpdatedState(onError)
+
+    return remember(scope) {
+        ImagePickerLauncher {
+            scope.launch {
+                // showOpenDialog is modal and must run on the AWT event
+                // thread. Compose Desktop's own frame lives there too, so
+                // dispatching explicitly is what keeps the chooser from
+                // deadlocking against it when this is called from a
+                // background context.
+                val file = withContext(Dispatchers.Swing) { chooseImageFile() }
+                    ?: return@launch
+
+                val outcome = withContext(Dispatchers.IO) {
+                    runCatching {
+                        // Length first: reading a multi-gigabyte file the
+                        // user picked by mistake would exhaust the heap
+                        // before any size check downstream could fire.
+                        if (file.length() > MAX_LOGO_BYTES) null else file.readBytes()
+                    }
+                }
+
+                outcome.fold(
+                    onSuccess = { bytes ->
+                        when {
+                            bytes == null -> failed("Logo must be under 2MB.")
+                            else -> {
+                                val image = pickedImageOrNull(bytes, file.name, contentType = null)
+                                if (image == null) {
+                                    failed("Logo must be a PNG, JPG, WebP, or SVG.")
+                                } else {
+                                    picked(image)
+                                }
+                            }
+                        }
+                    },
+                    onFailure = { failed("Could not read ${file.name}.") },
+                )
+            }
+        }
+    }
+}
+
+/** Returns the chosen file, or null if the user cancelled. */
+private fun chooseImageFile(): File? {
+    val chooser = JFileChooser().apply {
+        dialogTitle = "Choose a logo"
+        isMultiSelectionEnabled = false
+        // Set as the *only* filter, with "All files" suppressed, so the
+        // list the user sees matches what the upload will actually accept.
+        isAcceptAllFileFilterUsed = false
+        fileFilter = FileNameExtensionFilter(
+            "Images (PNG, JPG, WebP, SVG)",
+            *LOGO_EXTENSIONS.toTypedArray(),
+        )
+    }
+    return if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+        chooser.selectedFile
+    } else {
+        null
+    }
+}

--- a/cmp/composeApp/src/iosMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.ios.kt
+++ b/cmp/composeApp/src/iosMain/kotlin/com/hereliesaz/barbacker/ui/ImagePicker.ios.kt
@@ -1,0 +1,137 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import com.hereliesaz.barbacker.data.MAX_LOGO_BYTES
+import com.hereliesaz.barbacker.data.PickedImage
+import com.hereliesaz.barbacker.data.pickedImageOrNull
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSURL
+import platform.Foundation.dataWithContentsOfURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIDocumentPickerDelegateProtocol
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIViewController
+import platform.UniformTypeIdentifiers.UTTypeImage
+import platform.darwin.NSObject
+import platform.posix.memcpy
+
+/**
+ * A document picker limited to images.
+ *
+ * `UIDocumentPickerViewController` rather than a photo picker on purpose:
+ * a bar's logo is usually a file someone was emailed, not a camera roll
+ * entry, and the document picker hands back the original bytes and file
+ * name — which is what keeps an SVG an SVG.
+ *
+ * Unverified. There is no Xcode project in this repository yet (see
+ * `cmp/iosApp/README.md`) and CI has no macOS runner, so this file has
+ * never been compiled. Treat it as a first draft of the iOS path, not as
+ * something known to work.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun rememberImagePicker(
+    onPicked: (PickedImage) -> Unit,
+    onError: (String) -> Unit,
+): ImagePickerLauncher {
+    val picked by rememberUpdatedState(onPicked)
+    val failed by rememberUpdatedState(onError)
+
+    // UIKit holds its delegate weakly, so this reference is what keeps the
+    // object alive between presenting the picker and the callback. Held in
+    // `remember` rather than a local, or it would be collected the instant
+    // the composition that created it settles.
+    val delegate = remember { LogoPickerDelegate() }
+
+    DisposableEffect(delegate) {
+        delegate.onPick = { url ->
+            when (val result = readLogo(url)) {
+                is IosReadResult.Ok -> picked(result.image)
+                is IosReadResult.Failed -> failed(result.message)
+            }
+        }
+        onDispose { delegate.onPick = {} }
+    }
+
+    return remember(delegate) {
+        ImagePickerLauncher {
+            val host = topViewController()
+            if (host == null) {
+                failed("Could not open the file picker.")
+                return@ImagePickerLauncher
+            }
+            val controller = UIDocumentPickerViewController(
+                forOpeningContentTypes = listOf(UTTypeImage),
+                // A copy in the app's own sandbox, so the bytes stay
+                // readable after the picker's security scope closes.
+                asCopy = true,
+            )
+            controller.delegate = delegate
+            host.presentViewController(controller, animated = true, completion = null)
+        }
+    }
+}
+
+private class LogoPickerDelegate : NSObject(), UIDocumentPickerDelegateProtocol {
+    var onPick: (NSURL) -> Unit = {}
+
+    override fun documentPicker(
+        controller: UIDocumentPickerViewController,
+        didPickDocumentsAtURLs: List<*>,
+    ) {
+        val url = didPickDocumentsAtURLs.firstOrNull() as? NSURL ?: return
+        onPick(url)
+    }
+
+    // Cancelling calls nothing: backing out of a picker is not a failure.
+    override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) = Unit
+}
+
+private sealed interface IosReadResult {
+    data class Ok(val image: PickedImage) : IosReadResult
+    data class Failed(val message: String) : IosReadResult
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun readLogo(url: NSURL): IosReadResult {
+    val data = NSData.dataWithContentsOfURL(url)
+        ?: return IosReadResult.Failed("Could not read that image.")
+    if (data.length.toLong() > MAX_LOGO_BYTES) {
+        return IosReadResult.Failed("Logo must be under 2MB.")
+    }
+    val image = pickedImageOrNull(
+        bytes = data.toByteArray(),
+        fileName = url.lastPathComponent,
+        contentType = null,
+    ) ?: return IosReadResult.Failed("Logo must be a PNG, JPG, WebP, or SVG.")
+    return IosReadResult.Ok(image)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    if (size == 0) return ByteArray(0)
+    return ByteArray(size).apply {
+        usePinned { pinned -> memcpy(pinned.addressOf(0), bytes, length) }
+    }
+}
+
+/**
+ * The controller to present from: the deepest one already presenting
+ * something, so the picker does not try to open behind a dialog that is
+ * already up.
+ */
+private fun topViewController(): UIViewController? {
+    var controller = UIApplication.sharedApplication.keyWindow?.rootViewController
+    while (controller?.presentedViewController != null) {
+        controller = controller.presentedViewController
+    }
+    return controller
+}

--- a/cmp/gradle/libs.versions.toml
+++ b/cmp/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ lifecycle = "2.9.4"
 # setContent; there is no multiplatform equivalent because the entry
 # point is inherently per-platform.
 androidxActivity = "1.9.3"
+# ContextCompat, for the Android 13+ notification permission check.
+androidxCore = "1.13.1"
 
 # GitLive's Firebase KMP wrappers. Publishes android/ios/jvm/js/macos
 # targets — notably NOT wasmJs, which is why the web build stays on the
@@ -45,6 +47,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 
 lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
@@ -53,6 +56,7 @@ firebase-auth = { module = "dev.gitlive:firebase-auth", version.ref = "gitliveFi
 firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = "gitliveFirebase" }
 firebase-storage = { module = "dev.gitlive:firebase-storage", version.ref = "gitliveFirebase" }
 firebase-functions = { module = "dev.gitlive:firebase-functions", version.ref = "gitliveFirebase" }
+firebase-messaging = { module = "dev.gitlive:firebase-messaging", version.ref = "gitliveFirebase" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/cmp/shared/build.gradle.kts
+++ b/cmp/shared/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             api(libs.firebase.firestore)
             implementation(libs.firebase.storage)
             implementation(libs.firebase.functions)
+            implementation(libs.firebase.messaging)
 
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)

--- a/cmp/shared/build.gradle.kts
+++ b/cmp/shared/build.gradle.kts
@@ -42,7 +42,11 @@ kotlin {
             // permission denial from a network failure.
             api(libs.firebase.auth)
             api(libs.firebase.firestore)
-            implementation(libs.firebase.storage)
+            // `api` for the same reason as auth and firestore:
+            // BarBackerFirebase exposes the FirebaseStorage instance, and
+            // callers need to catch FirebaseStorageException to tell a
+            // rejected upload apart from a dropped connection.
+            api(libs.firebase.storage)
             implementation(libs.firebase.functions)
             implementation(libs.firebase.messaging)
 

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/Alerter.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/Alerter.android.kt
@@ -1,0 +1,55 @@
+package com.hereliesaz.barbacker
+
+import android.content.Context
+import android.media.RingtoneManager
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+/** The pattern the web client uses: buzz, pause, buzz. */
+private val VIBRATION_PATTERN = longArrayOf(0, 500, 200, 500)
+
+private class AndroidAlerter(private val context: Context) : Alerter {
+
+    override fun alert() {
+        playNotificationSound()
+        vibrate()
+    }
+
+    private fun playNotificationSound() {
+        try {
+            val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+            RingtoneManager.getRingtone(context, uri)?.play()
+        } catch (e: Exception) {
+            // Never let an alert failure propagate — the loop that calls
+            // this runs forever, and one bad ringtone lookup should not
+            // end it.
+            logWarning("Could not play the alert sound", e)
+        }
+    }
+
+    private fun vibrate() {
+        try {
+            val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val manager =
+                    context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager
+                manager?.defaultVibrator
+            } else {
+                @Suppress("DEPRECATION")
+                context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+            } ?: return
+
+            if (!vibrator.hasVibrator()) return
+            vibrator.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, -1))
+        } catch (e: Exception) {
+            logWarning("Could not vibrate", e)
+        }
+    }
+}
+
+actual fun createAlerter(platformContext: Any?): Alerter {
+    val context = platformContext as? Context
+        ?: error("An Android Context is required to create the alerter")
+    return AndroidAlerter(context.applicationContext)
+}

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.android.kt
@@ -1,0 +1,29 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.messaging.messaging
+
+private class AndroidPushTokenProvider : PushTokenProvider {
+    override val isSupported: Boolean = true
+
+    override suspend fun currentToken(): String? = try {
+        Firebase.messaging.getToken()
+    } catch (e: Exception) {
+        // A missing token is recoverable — Play Services may be absent or
+        // updating — and must not block clocking in.
+        logWarning("Could not obtain an FCM token", e)
+        null
+    }
+
+    override suspend fun deleteToken() {
+        try {
+            Firebase.messaging.deleteToken()
+        } catch (e: Exception) {
+            logWarning("Could not delete the FCM token", e)
+        }
+    }
+}
+
+actual fun createPushTokenProvider(platformContext: Any?): PushTokenProvider =
+    AndroidPushTokenProvider()

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.android.kt
@@ -1,0 +1,5 @@
+package com.hereliesaz.barbacker.data
+
+import dev.gitlive.firebase.storage.Data
+
+internal actual fun storageDataOf(bytes: ByteArray): Data = Data(bytes)

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Alerter.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Alerter.kt
@@ -1,0 +1,15 @@
+package com.hereliesaz.barbacker
+
+/**
+ * Makes the device demand attention.
+ *
+ * This is the in-app half of paging, and it matters most exactly where
+ * push is weakest: a tablet sitting on the back bar with the app open, in
+ * a room too loud for a notification chime alone. Sound AND vibration
+ * together, because either one alone is missable in a working bar.
+ */
+interface Alerter {
+    fun alert()
+}
+
+expect fun createAlerter(platformContext: Any?): Alerter

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -1,5 +1,8 @@
 package com.hereliesaz.barbacker.data
 
+import com.hereliesaz.barbacker.Alerter
+import com.hereliesaz.barbacker.createAlerter
+
 /**
  * Wires the repositories to a live Firebase project.
  *
@@ -11,6 +14,8 @@ package com.hereliesaz.barbacker.data
 class AppContainer(
     firebase: BarBackerFirebase,
     val store: KeyValueStore,
+    /** The Android `Context`; null elsewhere. */
+    platformContext: Any? = null,
 ) {
     val auth: AuthRepository = FirebaseAuthRepository(firebase.auth)
     val bars: BarRepository = FirebaseBarRepository(firebase.firestore)
@@ -29,4 +34,7 @@ class AppContainer(
 
     val placeSearch: PlaceSearchRepository =
         DefaultPlaceSearchRepository(firebase.firestore, httpClient)
+
+    val pushTokens: PushTokenProvider = createPushTokenProvider(platformContext)
+    val alerter: Alerter = createAlerter(platformContext)
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -25,6 +25,7 @@ class AppContainer(
     val eightySix: EightySixRepository = FirebaseEightySixRepository(firebase.firestore)
     val ownershipClaims: OwnershipClaimRepository =
         FirebaseOwnershipClaimRepository(firebase.firestore, firebase.functions)
+    val storage: StorageRepository = FirebaseStorageRepository(firebase.storage)
 
     /**
      * One client for the whole process. Ktor clients own a connection pool

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
@@ -10,6 +10,8 @@ import dev.gitlive.firebase.firestore.firestore
 import dev.gitlive.firebase.functions.FirebaseFunctions
 import dev.gitlive.firebase.functions.functions
 import dev.gitlive.firebase.initialize
+import dev.gitlive.firebase.storage.FirebaseStorage
+import dev.gitlive.firebase.storage.storage
 
 /**
  * The Firebase project this build talks to.
@@ -52,6 +54,7 @@ class BarBackerFirebase private constructor(
     val auth: FirebaseAuth,
     val firestore: FirebaseFirestore,
     val functions: FirebaseFunctions,
+    val storage: FirebaseStorage,
 ) {
     companion object {
         /**
@@ -71,6 +74,7 @@ class BarBackerFirebase private constructor(
                 // client's getFunctions(app) points and where the
                 // callables are actually deployed.
                 functions = Firebase.functions(app),
+                storage = Firebase.storage(app),
             )
         }
     }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarRepository.kt
@@ -183,6 +183,13 @@ class FirebaseBarRepository(private val firestore: FirebaseFirestore) : BarRepos
 
     override suspend fun saveTheme(barId: String, theme: BarTheme) {
         firestore.document(Paths.bar(barId)).updateFields {
+            // The whole `theme` map is replaced, so an absent logoUrl
+            // genuinely removes the logo — which is what "Remove" in the
+            // editor has to mean. Without this the key would be written as
+            // an explicit null, and the two clients would disagree about
+            // whether a bar has a logo depending on which one cleared it.
+            encodeDefaults = false
+
             Fields.THEME to ThemeWrite(
                 primaryColor = theme.primaryColor,
                 accentColor = theme.accentColor,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/MembershipRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/MembershipRepository.kt
@@ -14,6 +14,22 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
 
+/**
+ * The roles an invite is allowed to grant.
+ *
+ * A separate type from [BarRole] rather than a runtime check, because the
+ * omission here is the point: an invite that named `Owner` would have
+ * `onInviteConsumed` hand ownership to whoever opened the bar next, with
+ * no review step and no way back short of a database edit.
+ */
+enum class InvitableRole(val role: BarRole) {
+    Staff(BarRole.Staff),
+    Manager(BarRole.Manager),
+    ;
+
+    val wire: String get() = role.wire
+}
+
 /** The account-level document: which bars you belong to, and your ntfy topic. */
 data class AccountProfile(
     val joinedBarIds: List<String> = emptyList(),
@@ -66,6 +82,24 @@ interface MembershipRepository {
     suspend fun clearPushToken(barId: String, uid: String)
 
     /**
+     * Creates an invite so [email] is admitted at [role] the next time they
+     * open this bar.
+     *
+     * [role] is deliberately not a [BarRole]: an invite can grant Staff or
+     * Manager, never Owner. Ownership moves through the claim workflow,
+     * which needs a human review step — an invite is a one-line write any
+     * Manager can make, and `onInviteConsumed` grants whatever role the
+     * document names.
+     */
+    suspend fun sendInvite(
+        barId: String,
+        email: String,
+        role: InvitableRole,
+        createdBy: String,
+        createdByName: String,
+    )
+
+    /**
      * Consumes an unconsumed invite for [email], if one exists.
      *
      * Only flips the invite; the membership document is written by the
@@ -97,6 +131,16 @@ class FirebaseMembershipRepository(
     private data class PushTokenWrite(
         val token: String,
         val updated: Timestamp.ServerTimestamp,
+    )
+
+    @Serializable
+    private data class InviteCreate(
+        val email: String,
+        val role: String,
+        val createdBy: String,
+        val createdByName: String,
+        val createdAt: Timestamp.ServerTimestamp,
+        val consumed: Boolean,
     )
 
     @Serializable
@@ -236,6 +280,29 @@ class FirebaseMembershipRepository(
 
     override suspend fun clearPushToken(barId: String, uid: String) {
         firestore.document(Paths.barToken(barId, uid)).delete()
+    }
+
+    override suspend fun sendInvite(
+        barId: String,
+        email: String,
+        role: InvitableRole,
+        createdBy: String,
+        createdByName: String,
+    ) {
+        firestore.collection(Paths.barInvites(barId)).add(
+            InviteCreate(
+                // Stored lowercase, because the lookup in
+                // consumePendingInvite is an exact equality match — an
+                // invite typed as "Sam@Example.com" would otherwise sit
+                // there unconsumable forever, looking sent.
+                email = email.trim().lowercase(),
+                role = role.wire,
+                createdBy = createdBy,
+                createdByName = createdByName,
+                createdAt = Timestamp.ServerTimestamp,
+                consumed = false,
+            ),
+        )
     }
 
     override suspend fun consumePendingInvite(barId: String, email: String, uid: String): Boolean {

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Paths.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Paths.kt
@@ -48,8 +48,17 @@ object Paths {
     fun bottlePhoto(barId: String, uid: String, epochMillis: Long) =
         "bottlePhotos/$barId/${uid}_$epochMillis.jpg"
 
-    /** Storage object path for a premium bar's logo. */
-    fun barLogo(barId: String, fileName: String) = "barLogos/$barId/$fileName"
+    /**
+     * Storage object path for a premium bar's logo.
+     *
+     * `bars/`, not `barLogos/`, and the file name must start with `logo.`
+     * — `storage.rules` matches `/bars/{barId}/{fileName}` and then
+     * re-narrows `fileName` with `matches('logo\\..+')`. Anything outside
+     * that shape has no matching rule at all, and Storage denies by
+     * default, so a near-miss here fails as a flat permission error with
+     * nothing pointing at the path.
+     */
+    fun barLogo(barId: String, extension: String) = "bars/$barId/logo.$extension"
 }
 
 /** Firestore field names, so a typo fails at one site rather than silently. */
@@ -81,4 +90,7 @@ object Fields {
     const val CLAIMED_AT = "claimedAt"
     const val LAST_SEEN = "lastSeen"
     const val THEME = "theme"
+    const val CREATED_BY = "createdBy"
+    const val CREATED_BY_NAME = "createdByName"
+    const val CREATED_AT = "createdAt"
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.kt
@@ -1,0 +1,29 @@
+package com.hereliesaz.barbacker.data
+
+/**
+ * This device's push registration.
+ *
+ * A token is per-device, not per-account: registering it under
+ * `bars/{barId}/tokens/{uid}` is what makes the server-side fanout and the
+ * five-minute nag cron able to reach this phone. Deleting it is how going
+ * off clock actually stops the pages — without that, a device keeps being
+ * paged for a bar whose shift ended hours ago.
+ */
+interface PushTokenProvider {
+    /**
+     * Whether this platform can receive push at all.
+     *
+     * False on desktop: there is no FCM transport for a JVM app, so the
+     * in-app alert loop is the only thing that will fire there. Callers
+     * check this rather than treating a null token as an error.
+     */
+    val isSupported: Boolean
+
+    /** The current registration token, or null if unavailable. */
+    suspend fun currentToken(): String?
+
+    /** Drops the registration, so the server stops targeting this device. */
+    suspend fun deleteToken()
+}
+
+expect fun createPushTokenProvider(platformContext: Any?): PushTokenProvider

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.kt
@@ -1,0 +1,130 @@
+package com.hereliesaz.barbacker.data
+
+import dev.gitlive.firebase.storage.Data
+import dev.gitlive.firebase.storage.FirebaseStorage
+import dev.gitlive.firebase.storage.storageMetadata
+
+/**
+ * An image the user chose, already read into memory.
+ *
+ * Bytes rather than a platform file handle: the three platforms disagree
+ * about what a "file" is (a content `Uri`, a `java.io.File`, an `NSURL`
+ * behind a security scope), and none of those survives being handed to
+ * shared code. Logos are capped at [MAX_LOGO_BYTES] anyway, so holding one
+ * in memory costs nothing.
+ */
+class PickedImage(
+    val bytes: ByteArray,
+    /** Lowercase extension with no dot, e.g. `png`. */
+    val extension: String,
+    val contentType: String,
+) {
+    val sizeBytes: Int get() = bytes.size
+}
+
+/** Mirrors the web client's 2MB check; `storage.rules` enforces it too. */
+const val MAX_LOGO_BYTES: Int = 2 * 1024 * 1024
+
+/**
+ * Extension to MIME type for the formats a logo may be in.
+ *
+ * The storage rule only checks `image/.*`, so this list is a product
+ * decision rather than a security boundary — it matches the `accept`
+ * attribute on the web client's file input so the two clients take the
+ * same files.
+ */
+private val LOGO_TYPES: Map<String, String> = mapOf(
+    "png" to "image/png",
+    "jpg" to "image/jpeg",
+    "jpeg" to "image/jpeg",
+    "webp" to "image/webp",
+    "svg" to "image/svg+xml",
+)
+
+/**
+ * The canonical extension per MIME type — `image/jpeg` resolves to `jpg`,
+ * not `jpeg`, so two uploads of the same photo overwrite each other
+ * instead of leaving an orphan behind.
+ */
+private val LOGO_EXTENSIONS_BY_TYPE: Map<String, String> = mapOf(
+    "image/png" to "png",
+    "image/jpeg" to "jpg",
+    "image/webp" to "webp",
+    "image/svg+xml" to "svg",
+)
+
+val LOGO_EXTENSIONS: Set<String> get() = LOGO_TYPES.keys
+
+/**
+ * Builds a [PickedImage] from whatever identity the platform picker
+ * returned — a file name on desktop and iOS, a MIME type on Android,
+ * sometimes both and sometimes neither.
+ *
+ * The file name is consulted first: a picker that reports
+ * `application/octet-stream` for a `.png` is common, whereas a file named
+ * `.png` that is not one is the user's problem and Storage will still
+ * accept it. Returns null when neither names an accepted format, which the
+ * caller turns into a message rather than an upload that fails later with
+ * a permission error.
+ */
+fun pickedImageOrNull(
+    bytes: ByteArray,
+    fileName: String?,
+    contentType: String?,
+): PickedImage? {
+    val fromName = fileName
+        ?.substringAfterLast('.', missingDelimiterValue = "")
+        ?.lowercase()
+        ?.takeIf { it in LOGO_TYPES }
+
+    val normalisedType = contentType?.substringBefore(';')?.trim()?.lowercase()
+    val extension = fromName ?: LOGO_EXTENSIONS_BY_TYPE[normalisedType] ?: return null
+
+    return PickedImage(
+        bytes = bytes,
+        extension = extension,
+        // Derived from the extension rather than passed through: the
+        // storage rule matches on contentType, and the picker's value is
+        // the less reliable of the two.
+        contentType = LOGO_TYPES.getValue(extension),
+    )
+}
+
+interface StorageRepository {
+    /**
+     * Uploads a premium bar's logo and returns its download URL.
+     *
+     * @throws IllegalArgumentException if the image is too large or not an
+     *   accepted type. Checked here rather than only at the call site so a
+     *   later caller cannot skip it — Storage would reject the write
+     *   anyway, but as an opaque permission error.
+     */
+    suspend fun uploadBarLogo(barId: String, image: PickedImage): String
+}
+
+class FirebaseStorageRepository(private val storage: FirebaseStorage) : StorageRepository {
+
+    override suspend fun uploadBarLogo(barId: String, image: PickedImage): String {
+        require(image.sizeBytes <= MAX_LOGO_BYTES) { "Logo must be under 2MB." }
+        require(image.extension in LOGO_TYPES) { "Logo must be a PNG, JPG, WebP, or SVG." }
+
+        val reference = storage.reference(Paths.barLogo(barId, image.extension))
+        reference.putData(
+            data = storageDataOf(image.bytes),
+            // Set explicitly rather than left to the SDK's guess: the
+            // storage rule checks `contentType.matches('image/.*')`, and an
+            // upload that arrives as application/octet-stream is rejected.
+            metadata = storageMetadata { contentType = image.contentType },
+        )
+        return reference.getDownloadUrl()
+    }
+}
+
+/**
+ * Wraps raw bytes in the Firebase SDK's platform payload type.
+ *
+ * `Data` is an `expect class` with a different constructor on every target
+ * — `ByteArray` on the JVM and Android, `NSData` on Apple — and no common
+ * one, so this cannot be written once in shared code.
+ */
+internal expect fun storageDataOf(bytes: ByteArray): Data

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/ButtonLogic.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/ButtonLogic.kt
@@ -3,9 +3,11 @@ package com.hereliesaz.barbacker.logic
 import com.hereliesaz.barbacker.ADD_BRAND_BUTTON
 import com.hereliesaz.barbacker.ADD_TYPE_BUTTON
 import com.hereliesaz.barbacker.ADD_WELL_BUTTON
+import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
 import com.hereliesaz.barbacker.DEFAULT_BUTTONS
 import com.hereliesaz.barbacker.LABEL_SEPARATOR
 import com.hereliesaz.barbacker.QUANTITY_BUTTONS
+import com.hereliesaz.barbacker.model.ButtonAction
 import com.hereliesaz.barbacker.model.ButtonConfig
 
 /**
@@ -134,6 +136,58 @@ fun dynamicChildrenOf(
     button.id.startsWith("type_") -> QUANTITY_BUTTONS
 
     else -> button.children
+}
+
+/**
+ * What tapping a grid tile should actually do.
+ *
+ * Worth naming rather than deciding inline, because the default — submit a
+ * page labelled after the tile — is WRONG for five of these and wrong in a
+ * way that looks like it works: tapping "+ ADD WELL" without this
+ * classification pages the whole floor asking for "ICE: + ADD WELL".
+ */
+sealed interface ButtonTap {
+    /** Open the sub-menu this tile leads to. */
+    data object Descend : ButtonTap
+
+    /** Send a page for the trail ending at this tile. */
+    data object Submit : ButtonTap
+
+    /** Ask for a new beer brand. */
+    data object PromptForBrand : ButtonTap
+
+    /** Ask for a new type under the brand currently open. */
+    data object PromptForType : ButtonTap
+
+    /** Ask for a new well name. */
+    data object PromptForWell : ButtonTap
+
+    /** Ask how many, for the beer type currently open. */
+    data object PromptForQuantity : ButtonTap
+
+    /** Ask for free text to send as a one-off. */
+    data object PromptForCustomRequest : ButtonTap
+}
+
+/**
+ * Decides what a tap on [button] means.
+ *
+ * The synthesised tiles are checked BEFORE the children lookup: they all
+ * have no children, so anything reaching the children check would fall
+ * through to [ButtonTap.Submit].
+ */
+fun classifyTap(
+    button: ButtonConfig,
+    wells: List<String>,
+    beerInventory: Map<String, List<String>>,
+): ButtonTap = when {
+    button.id == ADD_WELL_BUTTON.id -> ButtonTap.PromptForWell
+    button.action == ButtonAction.AddBrand -> ButtonTap.PromptForBrand
+    button.action == ButtonAction.AddType -> ButtonTap.PromptForType
+    button.action == ButtonAction.CustomQuantity -> ButtonTap.PromptForQuantity
+    button.id == CUSTOM_REQUEST_BUTTON.id -> ButtonTap.PromptForCustomRequest
+    dynamicChildrenOf(button, wells, beerInventory).isNotEmpty() -> ButtonTap.Descend
+    else -> ButtonTap.Submit
 }
 
 /**

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/Reorder.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/Reorder.kt
@@ -1,0 +1,65 @@
+package com.hereliesaz.barbacker.logic
+
+import com.hereliesaz.barbacker.ADD_BRAND_BUTTON
+import com.hereliesaz.barbacker.ADD_TYPE_BUTTON
+import com.hereliesaz.barbacker.ADD_WELL_BUTTON
+import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
+import com.hereliesaz.barbacker.model.ButtonConfig
+
+/**
+ * Moves the element at [from] to [to], sliding everything in between.
+ *
+ * The web client gets this from dnd-kit's `arrayMove`. Writing it out here
+ * keeps the reorder gesture's result testable without a UI toolkit, which
+ * matters because the off-by-one directions differ — dragging down lands
+ * *after* the target, dragging up lands *before* it — and that is exactly
+ * the sort of thing that only shows up as "the button ends up one slot
+ * wrong" on a real device.
+ *
+ * Out-of-range indices return the list unchanged rather than throwing: a
+ * drag can outlive the list it started on (a remote snapshot arrives
+ * mid-gesture and drops a button), and a crash is a far worse outcome than
+ * a reorder that quietly does nothing.
+ */
+fun <T> List<T>.moveItem(from: Int, to: Int): List<T> {
+    if (from == to) return this
+    if (from !in indices || to !in indices) return this
+    val out = toMutableList()
+    out.add(to, out.removeAt(from))
+    return out
+}
+
+/**
+ * Tiles that exist only at render time and must never be written into a
+ * saved order.
+ *
+ * These four are appended by the grid itself rather than read from the bar
+ * document, and their position is fixed by the code that synthesises them
+ * — [CUSTOM_REQUEST_BUTTON] is pinned last on the main grid, and each
+ * `+ ADD …` tile is pinned last in the sub-menu it belongs to. Letting one
+ * be dragged would persist an id whose position is then ignored, so the
+ * button would visibly snap back on the next snapshot.
+ *
+ * Not included: `well_*`, `brand_*`, and `type_*` tiles. Those are also
+ * synthesised, from the bar's own wells and inventory, but their order is
+ * a genuine manager preference and [sortButtons] honours it.
+ */
+val SYNTHETIC_BUTTON_IDS: Set<String> = setOf(
+    CUSTOM_REQUEST_BUTTON.id,
+    ADD_WELL_BUTTON.id,
+    ADD_BRAND_BUTTON.id,
+    ADD_TYPE_BUTTON.id,
+)
+
+/** Whether this tile may take part in a drag-to-reorder gesture. */
+fun ButtonConfig.isReorderable(): Boolean = id !in SYNTHETIC_BUTTON_IDS
+
+/**
+ * The order to persist after a drag, with the render-time tiles stripped.
+ *
+ * Stripping happens on the way to Firestore rather than before the drag so
+ * the on-screen indices the gesture works in stay aligned with what is
+ * actually rendered.
+ */
+fun persistableOrder(buttons: List<ButtonConfig>): List<String> =
+    buttons.filter { it.isReorderable() }.map { it.id }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/RequestFilter.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/RequestFilter.kt
@@ -49,6 +49,20 @@ fun visibleRequests(
     .sortedBy { it.id in ignoredIds }
 
 /**
+ * Whether the in-app alert loop should sound.
+ *
+ * Muted requests are excluded, which is the entire point of muting — the
+ * loop repeats every minute, so a page someone deliberately set aside
+ * would otherwise keep making noise until it was resolved by someone else.
+ *
+ * Note this differs from [visibleRequests], which keeps muted entries
+ * (sorted last) so they stay countable and recoverable. Visible and
+ * alert-worthy are genuinely different questions.
+ */
+fun hasOutstandingAlerts(visible: List<Request>, ignoredIds: Set<String>): Boolean =
+    visible.any { it.id !in ignoredIds }
+
+/**
  * Whether a grid tile should render its pending/pulsing state.
  *
  * A prefix match, so a page for "GARNISH: LIMES" lights up the GARNISH

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/PickedImageTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/PickedImageTest.kt
@@ -1,0 +1,66 @@
+package com.hereliesaz.barbacker.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PickedImageTest {
+
+    private val bytes = ByteArray(4)
+
+    @Test
+    fun resolves_from_a_file_name() {
+        val image = pickedImageOrNull(bytes, "logo.PNG", contentType = null)
+        assertEquals("png", image?.extension)
+        assertEquals("image/png", image?.contentType)
+    }
+
+    @Test
+    fun resolves_from_a_mime_type_when_there_is_no_file_name() {
+        val image = pickedImageOrNull(bytes, fileName = null, contentType = "image/webp")
+        assertEquals("webp", image?.extension)
+        assertEquals("image/webp", image?.contentType)
+    }
+
+    /**
+     * Android's picker routinely reports `application/octet-stream` for a
+     * perfectly good PNG, so a recognised file name has to win.
+     */
+    @Test
+    fun a_recognised_file_name_beats_a_useless_mime_type() {
+        val image = pickedImageOrNull(bytes, "brand.png", "application/octet-stream")
+        assertEquals("png", image?.extension)
+        assertEquals("image/png", image?.contentType)
+    }
+
+    /**
+     * Both uploads must land on the SAME object, or picking a `.jpeg`
+     * after a `.jpg` leaves the old logo orphaned in the bucket while the
+     * bar document points at the new one.
+     */
+    @Test
+    fun jpeg_and_jpg_both_declare_image_jpeg() {
+        assertEquals("image/jpeg", pickedImageOrNull(bytes, "a.jpg", null)?.contentType)
+        assertEquals("image/jpeg", pickedImageOrNull(bytes, "a.jpeg", null)?.contentType)
+        assertEquals("jpg", pickedImageOrNull(bytes, null, "image/jpeg")?.extension)
+    }
+
+    @Test
+    fun a_mime_type_with_parameters_still_resolves() {
+        assertEquals("png", pickedImageOrNull(bytes, null, "image/png; charset=binary")?.extension)
+    }
+
+    @Test
+    fun an_unusable_identity_resolves_to_null() {
+        assertNull(pickedImageOrNull(bytes, "notes.pdf", "application/pdf"))
+        assertNull(pickedImageOrNull(bytes, fileName = null, contentType = null))
+        assertNull(pickedImageOrNull(bytes, "no-extension-at-all", null))
+    }
+
+    @Test
+    fun gif_is_rejected_even_though_storage_rules_would_take_it() {
+        // The rule only checks `image/.*`; the web client's file input does
+        // not offer GIF, and the two clients have to accept the same set.
+        assertNull(pickedImageOrNull(bytes, "loop.gif", "image/gif"))
+    }
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/ButtonLogicTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/ButtonLogicTest.kt
@@ -1,6 +1,11 @@
 package com.hereliesaz.barbacker.logic
 
+import com.hereliesaz.barbacker.ADD_BRAND_BUTTON
+import com.hereliesaz.barbacker.ADD_TYPE_BUTTON
+import com.hereliesaz.barbacker.ADD_WELL_BUTTON
+import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
 import com.hereliesaz.barbacker.DEFAULT_BUTTONS
+import com.hereliesaz.barbacker.QUANTITY_BUTTONS
 import com.hereliesaz.barbacker.model.ButtonAction
 import com.hereliesaz.barbacker.model.ButtonConfig
 import kotlin.test.Test
@@ -237,6 +242,83 @@ class DynamicChildrenTest {
     @Test
     fun a_leaf_returns_nothing() {
         assertTrue(dynamicChildrenOf(ButtonConfig("lime", "LIMES"), emptyList(), emptyMap()).isEmpty())
+    }
+}
+
+class ClassifyTapTest {
+
+    private val inventory = mapOf("Corona" to listOf("Bottle"))
+    private val wells = listOf("Well #1")
+
+    private fun classify(button: ButtonConfig) = classifyTap(button, wells, inventory)
+
+    @Test
+    fun a_parent_tile_descends() {
+        val garnish = DEFAULT_BUTTONS.first { it.id == "fruit" }
+        assertEquals(ButtonTap.Descend, classify(garnish))
+    }
+
+    @Test
+    fun a_leaf_submits() {
+        assertEquals(ButtonTap.Submit, classify(ButtonConfig("lime", "LIMES")))
+    }
+
+    @Test
+    fun add_well_prompts_rather_than_paging_the_floor() {
+        // The bug this guards: "+ ADD WELL" has no children, so without an
+        // explicit branch it falls through to Submit and pages everyone
+        // asking for "ICE: + ADD WELL".
+        assertEquals(ButtonTap.PromptForWell, classify(ADD_WELL_BUTTON))
+    }
+
+    @Test
+    fun add_brand_prompts() {
+        assertEquals(ButtonTap.PromptForBrand, classify(ADD_BRAND_BUTTON))
+    }
+
+    @Test
+    fun add_type_prompts() {
+        assertEquals(ButtonTap.PromptForType, classify(ADD_TYPE_BUTTON))
+    }
+
+    @Test
+    fun the_other_quantity_option_prompts() {
+        val other = QUANTITY_BUTTONS.first { it.action == ButtonAction.CustomQuantity }
+        assertEquals(ButtonTap.PromptForQuantity, classify(other))
+    }
+
+    @Test
+    fun a_fixed_quantity_submits() {
+        val twelve = QUANTITY_BUTTONS.first { it.id == "qty_12" }
+        assertEquals(ButtonTap.Submit, classify(twelve))
+    }
+
+    @Test
+    fun the_custom_tile_prompts() {
+        assertEquals(ButtonTap.PromptForCustomRequest, classify(CUSTOM_REQUEST_BUTTON))
+    }
+
+    @Test
+    fun a_brand_tile_descends_into_its_types() {
+        assertEquals(ButtonTap.Descend, classify(ButtonConfig("brand_Corona", "Corona")))
+    }
+
+    @Test
+    fun a_brand_with_no_types_still_descends_to_reach_its_add_tile() {
+        // The synthesised "+ ADD TYPE" entry is always present, so an empty
+        // brand must still open rather than paging for the brand alone.
+        val empty = classifyTap(
+            ButtonConfig("brand_Modelo", "Modelo"),
+            wells,
+            mapOf("Modelo" to emptyList()),
+        )
+        assertEquals(ButtonTap.Descend, empty)
+    }
+
+    @Test
+    fun ice_descends_even_with_no_wells_configured() {
+        val iceButton = DEFAULT_BUTTONS.first { it.id == "ice" }
+        assertEquals(ButtonTap.Descend, classifyTap(iceButton, emptyList(), emptyMap()))
     }
 }
 

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/ReorderTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/ReorderTest.kt
@@ -1,0 +1,96 @@
+package com.hereliesaz.barbacker.logic
+
+import com.hereliesaz.barbacker.ADD_BRAND_BUTTON
+import com.hereliesaz.barbacker.ADD_TYPE_BUTTON
+import com.hereliesaz.barbacker.ADD_WELL_BUTTON
+import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
+import com.hereliesaz.barbacker.model.ButtonConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MoveItemTest {
+
+    private val list = listOf("a", "b", "c", "d")
+
+    @Test
+    fun moving_forward_lands_after_the_intervening_items() {
+        assertEquals(listOf("b", "c", "a", "d"), list.moveItem(from = 0, to = 2))
+    }
+
+    @Test
+    fun moving_backward_lands_before_the_target() {
+        assertEquals(listOf("a", "d", "b", "c"), list.moveItem(from = 3, to = 1))
+    }
+
+    @Test
+    fun moving_to_the_same_index_is_a_no_op() {
+        assertEquals(list, list.moveItem(from = 2, to = 2))
+    }
+
+    @Test
+    fun moving_to_the_ends_works() {
+        assertEquals(listOf("d", "a", "b", "c"), list.moveItem(from = 3, to = 0))
+        assertEquals(listOf("b", "c", "d", "a"), list.moveItem(from = 0, to = 3))
+    }
+
+    /**
+     * A drag can outlive the list it started on — a remote snapshot lands
+     * mid-gesture and drops a button. Returning the list unchanged is the
+     * only outcome that neither crashes nor silently scrambles the order.
+     */
+    @Test
+    fun out_of_range_indices_leave_the_list_alone() {
+        assertEquals(list, list.moveItem(from = -1, to = 2))
+        assertEquals(list, list.moveItem(from = 1, to = 9))
+        assertEquals(emptyList(), emptyList<String>().moveItem(from = 0, to = 0))
+    }
+}
+
+class PersistableOrderTest {
+
+    private val real = listOf(
+        ButtonConfig(id = "ice", label = "ICE"),
+        ButtonConfig(id = "glass", label = "GLASS"),
+    )
+
+    @Test
+    fun render_time_tiles_are_not_reorderable() {
+        assertFalse(CUSTOM_REQUEST_BUTTON.isReorderable())
+        assertFalse(ADD_WELL_BUTTON.isReorderable())
+        assertFalse(ADD_BRAND_BUTTON.isReorderable())
+        assertFalse(ADD_TYPE_BUTTON.isReorderable())
+    }
+
+    /**
+     * Well, brand, and type tiles are synthesised too, but from the bar's
+     * own data — a manager putting the busiest well first is a real
+     * preference, and [sortButtons] honours it.
+     */
+    @Test
+    fun tiles_synthesised_from_bar_data_stay_reorderable() {
+        assertTrue(ButtonConfig(id = "well_Main", label = "Main").isReorderable())
+        assertTrue(ButtonConfig(id = "brand_Corona", label = "Corona").isReorderable())
+        assertTrue(ButtonConfig(id = "type_Corona_Bottle", label = "Bottle").isReorderable())
+    }
+
+    @Test
+    fun the_persisted_order_strips_render_time_tiles() {
+        assertEquals(
+            listOf("ice", "glass"),
+            persistableOrder(real + CUSTOM_REQUEST_BUTTON),
+        )
+    }
+
+    /**
+     * The stripped tile is always last on screen, so removing it must not
+     * disturb the surviving order — which is the whole reason stripping
+     * happens on the way to Firestore rather than before the gesture.
+     */
+    @Test
+    fun stripping_preserves_the_order_of_what_remains() {
+        val dragged = (real + CUSTOM_REQUEST_BUTTON).moveItem(from = 1, to = 0)
+        assertEquals(listOf("glass", "ice"), persistableOrder(dragged))
+    }
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/RequestFilterTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/RequestFilterTest.kt
@@ -121,6 +121,44 @@ class VisibleRequestsTest {
     }
 }
 
+class OutstandingAlertsTest {
+
+    private fun request(id: String) =
+        Request(id = id, label = "ICE", requesterId = "u", barId = "bar1")
+
+    @Test
+    fun sounds_when_an_unmuted_request_is_waiting() {
+        assertTrue(hasOutstandingAlerts(listOf(request("1")), emptySet()))
+    }
+
+    @Test
+    fun stays_silent_when_every_request_is_muted() {
+        // The loop repeats every minute. Without this, muting a page would
+        // dim it visually but keep making noise until someone else resolved
+        // it — which defeats the point of muting entirely.
+        assertFalse(hasOutstandingAlerts(listOf(request("1")), setOf("1")))
+    }
+
+    @Test
+    fun sounds_when_one_of_several_is_unmuted() {
+        assertTrue(hasOutstandingAlerts(listOf(request("1"), request("2")), setOf("1")))
+    }
+
+    @Test
+    fun stays_silent_with_nothing_waiting() {
+        assertFalse(hasOutstandingAlerts(emptyList(), emptySet()))
+    }
+
+    @Test
+    fun a_muted_request_still_counts_as_visible() {
+        // The two questions are deliberately different: a muted page stays
+        // on screen and countable, it just stops making noise.
+        val muted = listOf(request("1"))
+        assertFalse(hasOutstandingAlerts(muted, setOf("1")))
+        assertTrue(muted.isNotEmpty())
+    }
+}
+
 class ButtonPendingTest {
 
     private fun pending(id: String, label: String) =

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/Alerter.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/Alerter.desktop.kt
@@ -1,0 +1,17 @@
+package com.hereliesaz.barbacker
+
+import java.awt.Toolkit
+
+private object DesktopAlerter : Alerter {
+    override fun alert() {
+        try {
+            // The system beep rather than a bundled sound file: it respects
+            // the user's own alert settings and needs no asset shipped.
+            Toolkit.getDefaultToolkit().beep()
+        } catch (e: Exception) {
+            logWarning("Could not sound the alert", e)
+        }
+    }
+}
+
+actual fun createAlerter(platformContext: Any?): Alerter = DesktopAlerter

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.desktop.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.barbacker.data
+
+/**
+ * Desktop has no FCM transport, so there is nothing to register.
+ *
+ * This reports unsupported rather than pretending: a desktop client that
+ * silently registered no token would look identical to one whose
+ * registration was failing. The in-app alert loop is what pages a desktop
+ * user, and it runs regardless.
+ */
+private object DesktopPushTokenProvider : PushTokenProvider {
+    override val isSupported: Boolean = false
+    override suspend fun currentToken(): String? = null
+    override suspend fun deleteToken() = Unit
+}
+
+actual fun createPushTokenProvider(platformContext: Any?): PushTokenProvider =
+    DesktopPushTokenProvider

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.desktop.kt
@@ -1,0 +1,5 @@
+package com.hereliesaz.barbacker.data
+
+import dev.gitlive.firebase.storage.Data
+
+internal actual fun storageDataOf(bytes: ByteArray): Data = Data(bytes)

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/Alerter.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/Alerter.ios.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.barbacker
+
+import platform.AudioToolbox.AudioServicesPlaySystemSound
+import platform.AudioToolbox.kSystemSoundID_Vibrate
+
+/** The standard "new mail" alert tone. */
+private const val ALERT_SOUND_ID: UInt = 1007u
+
+private object IosAlerter : Alerter {
+    override fun alert() {
+        AudioServicesPlaySystemSound(ALERT_SOUND_ID)
+        // On a device without a taptic engine this is a no-op rather than
+        // an error, so it is always safe to request.
+        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+    }
+}
+
+actual fun createAlerter(platformContext: Any?): Alerter = IosAlerter

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.ios.kt
@@ -1,0 +1,33 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.messaging.messaging
+
+/**
+ * iOS push depends on an APNs capability and entitlement configured in the
+ * Xcode project, plus a Firebase iOS SDK linked through SPM or CocoaPods.
+ * Until that project exists (see cmp/iosApp/README.md), `getToken()` will
+ * simply fail here and the app falls back to the in-app alert loop.
+ */
+private class IosPushTokenProvider : PushTokenProvider {
+    override val isSupported: Boolean = true
+
+    override suspend fun currentToken(): String? = try {
+        Firebase.messaging.getToken()
+    } catch (e: Exception) {
+        logWarning("Could not obtain an APNs/FCM token", e)
+        null
+    }
+
+    override suspend fun deleteToken() {
+        try {
+            Firebase.messaging.deleteToken()
+        } catch (e: Exception) {
+            logWarning("Could not delete the push token", e)
+        }
+    }
+}
+
+actual fun createPushTokenProvider(platformContext: Any?): PushTokenProvider =
+    IosPushTokenProvider()

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.ios.kt
@@ -1,0 +1,29 @@
+package com.hereliesaz.barbacker.data
+
+import dev.gitlive.firebase.storage.Data
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.create
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun storageDataOf(bytes: ByteArray): Data = Data(bytes.toNSData())
+
+/**
+ * Copies a [ByteArray] into an [NSData].
+ *
+ * `NSData.create` copies the buffer, so the pinning only has to outlive
+ * this call — but it does have to cover it, or the GC is free to move the
+ * array out from under the pointer mid-copy.
+ *
+ * The empty case is special-cased because `addressOf(0)` on a
+ * zero-length array is out of bounds.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun ByteArray.toNSData(): NSData {
+    if (isEmpty()) return NSData()
+    return usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = size.toULong())
+    }
+}

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -175,10 +175,10 @@ without the refresh, every role-gated read stays denied for up to an hour.
 
 ## Testing
 
-`./gradlew :shared:desktopTest` runs the shared suite: 70 tests covering
+`./gradlew :shared:desktopTest` runs the shared suite: 75 tests covering
 the ported pure logic — contrast colour, brand matching, the button label
-resolver, sort order, sub-menu synthesis, and the request visibility
-filter.
+resolver, sort order, sub-menu synthesis, the request visibility filter,
+and alert eligibility.
 
 These are the pieces where a silent divergence from the PWA would be
 hardest to notice, so each behavioural subtlety is pinned by a test that
@@ -194,6 +194,10 @@ fails if it is lost:
 - An explicitly empty preference list is not overwritten by job-title
   defaults.
 - Brand sub-menus key off the label, not the `brand_`-prefixed id.
+- Muted requests stay *visible* but stop being *alert-worthy* — two
+  genuinely different questions, and conflating them would either
+  silently drop pages or keep making noise about ones deliberately set
+  aside.
 
 ## Status
 
@@ -214,15 +218,22 @@ Working end to end:
   the 86'd list, and ownership claims
 - Premium bar theming, with a readability check on the branded label
   colour
+- Push registration on Android and iOS, plus the in-app alert loop that
+  sounds and vibrates every minute while un-muted pages are waiting
 
 Not built yet — the PWA remains the complete client:
 
 - **Calendar, POS settings, and the bottle scanner.** The domain models
   are ported; the screens are not.
-- **Push notifications.** No FCM registration, so the nag loop and
-  server-side fanout do not reach this client. The notification-settings
-  screen shows the ntfy topic for manual subscription but has no
-  `ntfy://` deep link.
+- **iOS push delivery.** The token code is shared with Android, but iOS
+  needs an APNs capability and entitlement configured in an Xcode
+  project that does not exist yet (see `cmp/iosApp/README.md`). Until
+  then iOS falls back to the in-app alert loop.
+- **Desktop push.** There is no FCM transport for a JVM app. The
+  provider reports this explicitly rather than registering nothing and
+  looking broken; the in-app alert loop is what pages a desktop user.
+- **ntfy deep linking.** The notification-settings screen shows the
+  topic for manual subscription but has no `ntfy://` link.
 - **Drag-to-reorder.** The grid honours a saved order; it cannot write one.
 - **Bar management.** No invite form, button hiding, or inventory editing.
 - **Google and Apple sign-in.** Email/password only.

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -175,10 +175,10 @@ without the refresh, every role-gated read stays denied for up to an hour.
 
 ## Testing
 
-`./gradlew :shared:desktopTest` runs the shared suite: 75 tests covering
+`./gradlew :shared:desktopTest` runs the shared suite: 86 tests covering
 the ported pure logic — contrast colour, brand matching, the button label
-resolver, sort order, sub-menu synthesis, the request visibility filter,
-and alert eligibility.
+resolver, sort order, sub-menu synthesis, tap classification, the request
+visibility filter, and alert eligibility.
 
 These are the pieces where a silent divergence from the PWA would be
 hardest to notice, so each behavioural subtlety is pinned by a test that
@@ -194,6 +194,10 @@ fails if it is lost:
 - An explicitly empty preference list is not overwritten by job-title
   defaults.
 - Brand sub-menus key off the label, not the `brand_`-prefixed id.
+- The synthesised "+ ADD …" and CUSTOM tiles have no children, so any
+  path that reaches the children check treats them as leaves and pages
+  the floor asking for "ICE: + ADD WELL". Tap classification runs first,
+  and a test pins each case.
 - Muted requests stay *visible* but stop being *alert-worthy* — two
   genuinely different questions, and conflating them would either
   silently drop pages or keep making noise about ones deliberately set
@@ -209,6 +213,8 @@ Working end to end:
 - The join flow, including invite consumption and approval-pending
 - The dashboard: request grid, sub-menu drill-down with synthesised
   children, sending pages, and claim / cancel / mute
+- Adding wells, beer brands, and types from the grid's "+ ADD …" tiles,
+  plus free-text custom requests and the quantity stepper
 - Chat, with pinning, deletion, paged scrollback, the dashboard marquee,
   and an unread badge
 - The 86'd list, including premium private entries

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -156,6 +156,27 @@ a dotted `"beerInventory.$brand"` string. Firestore splits dotted paths on
 `.`, so a brand like "St. Pauli Girl" would land in a nested
 `{ St: { " Pauli Girl": ... } }`.
 
+A logo goes to `bars/{barId}/logo.<ext>` in Storage, which is not a free
+choice either: `storage.rules` matches `/bars/{barId}/{fileName}` and then
+narrows `fileName` with `matches('logo\\..+')`. Anything outside that shape
+has no matching rule, and Storage denies by default — so a near-miss fails
+as a flat permission error with nothing pointing at the path.
+
+### Theming
+
+Which brand colour lands where is fixed by the PWA, because the same
+`theme` map is read by both clients and the two sit on the same bar:
+
+| Field | Role |
+|---|---|
+| `accentColor` | The request-tile background. Its label is whichever of black/white is readable on it — never the other brand colour. |
+| `primaryColor` | The M3 `primary` role: headings, filled buttons. |
+
+`fontFamily` stores a CSS font stack, so a font chosen in either client
+round-trips through the other. What this client renders from it is
+narrower — no font resources are bundled, so a serif stack becomes the
+platform serif and everything else the platform default.
+
 ### Roles
 
 `BarRole` (the privilege tier) and `JobTitle` (the job function) are
@@ -175,10 +196,11 @@ without the refresh, every role-gated read stays denied for up to an hour.
 
 ## Testing
 
-`./gradlew :shared:desktopTest` runs the shared suite: 86 tests covering
+`./gradlew :shared:desktopTest` runs the shared suite: 102 tests covering
 the ported pure logic — contrast colour, brand matching, the button label
-resolver, sort order, sub-menu synthesis, tap classification, the request
-visibility filter, and alert eligibility.
+resolver, sort order, sub-menu synthesis, tap classification, reorder
+arithmetic, picked-image identity, the request visibility filter, and
+alert eligibility.
 
 These are the pieces where a silent divergence from the PWA would be
 hardest to notice, so each behavioural subtlety is pinned by a test that
@@ -202,6 +224,12 @@ fails if it is lost:
   genuinely different questions, and conflating them would either
   silently drop pages or keep making noise about ones deliberately set
   aside.
+- A reorder dragged down lands *after* the tiles it passed; dragged up it
+  lands *before* the target. Getting that backwards puts the button one
+  slot off, which reads as a flaky gesture rather than a bug.
+- The synthesised tiles are stripped from a saved order on the way to
+  Firestore, not before the drag, so the indices the gesture works in
+  stay aligned with what is on screen.
 
 ## Status
 
@@ -222,10 +250,15 @@ Working end to end:
 - Per-member notification preferences
 - Realtime updates for bar config, membership, roster, requests, chat,
   the 86'd list, and ownership claims
-- Premium bar theming, with a readability check on the branded label
-  colour
+- Premium bar theming, with the tile label derived from the accent colour
+  it sits on
 - Push registration on Android and iOS, plus the in-app alert loop that
   sounds and vibrates every minute while un-muted pages are waiting
+- Bar management for Manager+: hiding grid buttons, restoring hidden ones
+  on premium, and inviting staff or managers by email
+- The theme editor: brand colours, font, and a logo uploaded to Storage
+- Drag-to-reorder on the main grid and inside every sub-menu, held behind
+  a long press so a tap still sends a page
 
 Not built yet — the PWA remains the complete client:
 
@@ -235,14 +268,26 @@ Not built yet — the PWA remains the complete client:
   needs an APNs capability and entitlement configured in an Xcode
   project that does not exist yet (see `cmp/iosApp/README.md`). Until
   then iOS falls back to the in-app alert loop.
+- **The iOS file picker is unverified.** `ImagePicker.ios.kt` is written
+  against `UIDocumentPickerViewController`, but with no macOS runner and
+  no Xcode project it has never been compiled. Treat it as a first draft
+  of that path. Android and desktop are built in CI.
 - **Desktop push.** There is no FCM transport for a JVM app. The
   provider reports this explicitly rather than registering nothing and
   looking broken; the in-app alert loop is what pages a desktop user.
 - **ntfy deep linking.** The notification-settings screen shows the
   topic for manual subscription but has no `ntfy://` link.
-- **Drag-to-reorder.** The grid honours a saved order; it cannot write one.
-- **Bar management.** No invite form, button hiding, or inventory editing.
+- **Keyboard-operable reordering.** The web client can reorder with the
+  arrow keys; here the gesture is pointer-only.
+- **Logo previews.** The theme editor shows the uploaded logo's URL, not
+  the image — rendering a remote image needs an image-loading library
+  this build does not carry.
 - **Google and Apple sign-in.** Email/password only.
+
+Deliberately absent, because the PWA has no such feature either:
+inventory *removal*. Wells, brands, and types are added from the grid's
+"+ ADD …" tiles in both clients, and a brand is taken off the floor by
+hiding its tile rather than by deleting it.
 
 One caveat worth stating plainly: the Firestore read and write paths
 compile and are structured to match the rules, but have not been exercised


### PR DESCRIPTION
Three commits. Two of them fix things that were actively wrong, not missing.

---

# 1. Push registration and the in-app alert loop

Until now the CMP client could *send* pages but never *receive* one.

**Push registration.** The device token is written to `bars/{barId}/tokens/{uid}` once the member is **ACTIVE** in a bar — not merely present. A pending member must not be paged for a bar that hasn't admitted them yet, and the rules would reject the write anyway. De-registration was already in place from the first PR; this supplies the missing registration side. Deleting that document is what actually stops the pages — leave one behind and the nag cron keeps waking a phone whose shift ended hours ago.

Desktop reports push as **unsupported** rather than registering nothing. There's no FCM transport for a JVM app, and a client that silently registered no token would look identical to one whose registration was failing.

**In-app alert loop.** Sounds and vibrates once a minute while un-muted pages are outstanding. This is the half that matters most exactly where push is weakest: a tablet sitting open on the back bar, in a room too loud for a notification chime alone.

Muted requests are excluded — that's the entire point of muting. The predicate lives in shared logic rather than inline, specifically so it could be tested: *visible* and *alert-worthy* are different questions, and conflating them either silently drops pages or nags about ones already handled.

**Android specifics.** Creates the `urgent_alerts` notification channel at startup and requests `POST_NOTIFICATIONS` on 13+. The channel id must match what the server-side fanout and nag cron send, or Android strips the high-priority treatment and the page arrives silently — for a paging app, indistinguishable from not arriving.

---

# 2. Fixing the dead "+ ADD" and CUSTOM tiles

**A real bug, not a new feature.** The synthesised tiles — `+ ADD WELL`, `+ ADD BRAND`, `+ ADD TYPE`, the `Other` quantity option, and `CUSTOM` — all rendered, but none had a handler. Every one has no children, so tapping any of them fell through to the submit path and **paged the entire floor asking for, literally, `"ICE: + ADD WELL"`**.

Worse than a dead button: it looked like it worked, and the nonsense went out to everyone subscribed.

Each now opens the prompt it should. Wells write and then send the ice request that motivated adding them; brands and types write and then descend into the new entry; `Other` opens a numeric stepper floored at one; `CUSTOM` takes free text.

**Inventory writes land before the local navigation moves**, and a failure returns early. Navigating first would drop the user into a brand or type menu that doesn't exist on the server, and every request sent from it would reference something nobody else can see. A name that already exists navigates straight in rather than failing a duplicate write and stranding the user.

**The routing decision moved into shared logic as `classifyTap`** — specifically so it could be tested. The whole bug was a missing branch in an if/else with no coverage. Eleven tests pin every case, including the two easiest to get backwards: a brand with no types yet must still **descend** (to reach its `+ ADD TYPE` tile) rather than submit, and so must `ICE` with no wells configured.

---

# 3. Bar management, theming, and drag-to-reorder

Manager+ can now configure a bar from this client: hide grid buttons, restore hidden ones on premium, invite staff or managers by email, and edit the bar's branding. The grid also accepts a drag-to-reorder gesture, which it previously honoured but could not write.

## Two things that were wrong, not missing

**The theme fields were mapped to the wrong roles.** `useBarTheme.ts` makes `accentColor` the request-tile background and derives the tile's label from it. This client had `primaryColor` as the tile and treated `accentColor` as a candidate label. Same theme document, two different-looking bars — on devices that sit side by side on the same counter. Now matched to the web client, which also retires the "is this label readable" fallback: the label is always the WCAG choice of black or white, so an unreadable pairing is no longer representable.

**`Paths.barLogo` pointed at a path no storage rule matches.** It built `barLogos/{barId}/…`; `storage.rules` matches `/bars/{barId}/{fileName}` and then narrows `fileName` to `logo\..+`. Storage denies unmatched paths, so the first upload would have failed as a bare permission error with nothing pointing at the cause. Corrected to `bars/{barId}/logo.<ext>` — the rule's shape, and the PWA's.

## The reorder gesture

It watches the **initial** pointer pass rather than composing `detectDragGesturesAfterLongPress` with a clickable tile. Those two land in the same gesture arena and which one wins depends on whether the tile consumed the press first — so the drag either never starts or eats every tap. Watching the initial pass means the grid sees the press before the tile does, stays out of the way until the 250ms pickup delay elapses (matching the web client's `TouchSensor`), and only then consumes. The release is consumed too: otherwise holding a tile for a moment and letting go would page the floor.

Reordering is gated on Manager+ rather than left to fail. `customOrders` lives on the bar document, which the rules restrict to Manager+; the web client lets anyone drag and alerts on the rejected write, and a gesture that does nothing is better than one that appears to work and then reverts.

A committed order is held locally until the bar document confirms it, and rolled back with a message if the write is rejected. Without that the tiles snap back to the old arrangement in the gap before the snapshot lands — precisely when a manager is watching to see whether the drag took. The pending order is dropped on every bar change: it is keyed by grid context, not by bar, so a leftover entry would shadow the next bar's saved order on a shared tablet and go on shadowing it forever.

Sub-menus reorder independently, since `customOrders` is keyed by context id.

## Invites

`InvitableRole` is a separate type from `BarRole`, and the omission is the point: an invite can grant Staff or Manager, never Owner. `onInviteConsumed` grants whatever role the document names, so an invite carrying `Owner` would hand a bar away with no review step. Email is lowercased on write, because the consumption lookup is an exact match — an invite typed with capitals would sit there unconsumable, looking sent.

## Logo upload

Needs a file chooser per platform. Android (`GetContent` + content resolver) and desktop (`JFileChooser`) are built in CI. **The iOS actual is unverified** — written against `UIDocumentPickerViewController`, but with no macOS runner and no Xcode project it has never been compiled. Said plainly in the file and in `docs/CMP.md`.

Size is checked before the read where the platform reports it, so a 40MB panorama is rejected without being pulled into memory first. Content type is set explicitly on upload rather than left to the SDK's guess, because the storage rule matches on it and an `application/octet-stream` arrival is rejected.

`saveTheme` now writes with `encodeDefaults = false`, so removing a logo omits the key instead of writing an explicit null — otherwise the two clients would disagree about whether a bar has a logo depending on which one cleared it.

---

## Still not built

`docs/CMP.md` updated throughout. Remaining: iOS push delivery, calendar, POS settings, the bottle scanner, `ntfy://` deep linking, keyboard-operable reordering, in-editor logo previews, and social sign-in.

Inventory *removal* is deliberately absent, because the PWA has none either — a brand comes off the floor by hiding its tile.

The standing runtime caveat holds: these paths compile and match the rules but have not been exercised against live Firebase from this client.

## Verification

Clean build: Android APK ✅, desktop JAR ✅, shared suite **102 tests / 0 failures**, no warnings in project code.