### PR TITLE
CMP client: calendar, POS, the bottle scanner, and closing the last parity gaps

### DIFF
--- a/cmp/composeApp/build.gradle.kts
+++ b/cmp/composeApp/build.gradle.kts
@@ -43,6 +43,8 @@ kotlin {
             implementation(compose.components.resources)
 
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor3)
             implementation(libs.lifecycle.viewmodel)
             implementation(libs.lifecycle.viewmodel.compose)
         }

--- a/cmp/composeApp/src/androidMain/AndroidManifest.xml
+++ b/cmp/composeApp/src/androidMain/AndroidManifest.xml
@@ -36,5 +36,20 @@
                       android:pathPrefix="/BarBacker" />
             </intent-filter>
         </activity>
+
+        <!-- Hands the camera app a writable Uri for one scan at a time.
+             ACTION_IMAGE_CAPTURE writes full resolution to a Uri we
+             supply; the alternative, TakePicturePreview, returns a
+             thumbnail, and OCR on a thumbnail reads a bottle label as
+             noise. The authority must match PhotoCapture.android.kt. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.android.kt
+++ b/cmp/composeApp/src/androidMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.android.kt
@@ -1,0 +1,127 @@
+package com.hereliesaz.barbacker.ui
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import com.hereliesaz.barbacker.data.MAX_BOTTLE_PHOTO_BYTES
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+@Composable
+actual fun rememberPhotoCapture(
+    onCaptured: (ByteArray) -> Unit,
+    onError: (String) -> Unit,
+): PhotoCaptureLauncher {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val captured by rememberUpdatedState(onCaptured)
+    val failed by rememberUpdatedState(onError)
+
+    // Where the camera app writes. Held across the round trip because the
+    // result callback gets only a success flag — the bytes are wherever
+    // we told the camera to put them.
+    var target by remember { mutableStateOf<File?>(null) }
+
+    val takePicture = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture(),
+    ) { success ->
+        val file = target
+        target = null
+        if (!success || file == null) {
+            // Cancelled. Still clean up: the empty placeholder is already
+            // on disk by this point.
+            file?.delete()
+            return@rememberLauncherForActivityResult
+        }
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching {
+                    val bytes = file.readBytes()
+                    file.delete()
+                    bytes
+                }
+            }
+            result.fold(
+                onSuccess = { bytes ->
+                    when {
+                        bytes.isEmpty() -> failed("The camera returned an empty photo.")
+                        bytes.size > MAX_BOTTLE_PHOTO_BYTES ->
+                            failed("That photo is too large to send.")
+                        else -> captured(bytes)
+                    }
+                },
+                onFailure = { failed("Could not read the photo.") },
+            )
+        }
+    }
+
+    fun startCapture() {
+        val outcome = runCatching {
+            val file = context.newPhotoFile()
+            target = file
+            takePicture.launch(context.uriFor(file))
+        }
+        if (outcome.isFailure) {
+            target = null
+            failed("Could not open the camera.")
+        }
+    }
+
+    // The manifest declares CAMERA, which means ACTION_IMAGE_CAPTURE
+    // requires it to be GRANTED — an app that never declares it can use
+    // the intent freely, but one that does must hold it.
+    val requestPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            startCapture()
+        } else {
+            failed("Camera access is needed to scan a bottle.")
+        }
+    }
+
+    return remember(takePicture, requestPermission, context) {
+        object : PhotoCaptureLauncher {
+            override val isSupported: Boolean = true
+
+            override fun launch() {
+                val granted = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.CAMERA,
+                ) == PackageManager.PERMISSION_GRANTED
+
+                if (granted) startCapture() else requestPermission.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
+}
+
+/**
+ * A fresh file in the cache directory.
+ *
+ * The cache, not files/: a scan is transient, the bytes are read back and
+ * deleted immediately, and anything left behind by a crash is the
+ * system's to reclaim.
+ */
+private fun Context.newPhotoFile(): File {
+    val directory = File(cacheDir, "bottle-scans").apply { mkdirs() }
+    return File.createTempFile("scan", ".jpg", directory)
+}
+
+private fun Context.uriFor(file: File): Uri =
+    FileProvider.getUriForFile(this, "$packageName.fileprovider", file)

--- a/cmp/composeApp/src/androidMain/res/xml/file_paths.xml
+++ b/cmp/composeApp/src/androidMain/res/xml/file_paths.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    The single directory the camera app is granted write access to.
+
+    Scoped to one subdirectory of the cache rather than the whole of it:
+    a FileProvider grant is per-path, and there is no reason for another
+    app to be able to name any cached file it likes.
+-->
+<paths>
+    <cache-path name="bottle-scans" path="bottle-scans/" />
+</paths>

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -35,6 +35,8 @@ import com.hereliesaz.barbacker.ui.Screen
 import com.hereliesaz.barbacker.ui.screens.ApprovalPendingScreen
 import com.hereliesaz.barbacker.ui.screens.BarManagerDialog
 import com.hereliesaz.barbacker.ui.screens.BarSelectionScreen
+import com.hereliesaz.barbacker.ui.screens.BottleScannerActions
+import com.hereliesaz.barbacker.ui.screens.BottleScannerDialog
 import com.hereliesaz.barbacker.ui.screens.CalendarDialog
 import com.hereliesaz.barbacker.ui.screens.CalendarSettingsActions
 import com.hereliesaz.barbacker.ui.screens.CalendarSettingsDialog
@@ -97,6 +99,7 @@ private fun BarBackerApp(container: AppContainer) {
             calendar = container.calendar,
             pos = container.pos,
             urls = container.urls,
+            bottleRecognizer = container.bottleRecognizer,
             icalFeedBaseUrl = container.icalFeedBaseUrl,
             placeSearch = container.placeSearch,
             pushTokens = container.pushTokens,
@@ -181,6 +184,9 @@ private fun BarBackerApp(container: AppContainer) {
                             onOpenBarManager = { viewModel.openDialog(ActiveDialog.BarManager) },
                             onOpenThemeEditor = { viewModel.openDialog(ActiveDialog.ThemeEditor) },
                             onOpenCalendar = { viewModel.openDialog(ActiveDialog.Calendar) },
+                            onOpenBottleScanner = {
+                                viewModel.openDialog(ActiveDialog.BottleScanner)
+                            },
                             onOpenPosSettings = { viewModel.openDialog(ActiveDialog.PosSettings) },
                             onSwitchBar = viewModel::backToBarSelection,
                             onGoOffClock = viewModel::goOffClock,
@@ -332,6 +338,19 @@ private fun DashboardDialogs(state: AppUiState, viewModel: AppViewModel) {
                 onClose = { viewModel.openDialog(ActiveDialog.Calendar) },
             )
         }
+
+        ActiveDialog.BottleScanner -> BottleScannerDialog(
+            isManagerPlus = state.isManagerPlus,
+            existingBrands = state.bar?.beerInventory?.keys?.toList().orEmpty(),
+            recognitionSupported = viewModel.bottleRecognitionSupported,
+            actions = BottleScannerActions(
+                onRecognize = viewModel::recognizeBottle,
+                onAddToMenu = viewModel::addBottleToMenu,
+                onEightySix = viewModel::eightySixBrand,
+                onSendAlert = viewModel::sendBottleAlert,
+            ),
+            onClose = viewModel::closeDialog,
+        )
 
         ActiveDialog.PosSettings -> PosSettingsDialog(
             connections = state.posConnections,

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -31,6 +31,7 @@ import com.hereliesaz.barbacker.data.loadFirebaseConfig
 import com.hereliesaz.barbacker.ui.ActiveDialog
 import com.hereliesaz.barbacker.ui.AppUiState
 import com.hereliesaz.barbacker.ui.AppViewModel
+import com.hereliesaz.barbacker.ui.InstallImageLoader
 import com.hereliesaz.barbacker.ui.Screen
 import com.hereliesaz.barbacker.ui.screens.ApprovalPendingScreen
 import com.hereliesaz.barbacker.ui.screens.BarManagerDialog
@@ -109,6 +110,10 @@ private fun BarBackerApp(container: AppContainer) {
     }
     val state by viewModel.state.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // Once for the process, over the HTTP engine this app already
+    // configured for its place search.
+    InstallImageLoader(container.httpClient)
 
     // Failures the user needs to know about — a lost claim race, a
     // rejected write — surface here rather than only reaching the log.

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -17,6 +17,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -33,6 +35,9 @@ import com.hereliesaz.barbacker.ui.Screen
 import com.hereliesaz.barbacker.ui.screens.ApprovalPendingScreen
 import com.hereliesaz.barbacker.ui.screens.BarManagerDialog
 import com.hereliesaz.barbacker.ui.screens.BarSelectionScreen
+import com.hereliesaz.barbacker.ui.screens.CalendarDialog
+import com.hereliesaz.barbacker.ui.screens.CalendarSettingsActions
+import com.hereliesaz.barbacker.ui.screens.CalendarSettingsDialog
 import com.hereliesaz.barbacker.ui.screens.ChatPanel
 import com.hereliesaz.barbacker.ui.screens.CheckingInviteScreen
 import com.hereliesaz.barbacker.ui.screens.DashboardActions
@@ -40,6 +45,8 @@ import com.hereliesaz.barbacker.ui.screens.DashboardScreen
 import com.hereliesaz.barbacker.ui.screens.EightySixDialog
 import com.hereliesaz.barbacker.ui.screens.InputPromptDialog
 import com.hereliesaz.barbacker.ui.screens.NotificationSettingsDialog
+import com.hereliesaz.barbacker.ui.screens.PosSettingsActions
+import com.hereliesaz.barbacker.ui.screens.PosSettingsDialog
 import com.hereliesaz.barbacker.ui.screens.QuantityPromptDialog
 import com.hereliesaz.barbacker.ui.screens.RestoringScreen
 import com.hereliesaz.barbacker.ui.screens.RoleSelectionScreen
@@ -68,6 +75,7 @@ fun App(platformContext: Any? = null) {
             firebase = BarBackerFirebase.initialize(config, platformContext),
             store = createKeyValueStore(platformContext),
             platformContext = platformContext,
+            icalFeedBaseUrl = config.icalFeedBaseUrl,
         )
     }
 
@@ -86,6 +94,10 @@ private fun BarBackerApp(container: AppContainer) {
             eightySix = container.eightySix,
             ownershipClaims = container.ownershipClaims,
             storage = container.storage,
+            calendar = container.calendar,
+            pos = container.pos,
+            urls = container.urls,
+            icalFeedBaseUrl = container.icalFeedBaseUrl,
             placeSearch = container.placeSearch,
             pushTokens = container.pushTokens,
             alerter = container.alerter,
@@ -168,6 +180,8 @@ private fun BarBackerApp(container: AppContainer) {
                             },
                             onOpenBarManager = { viewModel.openDialog(ActiveDialog.BarManager) },
                             onOpenThemeEditor = { viewModel.openDialog(ActiveDialog.ThemeEditor) },
+                            onOpenCalendar = { viewModel.openDialog(ActiveDialog.Calendar) },
+                            onOpenPosSettings = { viewModel.openDialog(ActiveDialog.PosSettings) },
                             onSwitchBar = viewModel::backToBarSelection,
                             onGoOffClock = viewModel::goOffClock,
                             onReorder = viewModel::saveButtonOrder,
@@ -268,6 +282,67 @@ private fun DashboardDialogs(state: AppUiState, viewModel: AppViewModel) {
             currentTheme = state.bar?.theme,
             onSave = viewModel::saveTheme,
             onUploadLogo = viewModel::uploadLogo,
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.Calendar -> CalendarDialog(
+            events = state.calendarEvents,
+            isManagerPlus = state.isManagerPlus,
+            onCreate = viewModel::createCalendarEvent,
+            onUpdate = viewModel::updateCalendarEvent,
+            onDelete = viewModel::deleteCalendarEvent,
+            // Every collection behind the settings screen is Manager+
+            // gated in the rules, so Staff would open three empty boxes.
+            onOpenSettings = if (state.isManagerPlus) {
+                { viewModel.openDialog(ActiveDialog.CalendarSettings) }
+            } else {
+                null
+            },
+            onClose = viewModel::closeDialog,
+        )
+
+        ActiveDialog.CalendarSettings -> {
+            // The replacement, LocalClipboard, takes a ClipEntry built
+            // from a platform-native object — a Transferable on desktop,
+            // a ClipData on Android — with no common factory for plain
+            // text. Swapping to it means an expect/actual per platform to
+            // copy one string; this deprecated API does the job on all
+            // three today.
+            @Suppress("DEPRECATION")
+            val clipboard = LocalClipboardManager.current
+            CalendarSettingsDialog(
+                googleConnection = state.googleCalendarConnection,
+                subscriptions = state.icalSubscriptions,
+                feedUrl = state.icalFeedUrl,
+                hasFeedToken = state.icalFeedToken != null,
+                feedBaseConfigured = state.icalFeedBaseUrl != null,
+                actions = CalendarSettingsActions(
+                    onConnectGoogle = viewModel::connectGoogleCalendar,
+                    onListCalendars = viewModel::listGoogleCalendars,
+                    onSelectCalendar = viewModel::selectGoogleCalendar,
+                    onDisconnectGoogle = viewModel::disconnectGoogleCalendar,
+                    onAddSubscription = viewModel::addICalSubscription,
+                    onRemoveSubscription = viewModel::removeICalSubscription,
+                    onRotateFeedToken = viewModel::rotateICalFeedToken,
+                    onCopyFeedUrl = { clipboard.setText(AnnotatedString(it)) },
+                ),
+                // Back to the calendar rather than closing outright — this
+                // screen is reached from there, and dropping the user to
+                // the dashboard would lose their place.
+                onClose = { viewModel.openDialog(ActiveDialog.Calendar) },
+            )
+        }
+
+        ActiveDialog.PosSettings -> PosSettingsDialog(
+            connections = state.posConnections,
+            menu = state.posMenu,
+            actions = PosSettingsActions(
+                onConnectSquare = viewModel::connectSquare,
+                onConnectToast = viewModel::connectToast,
+                onDisconnect = viewModel::disconnectPos,
+                onSyncMenu = viewModel::syncPosMenu,
+                onGetSales = viewModel::getPosSales,
+            ),
             onClose = viewModel::closeDialog,
         )
     }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -382,4 +382,5 @@ enum class ActiveDialog {
     Calendar,
     CalendarSettings,
     PosSettings,
+    BottleScanner,
 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -4,6 +4,7 @@ import com.hereliesaz.barbacker.CUSTOM_REQUEST_BUTTON
 import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.data.AuthState
 import com.hereliesaz.barbacker.data.PlaceResult
+import com.hereliesaz.barbacker.data.icalFeedUrl
 import com.hereliesaz.barbacker.logic.ButtonLabelResolver
 import com.hereliesaz.barbacker.logic.dynamicChildrenOf
 import com.hereliesaz.barbacker.logic.effectiveNotificationPreferences
@@ -14,10 +15,15 @@ import com.hereliesaz.barbacker.logic.visibleRequests
 import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.model.CalendarConnectionStatus
+import com.hereliesaz.barbacker.model.CalendarEvent
 import com.hereliesaz.barbacker.model.ChatMessage
 import com.hereliesaz.barbacker.model.EightySixEntry
+import com.hereliesaz.barbacker.model.ICalSubscription
 import com.hereliesaz.barbacker.model.MemberStatus
 import com.hereliesaz.barbacker.model.OwnershipClaim
+import com.hereliesaz.barbacker.model.POSConnectionStatus
+import com.hereliesaz.barbacker.model.POSMenuItem
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.model.SubscriptionTier
 
@@ -132,6 +138,23 @@ data class AppUiState(
      * nobody saved.
      */
     val pendingOrders: Map<String, List<String>> = emptyMap(),
+
+    // --- Integrations. ---
+
+    /** The bar's calendar, soonest first. Visible to every member. */
+    val calendarEvents: List<CalendarEvent> = emptyList(),
+
+    /** Manager+ only; null for everyone else, and while none is connected. */
+    val googleCalendarConnection: CalendarConnectionStatus? = null,
+    val icalSubscriptions: List<ICalSubscription> = emptyList(),
+    val icalFeedToken: String? = null,
+
+    /** Where the outbound feed is served from, if this build was told. */
+    val icalFeedBaseUrl: String? = null,
+
+    /** Keyed by provider id. Manager+ only. */
+    val posConnections: Map<String, POSConnectionStatus> = emptyMap(),
+    val posMenu: List<POSMenuItem> = emptyList(),
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 
@@ -270,6 +293,17 @@ data class AppUiState(
      */
     val canSeePrivateEightySix: Boolean get() = isPremium && isManagerPlus
 
+    /**
+     * The subscribable feed URL, or null when it cannot be built.
+     *
+     * Null covers two different situations that both have to be handled:
+     * no token minted yet, and a token that exists but a build that was
+     * never told where the feed is served from. The settings screen tells
+     * them apart with [icalFeedToken].
+     */
+    val icalFeedUrl: String?
+        get() = icalFeedUrl(icalFeedBaseUrl, barId.orEmpty(), icalFeedToken)
+
     val clockedInMembers: List<BarUser> by lazy {
         roster.filter { it.status == MemberStatus.Active }
     }
@@ -345,4 +379,7 @@ enum class ActiveDialog {
     NotificationSettings,
     BarManager,
     ThemeEditor,
+    Calendar,
+    CalendarSettings,
+    PosSettings,
 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -3,7 +3,9 @@ package com.hereliesaz.barbacker.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.barbacker.ASK_ME_SUFFIX
+import com.hereliesaz.barbacker.BEER_BUTTON_LABEL
 import com.hereliesaz.barbacker.DEFAULT_BEERS
+import com.hereliesaz.barbacker.DEFAULT_SPIRITS
 import com.hereliesaz.barbacker.LABEL_SEPARATOR
 import com.hereliesaz.barbacker.INVITE_CHECK_TIMEOUT_MILLIS
 import com.hereliesaz.barbacker.Alerter
@@ -18,6 +20,7 @@ import com.hereliesaz.barbacker.data.AccountProfile
 import com.hereliesaz.barbacker.data.AuthRepository
 import com.hereliesaz.barbacker.data.AuthState
 import com.hereliesaz.barbacker.data.BarRepository
+import com.hereliesaz.barbacker.data.BottleRecognizer
 import com.hereliesaz.barbacker.data.CHAT_PAGE_SIZE
 import com.hereliesaz.barbacker.data.CalendarEventDraft
 import com.hereliesaz.barbacker.data.CalendarRepository
@@ -46,6 +49,7 @@ import com.hereliesaz.barbacker.logic.ButtonTap
 import com.hereliesaz.barbacker.logic.classifyTap
 import com.hereliesaz.barbacker.logic.isoFromEpochMillis
 import com.hereliesaz.barbacker.logic.hasOutstandingAlerts
+import com.hereliesaz.barbacker.logic.matchBrand
 import com.hereliesaz.barbacker.logic.requestLabelFor
 import com.hereliesaz.barbacker.model.Bar
 import com.hereliesaz.barbacker.model.BarRole
@@ -100,6 +104,7 @@ class AppViewModel(
     private val calendar: CalendarRepository,
     private val pos: PosRepository,
     private val urls: UrlOpener,
+    private val bottleRecognizer: BottleRecognizer,
     private val placeSearch: PlaceSearchRepository,
     private val pushTokens: PushTokenProvider,
     private val alerter: Alerter,
@@ -963,6 +968,28 @@ class AppViewModel(
         }
     }
 
+    /**
+     * The write behind [submitRequest], awaited rather than fired off.
+     *
+     * The scanner needs to know whether the alert actually went out — it
+     * closes its dialog on success and stays open on failure — which
+     * [submitRequest]'s fire-and-forget shape cannot report. It also
+     * carries the photo URL, which the grid path never has.
+     */
+    private suspend fun submitRequestNow(barId: String, label: String, photoUrl: String?) {
+        val current = state.value
+        val user = current.currentUser ?: error("Signed out")
+        requests.submit(
+            barId = barId,
+            label = label,
+            requesterId = user.uid,
+            requesterName = current.membership?.displayName.orEmpty(),
+            requesterRole = current.membership?.role?.wire,
+            buttonId = current.resolver.idForLabel(label),
+            photoUrl = photoUrl,
+        )
+    }
+
     /** Submits whatever the sub-menu trail currently spells out, marked as a prompt. */
     fun submitPendingTrailAsAskMe() {
         val trail = localState.value.navStack
@@ -1129,6 +1156,76 @@ class AppViewModel(
         return runCatching { storage.uploadBarLogo(barId, image) }
             .onFailure { logWarning("Could not upload a logo for $barId", it) }
     }
+
+    // --- Bottle scanner -------------------------------------------------
+
+    /** True when this platform can read a label at all. */
+    val bottleRecognitionSupported: Boolean get() = bottleRecognizer.isSupported
+
+    /**
+     * Reads [photo] and returns the closest known brand, or null.
+     *
+     * Candidates are the stock lists plus this bar's own inventory, so a
+     * bottle the bar already stocks matches even when it is in neither
+     * default list.
+     */
+    suspend fun recognizeBottle(photo: ByteArray): Result<String?> = runCatching {
+        val lines = bottleRecognizer.recognizeLines(photo)
+        val candidates = DEFAULT_SPIRITS + DEFAULT_BEERS +
+            state.value.bar?.beerInventory?.keys.orEmpty()
+        matchBrand(lines, candidates)
+    }.onFailure { logWarning("Bottle recognition failed", it) }
+
+    /**
+     * Adds a scanned bottle to the beer inventory.
+     *
+     * A brand that is already stocked takes the arrayUnion path rather
+     * than the merge-set one — the merge-set writes the whole array for
+     * that key and would wipe the types already recorded against it.
+     */
+    suspend fun addBottleToMenu(brand: String, type: String): Result<Unit> = withBar { barId ->
+        val existing = state.value.bar?.beerInventory?.get(brand)
+        when {
+            existing == null -> {
+                bars.addBrand(barId, brand)
+                if (type.isNotBlank()) bars.addType(barId, brand, type)
+            }
+
+            type.isNotBlank() && type !in existing -> bars.addType(barId, brand, type)
+        }
+    }
+
+    /**
+     * Sends the scanned bottle to the floor, photo attached.
+     *
+     * The label is prefixed with "BEER: " to match the stock button's
+     * exact label rather than an invented prefix. The resolver maps a
+     * label to a button id, and a request with no resolvable id is
+     * treated as "cannot tell who this is for" and paged to everyone —
+     * so a made-up prefix mass-notifies the whole bar past everyone's
+     * preferences.
+     */
+    suspend fun sendBottleAlert(brand: String, photo: ByteArray): Result<Unit> {
+        val user = state.value.currentUser
+            ?: return Result.failure(IllegalStateException("Signed out"))
+        return withBar { barId ->
+            val photoUrl = storage.uploadBottlePhoto(
+                barId = barId,
+                uid = user.uid,
+                epochMillis = currentTimeMillis(),
+                jpegBytes = photo,
+            )
+            submitRequestNow(
+                barId = barId,
+                label = "${BEER_BUTTON_LABEL}$LABEL_SEPARATOR$brand",
+                photoUrl = photoUrl,
+            )
+        }
+    }
+
+    /** Hides a brand's grid tile, which is what "86 It" means for stock. */
+    suspend fun eightySixBrand(brand: String): Result<Unit> =
+        withBar { barId -> bars.hideButton(barId, "brand_$brand") }
 
     // --- Calendar -------------------------------------------------------
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -11,6 +11,7 @@ import com.hereliesaz.barbacker.MAX_IGNORED_IDS
 import com.hereliesaz.barbacker.NAG_INTERVAL_MILLIS
 import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.REQUEST_WINDOW_MILLIS
+import com.hereliesaz.barbacker.POS_INSIGHTS_WINDOW_MILLIS
 import com.hereliesaz.barbacker.REQUEST_WINDOW_REFRESH_MILLIS
 import com.hereliesaz.barbacker.currentTimeMillis
 import com.hereliesaz.barbacker.data.AccountProfile
@@ -18,8 +19,11 @@ import com.hereliesaz.barbacker.data.AuthRepository
 import com.hereliesaz.barbacker.data.AuthState
 import com.hereliesaz.barbacker.data.BarRepository
 import com.hereliesaz.barbacker.data.CHAT_PAGE_SIZE
+import com.hereliesaz.barbacker.data.CalendarEventDraft
+import com.hereliesaz.barbacker.data.CalendarRepository
 import com.hereliesaz.barbacker.data.ChatRepository
 import com.hereliesaz.barbacker.data.EightySixRepository
+import com.hereliesaz.barbacker.data.GoogleCalendar
 import com.hereliesaz.barbacker.data.InvitableRole
 import com.hereliesaz.barbacker.data.KeyValueStore
 import com.hereliesaz.barbacker.data.MembershipRepository
@@ -30,13 +34,17 @@ import com.hereliesaz.barbacker.data.PLACE_SEARCH_MIN_LENGTH
 import com.hereliesaz.barbacker.data.PlaceResult
 import com.hereliesaz.barbacker.data.PickedImage
 import com.hereliesaz.barbacker.data.PlaceSearchRepository
+import com.hereliesaz.barbacker.data.POSSales
+import com.hereliesaz.barbacker.data.PosRepository
 import com.hereliesaz.barbacker.data.PushTokenProvider
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.data.StorageRepository
+import com.hereliesaz.barbacker.data.UrlOpener
 import com.hereliesaz.barbacker.logWarning
 import com.hereliesaz.barbacker.logic.ButtonTap
 import com.hereliesaz.barbacker.logic.classifyTap
+import com.hereliesaz.barbacker.logic.isoFromEpochMillis
 import com.hereliesaz.barbacker.logic.hasOutstandingAlerts
 import com.hereliesaz.barbacker.logic.requestLabelFor
 import com.hereliesaz.barbacker.model.Bar
@@ -44,12 +52,17 @@ import com.hereliesaz.barbacker.model.BarRole
 import com.hereliesaz.barbacker.model.BarTheme
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.model.CalendarConnectionStatus
+import com.hereliesaz.barbacker.model.CalendarEvent
 import com.hereliesaz.barbacker.model.ChatMessage
 import com.hereliesaz.barbacker.model.EightySixEntry
 import com.hereliesaz.barbacker.model.EightySixVisibility
+import com.hereliesaz.barbacker.model.ICalSubscription
 import com.hereliesaz.barbacker.model.JoinPolicy
 import com.hereliesaz.barbacker.model.MemberStatus
 import com.hereliesaz.barbacker.model.OwnershipClaim
+import com.hereliesaz.barbacker.model.POSConnectionStatus
+import com.hereliesaz.barbacker.model.POSMenuItem
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.model.SubscriptionTier
 import kotlinx.coroutines.coroutineScope
@@ -84,10 +97,15 @@ class AppViewModel(
     private val eightySix: EightySixRepository,
     private val ownershipClaims: OwnershipClaimRepository,
     private val storage: StorageRepository,
+    private val calendar: CalendarRepository,
+    private val pos: PosRepository,
+    private val urls: UrlOpener,
     private val placeSearch: PlaceSearchRepository,
     private val pushTokens: PushTokenProvider,
     private val alerter: Alerter,
     private val store: KeyValueStore,
+    /** Where the outbound iCal feed is served from, if configured. */
+    private val icalFeedBaseUrl: String? = null,
 ) : ViewModel() {
 
     /** State the client owns outright, with no Firestore counterpart. */
@@ -206,14 +224,79 @@ class AppViewModel(
         FeatureScope(chatScope, entries, claims, account)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FeatureScope())
 
+    /** The calendar's four subscriptions, resolved together. */
+    private data class CalendarScope(
+        val events: List<CalendarEvent> = emptyList(),
+        val googleConnection: CalendarConnectionStatus? = null,
+        val subscriptions: List<ICalSubscription> = emptyList(),
+        val feedToken: String? = null,
+    )
+
+    private data class PosScope(
+        val connections: Map<String, POSConnectionStatus> = emptyMap(),
+        val menu: List<POSMenuItem> = emptyList(),
+    )
+
+    private data class IntegrationScope(
+        val calendar: CalendarScope = CalendarScope(),
+        val pos: PosScope = PosScope(),
+    )
+
+    /** barId paired with Manager+, for the subscriptions the rules gate on it. */
+    private val managedBarFlow = combine(barIdFlow, isManagerPlusFlow) { barId, isManagerPlus ->
+        barId to isManagerPlus
+    }
+
+    /**
+     * Calendar and POS, kept live rather than opened on demand.
+     *
+     * Matching the web client: the calendar is glanceable data the floor
+     * uses, and the settings collections are small and only ever fetched
+     * for Manager+ — the repositories return empty for everyone else
+     * rather than subscribing to something the rules will deny.
+     */
+    @Suppress("OPT_IN_USAGE")
+    private val integrationScope: StateFlow<IntegrationScope> = combine(
+        combine(
+            barIdFlow.flatMapLatest { calendar.eventsFlow(it) },
+            managedBarFlow.flatMapLatest { (barId, isManagerPlus) ->
+                calendar.googleConnectionFlow(barId, isManagerPlus)
+            },
+            managedBarFlow.flatMapLatest { (barId, isManagerPlus) ->
+                calendar.icalSubscriptionsFlow(barId, isManagerPlus)
+            },
+            managedBarFlow.flatMapLatest { (barId, isManagerPlus) ->
+                calendar.feedTokenFlow(barId, isManagerPlus)
+            },
+        ) { events, connection, subscriptions, token ->
+            CalendarScope(events, connection, subscriptions, token)
+        },
+        combine(
+            managedBarFlow.flatMapLatest { (barId, isManagerPlus) ->
+                pos.connectionsFlow(barId, isManagerPlus)
+            },
+            managedBarFlow.flatMapLatest { (barId, isManagerPlus) ->
+                pos.menuFlow(barId, isManagerPlus)
+            },
+        ) { connections, menu -> PosScope(connections, menu) },
+    ) { calendarScope, posScope ->
+        IntegrationScope(calendarScope, posScope)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), IntegrationScope())
+
+    // Paired up because `combine` tops out at five typed sources and the
+    // state assembly below already uses all five.
+    private val sideScopes = combine(featureScope, integrationScope) { features, integrations ->
+        features to integrations
+    }
+
     @Suppress("OPT_IN_USAGE")
     val state: StateFlow<AppUiState> = combine(
         auth.state,
         barIdFlow,
         barScope,
-        featureScope,
+        sideScopes,
         localState,
-    ) { authState, barId, scope, features, local ->
+    ) { authState, barId, scope, (features, integrations), local ->
         val account = features.account
         AppUiState(
             auth = authState,
@@ -248,6 +331,13 @@ class AppViewModel(
             inputPrompt = local.inputPrompt,
             quantityPrompt = local.quantityPrompt,
             pendingOrders = local.pendingOrders,
+            calendarEvents = integrations.calendar.events,
+            googleCalendarConnection = integrations.calendar.googleConnection,
+            icalSubscriptions = integrations.calendar.subscriptions,
+            icalFeedToken = integrations.calendar.feedToken,
+            icalFeedBaseUrl = icalFeedBaseUrl,
+            posConnections = integrations.pos.connections,
+            posMenu = integrations.pos.menu,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -1038,6 +1128,106 @@ class AppViewModel(
         val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
         return runCatching { storage.uploadBarLogo(barId, image) }
             .onFailure { logWarning("Could not upload a logo for $barId", it) }
+    }
+
+    // --- Calendar -------------------------------------------------------
+
+    suspend fun createCalendarEvent(draft: CalendarEventDraft): Result<Unit> =
+        withBar { barId -> calendar.createEvent(barId, draft) }
+
+    suspend fun updateCalendarEvent(eventId: String, draft: CalendarEventDraft): Result<Unit> =
+        withBar { barId -> calendar.updateEvent(barId, eventId, draft) }
+
+    suspend fun deleteCalendarEvent(eventId: String): Result<Unit> =
+        withBar { barId -> calendar.deleteEvent(barId, eventId) }
+
+    /**
+     * Starts the Google consent flow in the platform browser.
+     *
+     * There is no redirect back into this app — the callback lands on the
+     * Cloud Function, which writes the connection document, and the
+     * listener here picks it up when the user returns. Failing to open a
+     * browser is reported rather than swallowed, because otherwise the
+     * button looks like it did nothing.
+     */
+    suspend fun connectGoogleCalendar(): Result<Unit> = withBar { barId ->
+        val url = calendar.googleAuthorizeUrl(barId)
+        if (!urls.open(url)) error("No browser available")
+    }
+
+    suspend fun listGoogleCalendars(): Result<List<GoogleCalendar>> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        return runCatching { calendar.listGoogleCalendars(barId) }
+            .onFailure { logWarning("Could not list Google calendars", it) }
+    }
+
+    suspend fun selectGoogleCalendar(calendarId: String): Result<Unit> =
+        withBar { barId -> calendar.selectGoogleCalendar(barId, calendarId) }
+
+    suspend fun disconnectGoogleCalendar(): Result<Unit> =
+        withBar { barId -> calendar.disconnectGoogle(barId) }
+
+    suspend fun addICalSubscription(url: String): Result<Unit> {
+        val uid = state.value.currentUser?.uid
+            ?: return Result.failure(IllegalStateException("Signed out"))
+        return withBar { barId -> calendar.addICalSubscription(barId, url, uid) }
+    }
+
+    suspend fun removeICalSubscription(subscriptionId: String): Result<Unit> =
+        withBar { barId -> calendar.removeICalSubscription(barId, subscriptionId) }
+
+    suspend fun rotateICalFeedToken(revoke: Boolean): Result<Unit> =
+        withBar { barId -> calendar.rotateFeedToken(barId, revoke) }
+
+    // --- POS ------------------------------------------------------------
+
+    suspend fun connectSquare(): Result<Unit> = withBar { barId ->
+        val url = pos.squareAuthorizeUrl(barId)
+        if (!urls.open(url)) error("No browser available")
+    }
+
+    suspend fun connectToast(
+        clientId: String,
+        clientSecret: String,
+        restaurantGuid: String,
+    ): Result<Unit> = withBar { barId ->
+        pos.connectToast(barId, clientId, clientSecret, restaurantGuid)
+    }
+
+    suspend fun disconnectPos(provider: String): Result<Unit> =
+        withBar { barId -> pos.disconnect(barId, provider) }
+
+    suspend fun syncPosMenu(provider: String): Result<Int> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        return runCatching { pos.syncMenu(barId, provider) }
+            .onFailure { logWarning("Could not sync the $provider menu", it) }
+    }
+
+    /** The same seven-day window the web client's insights button uses. */
+    suspend fun getPosSales(provider: String): Result<POSSales> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        val end = currentTimeMillis()
+        return runCatching {
+            pos.getSales(
+                barId = barId,
+                provider = provider,
+                start = isoFromEpochMillis(end - POS_INSIGHTS_WINDOW_MILLIS),
+                end = isoFromEpochMillis(end),
+            )
+        }.onFailure { logWarning("Could not load $provider sales", it) }
+    }
+
+    /**
+     * Runs [block] against the selected bar, or fails if there isn't one.
+     *
+     * The failure is a Result rather than a silent return so the dialog
+     * that called it shows something — every one of these actions is
+     * behind a button the user just pressed.
+     */
+    private suspend fun withBar(block: suspend (String) -> Unit): Result<Unit> {
+        val barId = barIdFlow.value ?: return Result.failure(IllegalStateException("No bar"))
+        return runCatching { block(barId) }
+            .onFailure { logWarning("Bar-scoped action failed for $barId", it) }
     }
 
     // --- Dialogs --------------------------------------------------------

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/DateTimeField.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/DateTimeField.kt
@@ -1,0 +1,138 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.barbacker.logic.EventTimeParts
+import com.hereliesaz.barbacker.logic.epochMillisOf
+import com.hereliesaz.barbacker.logic.eventTimePartsFromMillis
+import com.hereliesaz.barbacker.logic.formatClockTime
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.datetime.TimeZone
+
+/**
+ * A date and a time, each behind its own picker.
+ *
+ * Two controls rather than one because Material has no combined
+ * date-and-time picker, and because a manager adjusting a shift usually
+ * wants to change only one of them.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DateTimeField(
+    label: String,
+    parts: EventTimeParts,
+    onChange: (EventTimeParts) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var pickingDate by remember { mutableStateOf(false) }
+    var pickingTime by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedButton(onClick = { pickingDate = true }, modifier = Modifier.weight(1f)) {
+                Text("${parts.year}-${pad(parts.month)}-${pad(parts.day)}")
+            }
+            OutlinedButton(onClick = { pickingTime = true }, modifier = Modifier.weight(1f)) {
+                Text(formatClockTime(parts.hour, parts.minute))
+            }
+        }
+    }
+
+    if (pickingDate) {
+        // Material's date picker works in UTC midnights — the value it
+        // hands back is the picked CALENDAR DAY at 00:00Z, not an instant
+        // in the user's zone. Seeding and reading it back through
+        // TimeZone.UTC is what keeps a date picked late in the evening
+        // from landing on the following day.
+        val state = rememberDatePickerState(
+            initialSelectedDateMillis = epochMillisOf(
+                parts.copy(hour = 0, minute = 0),
+                TimeZone.UTC,
+            ),
+        )
+        DatePickerDialog(
+            onDismissRequest = { pickingDate = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        state.selectedDateMillis?.let { millis ->
+                            val picked = eventTimePartsFromMillis(millis, TimeZone.UTC)
+                            onChange(
+                                parts.copy(
+                                    year = picked.year,
+                                    month = picked.month,
+                                    day = picked.day,
+                                ),
+                            )
+                        }
+                        pickingDate = false
+                    },
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pickingDate = false }) { Text("Cancel") }
+            },
+            colors = androidx.compose.material3.DatePickerDefaults.colors(
+                containerColor = BarBackerColors.SurfaceContainer,
+            ),
+        ) {
+            DatePicker(state = state)
+        }
+    }
+
+    if (pickingTime) {
+        val state = rememberTimePickerState(
+            initialHour = parts.hour,
+            initialMinute = parts.minute,
+            is24Hour = false,
+        )
+        // Not a DatePickerDialog: Material ships no TimePickerDialog, so
+        // the picker goes in a plain AlertDialog with the same buttons.
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { pickingTime = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onChange(parts.copy(hour = state.hour, minute = state.minute))
+                        pickingTime = false
+                    },
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pickingTime = false }) { Text("Cancel") }
+            },
+            text = { TimePicker(state = state) },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+private fun pad(value: Int): String = value.toString().padStart(2, '0')

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/PhotoBytesImage.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/PhotoBytesImage.kt
@@ -1,0 +1,58 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.runtime.remember
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import org.jetbrains.compose.resources.decodeToImageBitmap
+
+/**
+ * Renders encoded image bytes already in memory.
+ *
+ * Decoding is cached on the byte array's identity, so scrolling past a
+ * captured photo does not re-decode it every frame. A failed decode draws
+ * a labelled placeholder rather than nothing: the surrounding screen
+ * still works, and an empty box would read as a layout bug.
+ *
+ * This handles bytes the app itself produced. Remote images — a bar's
+ * logo, a request's photo URL — would need a network image loader, which
+ * this build does not carry.
+ */
+@Composable
+fun PhotoBytesImage(
+    bytes: ByteArray,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+) {
+    val bitmap = remember(bytes) { runCatching { bytes.decodeToImageBitmap() }.getOrNull() }
+
+    if (bitmap == null) {
+        Box(
+            modifier = modifier.background(BarBackerColors.SurfaceContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Preview unavailable",
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    Image(
+        bitmap = bitmap,
+        contentDescription = contentDescription,
+        contentScale = contentScale,
+        modifier = modifier.background(Color.Black),
+    )
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.kt
@@ -1,0 +1,35 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+
+/** Opens the platform camera. Safe to call more than once. */
+interface PhotoCaptureLauncher {
+    /**
+     * Whether this platform can take a photo at all.
+     *
+     * False on desktop. Reported so the scanner can say the brand has to
+     * be typed, rather than offering a button that does nothing.
+     */
+    val isSupported: Boolean
+
+    fun launch()
+}
+
+/**
+ * A camera capture, wired to the calling composable's lifetime.
+ *
+ * Yields JPEG bytes rather than a platform handle, for the same reason
+ * [rememberImagePicker] does: a content `Uri`, a `java.io.File`, and an
+ * `NSURL` behind a security scope have nothing in common that survives
+ * being handed to shared code.
+ *
+ * Cancelling calls neither callback — backing out of the camera is not a
+ * failure. Denying the camera permission does call [onError], because
+ * that one leaves the user looking at a button that will keep doing
+ * nothing until they change their mind.
+ */
+@Composable
+expect fun rememberPhotoCapture(
+    onCaptured: (ByteArray) -> Unit,
+    onError: (String) -> Unit,
+): PhotoCaptureLauncher

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/RemoteImage.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/RemoteImage.kt
@@ -1,0 +1,90 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import coil3.compose.setSingletonImageLoaderFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.request.crossfade
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import io.ktor.client.HttpClient
+
+/**
+ * Installs the process-wide image loader.
+ *
+ * Called once from the app root. Coil fetches over the [HttpClient] this
+ * app already built for its place search rather than resolving an engine
+ * of its own — two HTTP stacks in one process means two connection pools
+ * and two sets of timeouts to keep straight, and on iOS the second one may
+ * not resolve an engine at all.
+ */
+@Composable
+fun InstallImageLoader(httpClient: HttpClient) {
+    setSingletonImageLoaderFactory { context: PlatformContext ->
+        ImageLoader.Builder(context)
+            .components { add(KtorNetworkFetcherFactory(httpClient = { httpClient })) }
+            .crossfade(true)
+            .build()
+    }
+}
+
+/**
+ * An image fetched from a URL, with explicit loading and failure states.
+ *
+ * Both states are drawn rather than left blank. A bottle photo attached to
+ * a page is evidence — a barback photographed an empty bottle so someone
+ * could see it — and an empty box gives no way to tell "still loading"
+ * from "this device cannot read it", which for a Storage URL usually means
+ * the reader is not a member of that bar.
+ */
+@Composable
+fun RemoteImage(
+    url: String,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Crop,
+) {
+    val painter = rememberAsyncImagePainter(model = url, contentScale = contentScale)
+    // Coil's own placeholder/error slots take Painters, and there is no
+    // drawable resource here to hand them — so the state is read directly
+    // and each case rendered as a composable instead.
+    val state by painter.state.collectAsState()
+
+    when (state) {
+        is AsyncImagePainter.State.Success -> Image(
+            painter = painter,
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            modifier = modifier,
+        )
+
+        is AsyncImagePainter.State.Error -> ImageMessage("Unavailable", modifier)
+        else -> ImageMessage("…", modifier)
+    }
+}
+
+@Composable
+private fun ImageMessage(text: String, modifier: Modifier) {
+    Box(
+        modifier = modifier.background(BarBackerColors.SurfaceContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ReorderableGrid.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/ReorderableGrid.kt
@@ -17,9 +17,16 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -133,11 +140,70 @@ class GridReorderState internal constructor(internal val gridState: LazyGridStat
         draggingKey = null
         draggingIndex = -1
         moved = false
+        keyboardHeld = false
+    }
+
+    // --- Keyboard reordering --------------------------------------------
+
+    /**
+     * True while a tile has been picked up with the keyboard rather than a
+     * finger.
+     *
+     * Kept separate from [draggingKey] being non-null because the two
+     * behave differently in one respect that matters: a pointer drag ends
+     * when the finger lifts, while a keyboard pickup persists across key
+     * presses until it is explicitly dropped. [translationFor] also has to
+     * stay at zero for a keyboard drag — there is no pointer to follow, and
+     * the tile is genuinely moving between slots rather than floating.
+     */
+    var keyboardHeld: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Picks up or drops the tile at [index].
+     *
+     * The same key toggles both, which is the convention every desktop
+     * list-reordering affordance uses and what the web client's
+     * KeyboardSensor implements.
+     */
+    internal fun toggleKeyboardHold(index: Int, key: Any) {
+        if (keyboardHeld) {
+            onDragEnd()
+            return
+        }
+        if (!canReorder(index)) return
+        draggingKey = key
+        draggingIndex = index
+        moved = false
+        keyboardHeld = true
+    }
+
+    /** Moves a keyboard-held tile by [delta] slots. Returns false if it could not. */
+    internal fun moveKeyboard(delta: Int): Boolean {
+        if (!keyboardHeld) return false
+        val target = draggingIndex + delta
+        // Bounded here rather than left to [canReorder]: that predicate is
+        // caller-supplied, and a tile skidding off either end of the grid
+        // is not something to leave to a callback's good manners.
+        if (target !in 0 until gridState.layoutInfo.totalItemsCount) return false
+        if (!canReorder(target)) return false
+        onMove(draggingIndex, target)
+        draggingIndex = target
+        moved = true
+        return true
+    }
+
+    internal fun cancelKeyboardHold() {
+        if (!keyboardHeld) return
+        onDragCancel()
     }
 
     /** Draw-phase offset for the tile with [key]; zero for every other tile. */
     internal fun translationFor(key: Any): Offset {
         if (key != draggingKey) return Offset.Zero
+        // A keyboard-held tile really does occupy each slot it moves
+        // through; only a pointer drag floats above the grid.
+        if (keyboardHeld) return Offset.Zero
         // Read fresh from the layout rather than cached at pickup: the grid
         // can auto-scroll mid-drag, which moves the tile's slot while the
         // finger stays put.
@@ -272,16 +338,75 @@ fun Modifier.reorderable(state: GridReorderState): Modifier =
         }
     }
 
-/** Attaches the lift-and-follow rendering. Apply to each item, keyed as the grid keys it. */
-fun Modifier.reorderableItem(state: GridReorderState, key: Any): Modifier =
-    this.zIndex(if (state.draggingKey == key) 1f else 0f)
+/**
+ * Attaches the lift-and-follow rendering, and the keyboard path.
+ *
+ * Apply to each item, keyed as the grid keys it. [index] and [columns] are
+ * what let the arrow keys mean anything: a grid is a list underneath, so
+ * left/right is ±1 and up/down is ±[columns].
+ *
+ * Without this the grid has no keyboard-operable reordering at all —
+ * exactly the gap the web client's `SortableButton` had to be fixed for.
+ * A pointer is not the only way people use a tablet wedged behind a bar.
+ */
+fun Modifier.reorderableItem(
+    state: GridReorderState,
+    key: Any,
+    index: Int,
+    columns: Int,
+    enabled: Boolean = true,
+): Modifier {
+    val held = state.draggingKey == key && state.keyboardHeld
+    return this
+        .zIndex(if (state.draggingKey == key) 1f else 0f)
         .graphicsLayer {
             val offset = state.translationFor(key)
             translationX = offset.x
             translationY = offset.y
             if (state.draggingKey == key) {
-                scaleX = 1.05f
-                scaleY = 1.05f
+                // A keyboard-held tile is only lifted, not scaled: it is
+                // sitting in a real slot, and scaling it would overlap the
+                // neighbours it is about to swap with.
+                if (!state.keyboardHeld) {
+                    scaleX = 1.05f
+                    scaleY = 1.05f
+                }
                 alpha = 0.9f
             }
         }
+        .semantics {
+            stateDescription = if (held) "Held for reordering" else ""
+        }
+        .then(
+            if (!enabled) {
+                Modifier
+            } else {
+                Modifier.onKeyEvent { event ->
+                    // KeyUp only. A held-down arrow otherwise repeats at the
+                    // platform's key-repeat rate and skids the tile across
+                    // the grid faster than anyone can track.
+                    if (event.type != KeyEventType.KeyUp) return@onKeyEvent false
+                    when (event.key) {
+                        Key.Spacebar, Key.Enter -> {
+                            state.toggleKeyboardHold(index, key)
+                            true
+                        }
+
+                        Key.Escape -> {
+                            val wasHeld = state.keyboardHeld
+                            state.cancelKeyboardHold()
+                            // Consumed only when it did something, so Escape
+                            // still closes an enclosing dialog otherwise.
+                            wasHeld
+                        }
+
+                        Key.DirectionLeft -> state.moveKeyboard(-1)
+                        Key.DirectionRight -> state.moveKeyboard(1)
+                        Key.DirectionUp -> state.moveKeyboard(-columns)
+                        Key.DirectionDown -> state.moveKeyboard(columns)
+                        else -> false
+                    }
+                }
+            },
+        )
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BottleScannerDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/BottleScannerDialog.kt
@@ -1,0 +1,274 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.barbacker.ui.PhotoBytesImage
+import com.hereliesaz.barbacker.ui.rememberPhotoCapture
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/** What the scanner is doing right now. */
+private enum class ScanStage { Idle, Reading, Ready }
+
+/** Which action is in flight, so only the pressed button shows progress. */
+private enum class ScanAction { Menu, EightySix, Alert }
+
+/** The scanner's callbacks, grouped to keep the signature readable. */
+data class BottleScannerActions(
+    /** Reads label text and returns the best-matching known brand, or null. */
+    val onRecognize: suspend (ByteArray) -> Result<String?>,
+    val onAddToMenu: suspend (brand: String, type: String) -> Result<Unit>,
+    val onEightySix: suspend (brand: String) -> Result<Unit>,
+    val onSendAlert: suspend (brand: String, photo: ByteArray) -> Result<Unit>,
+)
+
+/**
+ * Point the camera at a bottle, confirm the brand, then act on it.
+ *
+ * OCR runs on the device — the photo is only uploaded by "Send Alert",
+ * and then only to this bar's own bucket so staff can see what was
+ * scanned. Recognition is a prefill, never a decision: the brand field is
+ * always editable, and a platform with no OCR (desktop) simply starts
+ * with it empty.
+ */
+@Composable
+fun BottleScannerDialog(
+    isManagerPlus: Boolean,
+    existingBrands: List<String>,
+    recognitionSupported: Boolean,
+    actions: BottleScannerActions,
+    onClose: () -> Unit,
+) {
+    var stage by remember { mutableStateOf(ScanStage.Idle) }
+    var photo by remember { mutableStateOf<ByteArray?>(null) }
+    var brand by remember { mutableStateOf("") }
+    var type by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+    var submitting by remember { mutableStateOf<ScanAction?>(null) }
+    val scope = rememberCoroutineScope()
+
+    val capture = rememberPhotoCapture(
+        onCaptured = { bytes ->
+            photo = bytes
+            error = null
+            if (!recognitionSupported) {
+                stage = ScanStage.Ready
+                return@rememberPhotoCapture
+            }
+            stage = ScanStage.Reading
+            scope.launch {
+                actions.onRecognize(bytes)
+                    .onSuccess { brand = it.orEmpty() }
+                    .onFailure { error = "Couldn't read the label. Type the brand instead." }
+                // Ready either way: a failed read is not a failed scan,
+                // and the photo is still worth sending.
+                stage = ScanStage.Ready
+            }
+        },
+        onError = {
+            error = it
+            stage = ScanStage.Idle
+        },
+    )
+
+    val trimmedBrand = brand.trim()
+
+    // Case-insensitive to FIND the brand, but every downstream write is
+    // case-sensitive: the inventory map is keyed by exact name and the
+    // hidden-button id is built as "brand_<name>". Scanning "JAMESON"
+    // against an existing "Jameson" has to resolve to "Jameson", or "Add
+    // to Menu" creates a second disconnected entry and "86 It" hides an
+    // id matching no real button.
+    val matchedBrand = existingBrands.firstOrNull { it.equals(trimmedBrand, ignoreCase = true) }
+    val canonicalBrand = matchedBrand ?: trimmedBrand
+
+    fun run(action: ScanAction, block: suspend () -> Result<Unit>) {
+        if (submitting != null) return
+        submitting = action
+        error = null
+        scope.launch {
+            block()
+                .onSuccess { onClose() }
+                .onFailure {
+                    error = "That failed. Please try again."
+                    submitting = null
+                }
+        }
+    }
+
+    BarBackerDialog(
+        title = "Scan Bottle",
+        onDismiss = onClose,
+        actions = {
+            TextButton(onClick = onClose) { Text("Close") }
+            if (stage == ScanStage.Ready) {
+                Spacer(Modifier.weight(1f))
+                Button(
+                    onClick = {
+                        val bytes = photo ?: return@Button
+                        run(ScanAction.Alert) { actions.onSendAlert(canonicalBrand, bytes) }
+                    },
+                    enabled = trimmedBrand.isNotEmpty() && submitting == null && photo != null,
+                ) {
+                    Text(if (submitting == ScanAction.Alert) "Sending..." else "Send Alert")
+                }
+            }
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 440.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (!capture.isSupported) {
+                Text(
+                    text = "This device has no camera. The scanner needs one.",
+                    color = BarBackerColors.Warning,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            if (stage == ScanStage.Idle) {
+                FilledTonalButton(
+                    onClick = { capture.launch() },
+                    enabled = capture.isSupported,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Filled.PhotoCamera, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("Take Photo")
+                }
+            }
+
+            photo?.let { bytes ->
+                PhotoBytesImage(
+                    bytes = bytes,
+                    contentDescription = "Captured bottle",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                )
+            }
+
+            if (stage == ScanStage.Reading) {
+                Text(
+                    text = "Reading label...",
+                    color = BarBackerColors.OnSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth().padding(8.dp),
+                )
+            }
+
+            if (stage == ScanStage.Ready) {
+                if (!recognitionSupported) {
+                    Text(
+                        text = "No label reader on this platform — type the brand.",
+                        color = BarBackerColors.OnSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+
+                OutlinedTextField(
+                    value = brand,
+                    onValueChange = { brand = it },
+                    label = { Text("Brand") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = type,
+                    onValueChange = { type = it },
+                    label = { Text("Type (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                if (matchedBrand != null) {
+                    Text(
+                        text = "Already on the menu as \"$matchedBrand\".",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BarBackerColors.OnSurfaceVariant,
+                    )
+                }
+
+                if (isManagerPlus) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(
+                            onClick = {
+                                run(ScanAction.Menu) {
+                                    actions.onAddToMenu(canonicalBrand, type.trim())
+                                }
+                            },
+                            enabled = trimmedBrand.isNotEmpty() && submitting == null,
+                        ) {
+                            Text(if (submitting == ScanAction.Menu) "Adding..." else "Add to Menu")
+                        }
+                        // Only offered for a brand that is actually on the
+                        // menu — 86'ing one that was never added hides a
+                        // button id nothing renders.
+                        if (matchedBrand != null) {
+                            OutlinedButton(
+                                onClick = {
+                                    run(ScanAction.EightySix) {
+                                        actions.onEightySix(canonicalBrand)
+                                    }
+                                },
+                                enabled = submitting == null,
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    contentColor = BarBackerColors.Error,
+                                ),
+                            ) {
+                                Text(
+                                    if (submitting == ScanAction.EightySix) "Marking..." else "86 It",
+                                )
+                            }
+                        }
+                    }
+                }
+
+                TextButton(onClick = { capture.launch() }, enabled = submitting == null) {
+                    Text("Retake")
+                }
+            }
+
+            error?.let {
+                Text(it, color = BarBackerColors.Error, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/CalendarDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/CalendarDialog.kt
@@ -1,0 +1,387 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.currentTimeMillis
+import com.hereliesaz.barbacker.data.CalendarEventDraft
+import com.hereliesaz.barbacker.logic.EventTimeParts
+import com.hereliesaz.barbacker.logic.eventTimePartsFromMillis
+import com.hereliesaz.barbacker.logic.eventTimePartsOf
+import com.hereliesaz.barbacker.logic.formatEventRange
+import com.hereliesaz.barbacker.logic.isoFromEventTimeParts
+import com.hereliesaz.barbacker.model.CalendarEvent
+import com.hereliesaz.barbacker.ui.DateTimeField
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/** One hour, the default length of a newly added event. */
+private const val DEFAULT_EVENT_MILLIS = 60L * 60L * 1000L
+
+private val EVENT_TYPES = listOf(
+    "event" to "Event",
+    "shift" to "Shift",
+    "booking" to "Booking",
+)
+
+private fun colorForType(type: String): Color = when (type) {
+    "shift" -> Color(0xFF3B82F6)
+    "booking" -> Color(0xFF8B5CF6)
+    "event" -> Color(0xFF22C55E)
+    // A provider-supplied type this client does not know about still has
+    // to render — a synced Google event can carry anything.
+    else -> BarBackerColors.OnSurfaceVariant
+}
+
+/**
+ * The bar's calendar, as a chronological agenda.
+ *
+ * An agenda rather than a month grid, matching the web client: the sync,
+ * the permissions, and the data model underneath are all real, and a grid
+ * is a presentation choice that can follow later. On a phone behind a bar
+ * it is arguably the better one anyway.
+ *
+ * Externally-owned events — anything an inbound Google or iCal sync wrote
+ * — render read-only with a badge. That is not a UI preference:
+ * `firestore.rules` rejects a client write to any event carrying an
+ * `externalProvider`, so an edit control there would only ever fail.
+ */
+@Composable
+fun CalendarDialog(
+    events: List<CalendarEvent>,
+    isManagerPlus: Boolean,
+    onCreate: suspend (CalendarEventDraft) -> Result<Unit>,
+    onUpdate: suspend (eventId: String, CalendarEventDraft) -> Result<Unit>,
+    onDelete: suspend (eventId: String) -> Result<Unit>,
+    onOpenSettings: (() -> Unit)?,
+    onClose: () -> Unit,
+) {
+    var editing by remember { mutableStateOf<EventEditorTarget?>(null) }
+    var confirmDeleteId by remember { mutableStateOf<String?>(null) }
+    var deleteError by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    BarBackerDialog(
+        title = "Calendar",
+        onDismiss = onClose,
+        actions = {
+            if (onOpenSettings != null) {
+                TextButton(onClick = onOpenSettings) { Text("Settings") }
+                Spacer(Modifier.weight(1f))
+            }
+            TextButton(onClick = onClose) { Text("Close") }
+        },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (isManagerPlus) {
+                FilledTonalButton(
+                    onClick = { editing = EventEditorTarget.New },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("Add Event")
+                }
+            }
+
+            deleteError?.let {
+                Text(it, color = BarBackerColors.Error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            if (events.isEmpty()) {
+                Text(
+                    text = "Nothing on the calendar.",
+                    color = BarBackerColors.OnSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(24.dp),
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 400.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(events, key = { it.id }) { event ->
+                        EventRow(
+                            event = event,
+                            canEdit = isManagerPlus && !event.isExternallyOwned,
+                            onEdit = { editing = EventEditorTarget.Existing(event) },
+                            onDelete = {
+                                deleteError = null
+                                confirmDeleteId = event.id
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    editing?.let { target ->
+        EventEditorDialog(
+            target = target,
+            onDismiss = { editing = null },
+            onSave = { draft ->
+                when (target) {
+                    EventEditorTarget.New -> onCreate(draft)
+                    is EventEditorTarget.Existing -> onUpdate(target.event.id, draft)
+                }
+            },
+            onSaved = { editing = null },
+        )
+    }
+
+    confirmDeleteId?.let { id ->
+        AlertDialog(
+            onDismissRequest = { confirmDeleteId = null },
+            title = { Text("Delete event?") },
+            text = { Text("This can't be undone.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        confirmDeleteId = null
+                        scope.launch {
+                            onDelete(id).onFailure {
+                                deleteError = "Failed to delete. Please try again."
+                            }
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BarBackerColors.Error,
+                        contentColor = BarBackerColors.OnError,
+                    ),
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteId = null }) { Text("Cancel") }
+            },
+            containerColor = BarBackerColors.SurfaceContainer,
+        )
+    }
+}
+
+private sealed interface EventEditorTarget {
+    data object New : EventEditorTarget
+    data class Existing(val event: CalendarEvent) : EventEditorTarget
+}
+
+@Composable
+private fun EventRow(
+    event: CalendarEvent,
+    canEdit: Boolean,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = 5.dp)
+                .size(10.dp)
+                .background(colorForType(event.type), CircleShape),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = event.title,
+                fontWeight = FontWeight.Medium,
+                color = BarBackerColors.OnSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = formatEventRange(event.start, event.end),
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+            event.description?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            event.externalProvider?.let {
+                Text(
+                    text = "SYNCED FROM ${it.uppercase()}",
+                    fontSize = 10.sp,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+        }
+        if (canEdit) {
+            Column(horizontalAlignment = Alignment.End) {
+                TextButton(onClick = onEdit) { Text("Edit") }
+                TextButton(onClick = onDelete) {
+                    Text("Delete", color = BarBackerColors.Error)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EventEditorDialog(
+    target: EventEditorTarget,
+    onDismiss: () -> Unit,
+    onSave: suspend (CalendarEventDraft) -> Result<Unit>,
+    onSaved: () -> Unit,
+) {
+    val existing = (target as? EventEditorTarget.Existing)?.event
+
+    var title by remember { mutableStateOf(existing?.title.orEmpty()) }
+    var description by remember { mutableStateOf(existing?.description.orEmpty()) }
+    var type by remember { mutableStateOf(existing?.type ?: "event") }
+    var start by remember { mutableStateOf(initialStart(existing)) }
+    var end by remember { mutableStateOf(initialEnd(existing)) }
+    var saving by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    BarBackerDialog(
+        title = if (existing == null) "Add Event" else "Edit Event",
+        onDismiss = onDismiss,
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(
+                onClick = {
+                    if (title.isBlank() || saving) return@Button
+                    saving = true
+                    error = null
+                    scope.launch {
+                        onSave(
+                            CalendarEventDraft(
+                                title = title,
+                                start = isoFromEventTimeParts(start),
+                                end = isoFromEventTimeParts(end),
+                                type = type,
+                                description = description.takeIf { it.isNotBlank() },
+                            ),
+                        )
+                            .onSuccess { onSaved() }
+                            .onFailure { error = "Failed to save. Please try again." }
+                        saving = false
+                    }
+                },
+                enabled = title.isNotBlank() && !saving,
+            ) {
+                Text(if (saving) "Saving..." else "Save")
+            }
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 420.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("Title") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            DateTimeField(label = "Starts", parts = start, onChange = { start = it })
+            DateTimeField(label = "Ends", parts = end, onChange = { end = it })
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                EVENT_TYPES.forEach { (value, label) ->
+                    FilterChip(
+                        selected = type == value,
+                        onClick = { type = value },
+                        label = { Text(label) },
+                    )
+                }
+            }
+
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text("Description (optional)") },
+                minLines = 2,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // An end before the start is allowed through rather than
+            // blocked: an overnight shift entered as 10 PM to 2 AM is a
+            // mistake the picker cannot distinguish from a deliberate
+            // same-day range, and refusing to save would be worse than
+            // saying so.
+            if (endsBeforeStart(start, end)) {
+                Text(
+                    text = "Ends before it starts. If this is an overnight " +
+                        "shift, move the end date to the next day.",
+                    color = BarBackerColors.Warning,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            error?.let {
+                Text(it, color = BarBackerColors.Error, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+private fun initialStart(existing: CalendarEvent?): EventTimeParts =
+    existing?.start?.let { eventTimePartsOf(it) }
+        ?: eventTimePartsFromMillis(currentTimeMillis())
+
+private fun initialEnd(existing: CalendarEvent?): EventTimeParts =
+    existing?.end?.let { eventTimePartsOf(it) }
+        ?: eventTimePartsFromMillis(currentTimeMillis() + DEFAULT_EVENT_MILLIS)
+
+private fun endsBeforeStart(start: EventTimeParts, end: EventTimeParts): Boolean =
+    isoFromEventTimeParts(end) < isoFromEventTimeParts(start)

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/CalendarSettingsDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/CalendarSettingsDialog.kt
@@ -1,0 +1,312 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.data.GoogleCalendar
+import com.hereliesaz.barbacker.model.CalendarConnectionStatus
+import com.hereliesaz.barbacker.model.ICalSubscription
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/** Everything the calendar settings screen can do. Grouped to keep the signature readable. */
+data class CalendarSettingsActions(
+    val onConnectGoogle: suspend () -> Result<Unit>,
+    val onListCalendars: suspend () -> Result<List<GoogleCalendar>>,
+    val onSelectCalendar: suspend (String) -> Result<Unit>,
+    val onDisconnectGoogle: suspend () -> Result<Unit>,
+    val onAddSubscription: suspend (String) -> Result<Unit>,
+    val onRemoveSubscription: suspend (String) -> Result<Unit>,
+    val onRotateFeedToken: suspend (revoke: Boolean) -> Result<Unit>,
+    val onCopyFeedUrl: (String) -> Unit,
+)
+
+/**
+ * Google connect, the outbound feed, and inbound `.ics` subscriptions.
+ *
+ * Manager+ only, and not merely by convention: every collection behind
+ * this screen is `isManagerPlus`-gated in `firestore.rules`, so a Staff
+ * member opening it would see three empty boxes and a permission error.
+ */
+@Composable
+fun CalendarSettingsDialog(
+    googleConnection: CalendarConnectionStatus?,
+    subscriptions: List<ICalSubscription>,
+    feedUrl: String?,
+    hasFeedToken: Boolean,
+    feedBaseConfigured: Boolean,
+    actions: CalendarSettingsActions,
+    onClose: () -> Unit,
+) {
+    var calendars by remember { mutableStateOf<List<GoogleCalendar>?>(null) }
+    var newSubscriptionUrl by remember { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+    var message by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    fun run(failureText: String, block: suspend () -> Result<Unit>) {
+        if (busy) return
+        busy = true
+        message = null
+        scope.launch {
+            block().onFailure { message = failureText }
+            busy = false
+        }
+    }
+
+    BarBackerDialog(
+        title = "Calendar Settings",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 460.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            SettingsSection("Google Calendar") {
+                if (googleConnection?.connected == true) {
+                    Text(
+                        text = googleConnection.calendarId
+                            ?.let { "Connected — $it" }
+                            ?: "Connected — no calendar selected yet",
+                        color = BarBackerColors.Success,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(
+                            enabled = !busy,
+                            onClick = {
+                                if (busy) return@OutlinedButton
+                                busy = true
+                                message = null
+                                scope.launch {
+                                    actions.onListCalendars()
+                                        .onSuccess { calendars = it }
+                                        .onFailure { message = "Could not list calendars." }
+                                    busy = false
+                                }
+                            },
+                        ) {
+                            Text(
+                                if (googleConnection.calendarId == null) {
+                                    "Pick Calendar"
+                                } else {
+                                    "Change Calendar"
+                                },
+                            )
+                        }
+                        TextButton(
+                            enabled = !busy,
+                            onClick = {
+                                run("Could not disconnect.") { actions.onDisconnectGoogle() }
+                            },
+                        ) { Text("Disconnect") }
+                    }
+
+                    calendars?.forEach { calendar ->
+                        TextButton(
+                            enabled = !busy,
+                            onClick = {
+                                run("Could not select that calendar.") {
+                                    actions.onSelectCalendar(calendar.id)
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                                text = calendar.summary.ifBlank { calendar.id } +
+                                    if (calendar.primary) " (primary)" else "",
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                } else {
+                    Button(
+                        enabled = !busy,
+                        onClick = { run("Could not start the Google connect flow.") { actions.onConnectGoogle() } },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Connect Google Calendar") }
+
+                    // The web client navigates the page and comes back
+                    // through the OAuth redirect. There is no redirect
+                    // back into this app, so the flow finishes in the
+                    // browser and the listener here picks it up. Saying
+                    // so beats a screen that appears to do nothing.
+                    Text(
+                        text = "Opens your browser. Come back here once " +
+                            "you've approved — this screen updates itself.",
+                        fontSize = 10.sp,
+                        color = BarBackerColors.OnSurfaceVariant,
+                    )
+                }
+                googleConnection?.error?.let {
+                    Text(it, color = BarBackerColors.Error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+
+            SettingsSection("Outbound iCal Feed") {
+                when {
+                    feedUrl != null -> {
+                        Text(
+                            text = feedUrl,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = BarBackerColors.OnSurfaceVariant,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedButton(onClick = { actions.onCopyFeedUrl(feedUrl) }) {
+                                Text("Copy URL")
+                            }
+                            OutlinedButton(
+                                enabled = !busy,
+                                onClick = {
+                                    run("Could not rotate the token.") {
+                                        actions.onRotateFeedToken(false)
+                                    }
+                                },
+                            ) { Text("Rotate") }
+                            TextButton(
+                                enabled = !busy,
+                                onClick = {
+                                    run("Could not revoke the token.") {
+                                        actions.onRotateFeedToken(true)
+                                    }
+                                },
+                            ) { Text("Revoke", color = BarBackerColors.Error) }
+                        }
+                    }
+
+                    // A token exists but nobody told this build where the
+                    // feed is served from. Showing a constructed URL would
+                    // hand out a link that 404s.
+                    hasFeedToken && !feedBaseConfigured -> Text(
+                        text = "A feed token exists, but this build has no " +
+                            "VITE_ICAL_FEED_BASE_URL, so the link can't be shown.",
+                        color = BarBackerColors.Warning,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+
+                    else -> Button(
+                        enabled = !busy,
+                        onClick = {
+                            run("Could not generate a feed URL.") {
+                                actions.onRotateFeedToken(false)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Generate Feed URL") }
+                }
+            }
+
+            SettingsSection("Inbound iCal Subscriptions") {
+                subscriptions.forEach { subscription ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = subscription.url,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = BarBackerColors.OnSurface,
+                                maxLines = 2,
+                            )
+                            subscription.lastError?.let {
+                                Text(
+                                    text = it,
+                                    fontSize = 10.sp,
+                                    color = BarBackerColors.Error,
+                                    maxLines = 2,
+                                )
+                            }
+                        }
+                        TextButton(
+                            enabled = !busy,
+                            onClick = {
+                                run("Could not remove that subscription.") {
+                                    actions.onRemoveSubscription(subscription.id)
+                                }
+                            },
+                        ) { Text("Remove") }
+                    }
+                }
+
+                OutlinedTextField(
+                    value = newSubscriptionUrl,
+                    onValueChange = { newSubscriptionUrl = it },
+                    label = { Text("External .ics URL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Button(
+                    enabled = newSubscriptionUrl.isNotBlank() && !busy,
+                    onClick = {
+                        val url = newSubscriptionUrl.trim()
+                        if (url.isEmpty() || busy) return@Button
+                        busy = true
+                        message = null
+                        scope.launch {
+                            actions.onAddSubscription(url)
+                                .onSuccess { newSubscriptionUrl = "" }
+                                .onFailure { message = "Could not add that subscription." }
+                            busy = false
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Add") }
+            }
+
+            message?.let {
+                Text(it, color = BarBackerColors.Error, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsSection(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = title.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = BarBackerColors.OnSurfaceVariant,
+            letterSpacing = 1.sp,
+        )
+        content()
+    }
+}

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -25,7 +26,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -66,6 +67,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -79,12 +81,22 @@ import com.hereliesaz.barbacker.logic.persistableOrder
 import com.hereliesaz.barbacker.model.ButtonConfig
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.ui.AppUiState
+import com.hereliesaz.barbacker.ui.RemoteImage
 import com.hereliesaz.barbacker.ui.iconForName
 import com.hereliesaz.barbacker.ui.rememberGridReorderState
 import com.hereliesaz.barbacker.ui.reorderable
 import com.hereliesaz.barbacker.ui.reorderableItem
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 import com.hereliesaz.barbacker.ui.theme.LocalBarAccent
+
+/**
+ * Grid width, in tiles.
+ *
+ * Referenced by both the layout and the keyboard reorder gesture — up and
+ * down have to move a whole row's worth of slots, and two hardcoded 2s is
+ * how the arrow keys quietly stop matching what is on screen.
+ */
+private const val GRID_COLUMNS = 2
 
 /** Actions the dashboard can trigger, grouped so the signature stays readable. */
 data class DashboardActions(
@@ -361,18 +373,28 @@ private fun ButtonGrid(
 
     LazyVerticalGrid(
         state = gridState,
-        columns = GridCells.Fixed(2),
+        columns = GridCells.Fixed(GRID_COLUMNS),
         contentPadding = contentPadding,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier.then(if (canReorder) Modifier.reorderable(reorderState) else Modifier),
     ) {
-        items(rendered, key = { it.id }) { button ->
+        itemsIndexed(rendered, key = { _, button -> button.id }) { index, button ->
             ButtonTile(
                 button = button,
                 pending = pendingFor(button),
+                held = reorderState.draggingKey == button.id && reorderState.keyboardHeld,
                 onClick = { onButtonTapped(button) },
-                modifier = Modifier.reorderableItem(reorderState, button.id),
+                modifier = Modifier.reorderableItem(
+                    state = reorderState,
+                    key = button.id,
+                    index = index,
+                    // A grid is a list underneath, so up/down is a whole
+                    // row's worth of slots. Hardcoding 2 in two places is
+                    // how the arrow keys quietly stop matching the layout.
+                    columns = GRID_COLUMNS,
+                    enabled = canReorder,
+                ),
             )
         }
     }
@@ -384,6 +406,7 @@ private fun ButtonTile(
     pending: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    held: Boolean = false,
 ) {
     val accent = LocalBarAccent.current
 
@@ -404,6 +427,13 @@ private fun ButtonTile(
         colors = CardDefaults.cardColors(
             containerColor = if (pending) BarBackerColors.Error else accent.tile,
         ),
+        // The outline is the only cue a keyboard user gets that a tile is
+        // picked up — there is no finger on it to make that obvious.
+        border = if (held) {
+            BorderStroke(3.dp, BarBackerColors.Primary)
+        } else {
+            null
+        },
         modifier = modifier
             .fillMaxWidth()
             .height(120.dp)
@@ -589,6 +619,19 @@ private fun RequestRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // A scanned bottle is evidence — someone photographed an empty
+        // bottle so a manager could see it. Without this the photo is
+        // uploaded, referenced on the request, and visible nowhere.
+        request.photoUrl?.let { photoUrl ->
+            RemoteImage(
+                url = photoUrl,
+                contentDescription = "Photo attached to ${request.label}",
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(6.dp)),
+            )
+        }
+
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = request.label,

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
@@ -33,10 +33,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.PointOfSale
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Store
@@ -98,6 +100,8 @@ data class DashboardActions(
     val onOpenNotificationSettings: () -> Unit,
     val onOpenBarManager: () -> Unit,
     val onOpenThemeEditor: () -> Unit,
+    val onOpenCalendar: () -> Unit,
+    val onOpenPosSettings: () -> Unit,
     val onSwitchBar: () -> Unit,
     val onGoOffClock: () -> Unit,
     /** The ids of the current grid context, in the order a drag settled on. */
@@ -235,6 +239,16 @@ private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
                     },
                 )
                 DropdownMenuItem(
+                    text = { Text("Calendar") },
+                    leadingIcon = {
+                        Icon(Icons.Filled.CalendarMonth, contentDescription = null)
+                    },
+                    onClick = {
+                        menuOpen = false
+                        actions.onOpenCalendar()
+                    },
+                )
+                DropdownMenuItem(
                     text = { Text("Manage Bar") },
                     leadingIcon = { Icon(Icons.Filled.Store, contentDescription = null) },
                     onClick = {
@@ -252,6 +266,16 @@ private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
                         onClick = {
                             menuOpen = false
                             actions.onOpenThemeEditor()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("POS Integration") },
+                        leadingIcon = {
+                            Icon(Icons.Filled.PointOfSale, contentDescription = null)
+                        },
+                        onClick = {
+                            menuOpen = false
+                            actions.onOpenPosSettings()
                         },
                     )
                 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/DashboardScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PointOfSale
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Settings
@@ -101,6 +102,7 @@ data class DashboardActions(
     val onOpenBarManager: () -> Unit,
     val onOpenThemeEditor: () -> Unit,
     val onOpenCalendar: () -> Unit,
+    val onOpenBottleScanner: () -> Unit,
     val onOpenPosSettings: () -> Unit,
     val onSwitchBar: () -> Unit,
     val onGoOffClock: () -> Unit,
@@ -256,6 +258,23 @@ private fun DashboardTopBar(state: AppUiState, actions: DashboardActions) {
                         actions.onOpenBarManager()
                     },
                 )
+                // Premium, but NOT Manager+ — matching the web client. A
+                // barback scanning a bottle and sending an alert is the
+                // staff-facing half of this feature; only "Add to Menu"
+                // and "86 It" inside it need Manager+, and the dialog
+                // gates those itself.
+                if (state.isPremium) {
+                    DropdownMenuItem(
+                        text = { Text("Scan Bottle") },
+                        leadingIcon = {
+                            Icon(Icons.Filled.PhotoCamera, contentDescription = null)
+                        },
+                        onClick = {
+                            menuOpen = false
+                            actions.onOpenBottleScanner()
+                        },
+                    )
+                }
                 // Premium branding, Manager+ only — matching the web
                 // client, where a Staff member has no write access to the
                 // bar document the theme lives on.

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/PosSettingsDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/PosSettingsDialog.kt
@@ -1,0 +1,328 @@
+package com.hereliesaz.barbacker.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.POS_PROVIDERS
+import com.hereliesaz.barbacker.data.POSSales
+import com.hereliesaz.barbacker.model.POSConnectionStatus
+import com.hereliesaz.barbacker.model.POSMenuItem
+import com.hereliesaz.barbacker.model.POSProvider
+import com.hereliesaz.barbacker.model.POSProviderStatus
+import com.hereliesaz.barbacker.ui.theme.BarBackerColors
+import kotlinx.coroutines.launch
+
+/** The POS screen's callbacks, grouped to keep the signature readable. */
+data class PosSettingsActions(
+    val onConnectSquare: suspend () -> Result<Unit>,
+    val onConnectToast: suspend (clientId: String, clientSecret: String, restaurantGuid: String) -> Result<Unit>,
+    val onDisconnect: suspend (provider: String) -> Result<Unit>,
+    val onSyncMenu: suspend (provider: String) -> Result<Int>,
+    val onGetSales: suspend (provider: String) -> Result<POSSales>,
+)
+
+/**
+ * Point-of-sale integration for one bar.
+ *
+ * Nothing here talks to a POS vendor. Connection status and the synced
+ * menu are read from Firestore (both write-denied to clients), and the
+ * three actions invoke Cloud Functions that hold the credentials. Only
+ * Square and Toast are wired up; the rest render disabled rather than
+ * being hidden, so a manager can see their POS is known about and simply
+ * not ready.
+ */
+@Composable
+fun PosSettingsDialog(
+    connections: Map<String, POSConnectionStatus>,
+    menu: List<POSMenuItem>,
+    actions: PosSettingsActions,
+    onClose: () -> Unit,
+) {
+    var busyProvider by remember { mutableStateOf<String?>(null) }
+    var status by remember { mutableStateOf<String?>(null) }
+    var insights by remember { mutableStateOf<POSSales?>(null) }
+    val scope = rememberCoroutineScope()
+
+    BarBackerDialog(
+        title = "POS Integration",
+        onDismiss = onClose,
+        actions = { TextButton(onClick = onClose) { Text("Close") } },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 460.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            POS_PROVIDERS.forEach { provider ->
+                if (provider.status == POSProviderStatus.ComingSoon) {
+                    ComingSoonRow(provider)
+                } else {
+                    ProviderCard(
+                        provider = provider,
+                        connection = connections[provider.id],
+                        syncedItemCount = menu.count { it.provider == provider.id },
+                        busy = busyProvider != null,
+                        onRun = { label, block ->
+                            if (busyProvider != null) return@ProviderCard
+                            busyProvider = provider.id
+                            status = null
+                            scope.launch {
+                                block()
+                                    .onSuccess { status = it }
+                                    .onFailure { status = "$label failed. Please try again." }
+                                busyProvider = null
+                            }
+                        },
+                        actions = actions,
+                        onInsights = { sales -> insights = sales },
+                    )
+                }
+            }
+
+            insights?.let { sales ->
+                Text(
+                    text = "Last 7 days: ${formatMoney(sales.grossCents)} gross, " +
+                        "${sales.orderCount} orders.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BarBackerColors.OnSurface,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+                        .padding(12.dp),
+                )
+            }
+
+            status?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = BarBackerColors.OnSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComingSoonRow(provider: POSProvider) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BarBackerColors.SurfaceContainer, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(provider.label, color = BarBackerColors.OnSurfaceVariant)
+        Text(
+            text = "Coming soon",
+            fontSize = 11.sp,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ProviderCard(
+    provider: POSProvider,
+    connection: POSConnectionStatus?,
+    syncedItemCount: Int,
+    busy: Boolean,
+    onRun: (label: String, block: suspend () -> Result<String>) -> Unit,
+    actions: PosSettingsActions,
+    onInsights: (POSSales) -> Unit,
+) {
+    val connected = connection?.connected == true
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, BarBackerColors.Outline, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(provider.label, fontWeight = FontWeight.Medium, color = BarBackerColors.OnSurface)
+            Text(
+                text = if (connected) {
+                    connection?.merchantId?.let { "Connected — $it" } ?: "Connected"
+                } else {
+                    "Not connected"
+                },
+                fontSize = 11.sp,
+                color = if (connected) BarBackerColors.Success else BarBackerColors.OnSurfaceVariant,
+            )
+        }
+
+        connection?.error?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = BarBackerColors.Error)
+        }
+
+        when {
+            connected -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(
+                        enabled = !busy,
+                        onClick = {
+                            onRun("Sync") {
+                                actions.onSyncMenu(provider.id).map { count -> "Synced $count items." }
+                            }
+                        },
+                    ) { Text("Sync Menu") }
+                    OutlinedButton(
+                        enabled = !busy,
+                        onClick = {
+                            onRun("Insights") {
+                                actions.onGetSales(provider.id).map { sales ->
+                                    onInsights(sales)
+                                    "Loaded 7-day insights."
+                                }
+                            }
+                        },
+                    ) { Text("7-Day Insights") }
+                }
+                TextButton(
+                    enabled = !busy,
+                    onClick = {
+                        onRun("Disconnect") {
+                            actions.onDisconnect(provider.id).map { "Disconnected." }
+                        }
+                    },
+                ) { Text("Disconnect", color = BarBackerColors.Error) }
+
+                if (connection?.lastSyncedAt != null) {
+                    Text(
+                        // Falls back to counting what actually landed in
+                        // the menu collection — an older connection
+                        // document may predate lastSyncedCount.
+                        text = "Menu: ${connection.lastSyncedCount ?: syncedItemCount} items.",
+                        fontSize = 11.sp,
+                        color = BarBackerColors.OnSurfaceVariant,
+                    )
+                }
+            }
+
+            provider.id == SQUARE -> Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Button(
+                    enabled = !busy,
+                    onClick = {
+                        onRun("Connect") {
+                            actions.onConnectSquare().map { "Opened Square in your browser." }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Connect Square") }
+                Text(
+                    text = "Opens your browser. Come back here once you've " +
+                        "approved — this screen updates itself.",
+                    fontSize = 10.sp,
+                    color = BarBackerColors.OnSurfaceVariant,
+                )
+            }
+
+            provider.id == TOAST -> ToastConnectForm(busy = busy, onRun = onRun, actions = actions)
+        }
+    }
+}
+
+@Composable
+private fun ToastConnectForm(
+    busy: Boolean,
+    onRun: (label: String, block: suspend () -> Result<String>) -> Unit,
+    actions: PosSettingsActions,
+) {
+    var clientId by remember { mutableStateOf("") }
+    var clientSecret by remember { mutableStateOf("") }
+    var restaurantGuid by remember { mutableStateOf("") }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedTextField(
+            value = clientId,
+            onValueChange = { clientId = it },
+            label = { Text("Client ID") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = clientSecret,
+            onValueChange = { clientSecret = it },
+            label = { Text("Client Secret") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = restaurantGuid,
+            onValueChange = { restaurantGuid = it },
+            label = { Text("Restaurant GUID") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Button(
+            enabled = !busy && clientId.isNotBlank() &&
+                clientSecret.isNotBlank() && restaurantGuid.isNotBlank(),
+            onClick = {
+                onRun("Connect") {
+                    actions.onConnectToast(clientId, clientSecret, restaurantGuid)
+                        .map {
+                            // Cleared on success rather than kept: the
+                            // secret has reached the function that
+                            // encrypts it, and there is no reason for it
+                            // to stay in a text field on the bar.
+                            clientId = ""
+                            clientSecret = ""
+                            restaurantGuid = ""
+                            "Toast connected."
+                        }
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Connect Toast") }
+        Text(
+            text = "Toast has no browser consent screen for this integration, " +
+                "so these go straight to the function that encrypts and stores them.",
+            fontSize = 10.sp,
+            color = BarBackerColors.OnSurfaceVariant,
+        )
+    }
+}
+
+/** Integer cents to `$1,234.56`. */
+private fun formatMoney(cents: Long): String {
+    val sign = if (cents < 0) "-" else ""
+    val absolute = if (cents < 0) -cents else cents
+    val dollars = absolute / 100
+    val remainder = (absolute % 100).toString().padStart(2, '0')
+    return "$sign$${dollars}.$remainder"
+}
+
+private const val SQUARE = "square"
+private const val TOAST = "toast"

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ThemeEditorDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/ThemeEditorDialog.kt
@@ -34,7 +34,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
@@ -43,6 +45,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import com.hereliesaz.barbacker.data.PickedImage
 import com.hereliesaz.barbacker.logic.contrastColorFor
 import com.hereliesaz.barbacker.model.BarTheme
+import com.hereliesaz.barbacker.ui.RemoteImage
 import com.hereliesaz.barbacker.ui.rememberImagePicker
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 import com.hereliesaz.barbacker.ui.theme.parseHexColor
@@ -192,7 +195,7 @@ fun ThemeEditorDialog(
             ThemePreview(
                 primaryColor = primaryColor,
                 accentColor = accentColor,
-                hasLogo = logoUrl != null,
+                logoUrl = logoUrl,
             )
 
             error?.let {
@@ -350,16 +353,22 @@ private fun LogoRow(
             }
         }
 
-        // The URL rather than the image: rendering a remote image needs an
-        // image-loading library this build does not carry, and showing a
-        // broken frame would be worse than showing the address of the file
-        // that was actually uploaded.
-        Text(
-            text = logoUrl ?: "No logo set.",
-            style = MaterialTheme.typography.bodySmall,
-            color = BarBackerColors.OnSurfaceVariant,
-            maxLines = 2,
-        )
+        if (logoUrl == null) {
+            Text(
+                text = "No logo set.",
+                style = MaterialTheme.typography.bodySmall,
+                color = BarBackerColors.OnSurfaceVariant,
+            )
+        } else {
+            RemoteImage(
+                url = logoUrl,
+                contentDescription = "Bar logo",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+            )
+        }
         Text(
             text = "PNG, JPG, WebP, or SVG. Max 2MB.",
             fontSize = 10.sp,
@@ -369,7 +378,7 @@ private fun LogoRow(
 }
 
 @Composable
-private fun ThemePreview(primaryColor: String, accentColor: String, hasLogo: Boolean) {
+private fun ThemePreview(primaryColor: String, accentColor: String, logoUrl: String?) {
     val tile = parseHexColor(accentColor) ?: BarBackerColors.SecondaryContainer
     // Derived exactly as BarBackerTheme derives it, so what is previewed
     // here is what the floor will see rather than an approximation.
@@ -399,8 +408,12 @@ private fun ThemePreview(primaryColor: String, accentColor: String, hasLogo: Boo
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            if (hasLogo) {
-                Box(modifier = Modifier.size(24.dp).background(tileLabel, CircleShape))
+            logoUrl?.let {
+                RemoteImage(
+                    url = it,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp).clip(CircleShape),
+                )
             }
             Text("ICE", color = tileLabel, fontWeight = FontWeight.Bold, fontSize = 18.sp)
         }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/theme/Theme.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/theme/Theme.kt
@@ -53,6 +53,9 @@ object BarBackerColors {
     /** The pending-approvals badge. */
     val Warning = Color(0xFFEAB308)
 
+    /** "Connected" states on the integration screens. */
+    val Success = Color(0xFF22C55E)
+
     /** Pinned-message marquee text. */
     val Pinned = Color(0xFFEAB308)
 }

--- a/cmp/composeApp/src/desktopMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.desktop.kt
+++ b/cmp/composeApp/src/desktopMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.desktop.kt
@@ -1,0 +1,24 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+/**
+ * No camera on the JVM build.
+ *
+ * Compose Desktop has no camera API, and there is no OCR here either
+ * (see `BottleRecognizer.desktop.kt`), so the scanner's whole point is
+ * absent rather than merely degraded. Reported as unsupported so the
+ * screen says the brand has to be typed instead of offering a dead
+ * button.
+ */
+@Composable
+actual fun rememberPhotoCapture(
+    onCaptured: (ByteArray) -> Unit,
+    onError: (String) -> Unit,
+): PhotoCaptureLauncher = remember {
+    object : PhotoCaptureLauncher {
+        override val isSupported: Boolean = false
+        override fun launch() = onError("Scanning isn't available on desktop.")
+    }
+}

--- a/cmp/composeApp/src/iosMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.ios.kt
+++ b/cmp/composeApp/src/iosMain/kotlin/com/hereliesaz/barbacker/ui/PhotoCapture.ios.kt
@@ -1,0 +1,127 @@
+package com.hereliesaz.barbacker.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import com.hereliesaz.barbacker.data.MAX_BOTTLE_PHOTO_BYTES
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+import platform.UIKit.UIImagePickerController
+import platform.UIKit.UIImagePickerControllerDelegateProtocol
+import platform.UIKit.UIImagePickerControllerOriginalImage
+import platform.UIKit.UIImagePickerControllerSourceType
+import platform.UIKit.UINavigationControllerDelegateProtocol
+import platform.UIKit.UIViewController
+import platform.darwin.NSObject
+import platform.posix.memcpy
+
+/** JPEG quality for the uploaded scan. High enough for OCR, small enough to send. */
+private const val JPEG_QUALITY = 0.85
+
+/**
+ * The system camera, via `UIImagePickerController`.
+ *
+ * Unverified. There is no Xcode project in this repository (see
+ * `cmp/iosApp/README.md`) and CI has no macOS runner, so this file has
+ * never been compiled. It also needs an `NSCameraUsageDescription` in
+ * `Info.plist`, or iOS terminates the app the moment the picker opens.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun rememberPhotoCapture(
+    onCaptured: (ByteArray) -> Unit,
+    onError: (String) -> Unit,
+): PhotoCaptureLauncher {
+    val captured by rememberUpdatedState(onCaptured)
+    val failed by rememberUpdatedState(onError)
+
+    // UIKit holds its delegate weakly; this reference is what keeps the
+    // object alive from presenting the camera to the callback.
+    val delegate = remember { CameraDelegate() }
+
+    DisposableEffect(delegate) {
+        delegate.onImage = { image ->
+            val data = UIImageJPEGRepresentation(image, JPEG_QUALITY)
+            when {
+                data == null -> failed("Could not encode the photo.")
+                data.length.toLong() > MAX_BOTTLE_PHOTO_BYTES ->
+                    failed("That photo is too large to send.")
+                else -> captured(data.toByteArray())
+            }
+        }
+        onDispose { delegate.onImage = {} }
+    }
+
+    return remember(delegate) {
+        object : PhotoCaptureLauncher {
+            override val isSupported: Boolean =
+                UIImagePickerController.isSourceTypeAvailable(
+                    UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera,
+                )
+
+            override fun launch() {
+                if (!isSupported) {
+                    failed("This device has no camera.")
+                    return
+                }
+                val host = topViewController()
+                if (host == null) {
+                    failed("Could not open the camera.")
+                    return
+                }
+                val picker = UIImagePickerController()
+                picker.sourceType =
+                    UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+                picker.setDelegate(delegate)
+                host.presentViewController(picker, animated = true, completion = null)
+            }
+        }
+    }
+}
+
+private class CameraDelegate :
+    NSObject(),
+    UIImagePickerControllerDelegateProtocol,
+    UINavigationControllerDelegateProtocol {
+
+    var onImage: (UIImage) -> Unit = {}
+
+    override fun imagePickerController(
+        picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo: Map<Any?, *>,
+    ) {
+        picker.dismissViewControllerAnimated(true, completion = null)
+        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
+            ?: return
+        onImage(image)
+    }
+
+    // Cancelling calls nothing: backing out of the camera is not a failure.
+    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
+        picker.dismissViewControllerAnimated(true, completion = null)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    if (size == 0) return ByteArray(0)
+    return ByteArray(size).apply {
+        usePinned { pinned -> memcpy(pinned.addressOf(0), bytes, length) }
+    }
+}
+
+private fun topViewController(): UIViewController? {
+    var controller = UIApplication.sharedApplication.keyWindow?.rootViewController
+    while (controller?.presentedViewController != null) {
+        controller = controller.presentedViewController
+    }
+    return controller
+}

--- a/cmp/gradle/libs.versions.toml
+++ b/cmp/gradle/libs.versions.toml
@@ -35,6 +35,12 @@ androidxCore = "1.13.1"
 # existing PWA rather than becoming a Compose/Wasm target.
 gitliveFirebase = "2.6.0"
 
+# ML Kit's bundled on-device Latin text recognizer, for the bottle
+# scanner. The BUNDLED model, not the Play-Services-downloaded one: a
+# bar's back-of-house Wi-Fi is exactly where a first-use model download
+# fails. Android-only; iOS uses Vision and desktop has no OCR at all.
+mlkitTextRecognition = "16.0.1"
+
 # HTTP, for the OpenStreetMap place lookup. Engines differ per platform:
 # OkHttp on Android, CIO on desktop, Darwin on iOS.
 ktor = "3.5.2"
@@ -57,6 +63,8 @@ firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = 
 firebase-storage = { module = "dev.gitlive:firebase-storage", version.ref = "gitliveFirebase" }
 firebase-functions = { module = "dev.gitlive:firebase-functions", version.ref = "gitliveFirebase" }
 firebase-messaging = { module = "dev.gitlive:firebase-messaging", version.ref = "gitliveFirebase" }
+
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkitTextRecognition" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/cmp/gradle/libs.versions.toml
+++ b/cmp/gradle/libs.versions.toml
@@ -41,6 +41,11 @@ gitliveFirebase = "2.6.0"
 # fails. Android-only; iOS uses Vision and desktop has no OCR at all.
 mlkitTextRecognition = "16.0.1"
 
+# Coil 3, for remote images: the bar logo in the theme editor and the
+# bottle photo on a request row. Fetches over the Ktor engine already
+# configured per platform rather than pulling in a second HTTP stack.
+coil = "3.3.0"
+
 # HTTP, for the OpenStreetMap place lookup. Engines differ per platform:
 # OkHttp on Android, CIO on desktop, Darwin on iOS.
 ktor = "3.5.2"
@@ -63,6 +68,9 @@ firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = 
 firebase-storage = { module = "dev.gitlive:firebase-storage", version.ref = "gitliveFirebase" }
 firebase-functions = { module = "dev.gitlive:firebase-functions", version.ref = "gitliveFirebase" }
 firebase-messaging = { module = "dev.gitlive:firebase-messaging", version.ref = "gitliveFirebase" }
+
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkitTextRecognition" }
 

--- a/cmp/shared/build.gradle.kts
+++ b/cmp/shared/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.mlkit.text.recognition)
         }
 
         val desktopMain by getting

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.android.kt
@@ -1,0 +1,57 @@
+package com.hereliesaz.barbacker.data
+
+import android.graphics.BitmapFactory
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.hereliesaz.barbacker.logWarning
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * ML Kit's on-device Latin text recogniser.
+ *
+ * The bundled model, not the Play-Services-downloaded one: a bar's
+ * back-of-house Wi-Fi is exactly where a first-use model download fails,
+ * and a scanner that works only after an unexplained delay is worse than
+ * one that works immediately.
+ */
+private class AndroidBottleRecognizer : BottleRecognizer {
+
+    override val isSupported: Boolean = true
+
+    private val recognizer by lazy {
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    }
+
+    override suspend fun recognizeLines(image: ByteArray): List<String> {
+        val bitmap = try {
+            BitmapFactory.decodeByteArray(image, 0, image.size)
+        } catch (e: Exception) {
+            logWarning("Could not decode the captured photo", e)
+            null
+        } ?: return emptyList()
+
+        return suspendCancellableCoroutine { continuation ->
+            // Rotation is 0 because the capture path writes an
+            // already-upright JPEG; ML Kit would otherwise read a
+            // sideways label as gibberish.
+            recognizer.process(InputImage.fromBitmap(bitmap, 0))
+                .addOnSuccessListener { result ->
+                    if (continuation.isActive) {
+                        continuation.resume(recognizedLinesOf(result.text))
+                    }
+                }
+                .addOnFailureListener { error ->
+                    logWarning("Text recognition failed", error)
+                    // Empty, not an exception: an unreadable label is an
+                    // ordinary outcome and the caller offers manual entry
+                    // either way.
+                    if (continuation.isActive) continuation.resume(emptyList())
+                }
+        }
+    }
+}
+
+actual fun createBottleRecognizer(platformContext: Any?): BottleRecognizer =
+    AndroidBottleRecognizer()

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.android.kt
@@ -1,0 +1,29 @@
+package com.hereliesaz.barbacker.data
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.hereliesaz.barbacker.logWarning
+
+private class AndroidUrlOpener(private val context: Context?) : UrlOpener {
+    override fun open(url: String): Boolean {
+        val host = context ?: return false
+        return try {
+            host.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                    // The context handed down here is the Application in
+                    // some entry points, and an Activity-less start
+                    // throws without this flag.
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                },
+            )
+            true
+        } catch (e: Exception) {
+            logWarning("Could not open a browser", e)
+            false
+        }
+    }
+}
+
+actual fun createUrlOpener(platformContext: Any?): UrlOpener =
+    AndroidUrlOpener(platformContext as? Context)

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Constants.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Constants.kt
@@ -197,6 +197,9 @@ const val MAX_IGNORED_IDS: Int = 200
 /** How far back the dashboard's request query reaches. */
 const val REQUEST_WINDOW_MILLIS: Long = 24L * 60 * 60 * 1000
 
+/** The window the POS screen's insights button reports over. */
+const val POS_INSIGHTS_WINDOW_MILLIS: Long = 7L * 24 * 60 * 60 * 1000
+
 /** Cap on the dashboard's request query. */
 const val REQUEST_QUERY_LIMIT: Int = 100
 

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Constants.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Constants.kt
@@ -118,6 +118,20 @@ val DEFAULT_BUTTONS: List<ButtonConfig> = listOf(
 )
 
 /** The synthesised free-text tile appended to the end of the main grid. */
+/**
+ * The stock BEER button's label, derived rather than repeated.
+ *
+ * The bottle scanner prefixes its alerts with this exact string so
+ * [com.hereliesaz.barbacker.logic.ButtonLabelResolver] can resolve them
+ * to a real button id. A request whose label resolves to nothing is
+ * treated as "cannot tell who this is for" and paged to the whole floor
+ * past everyone's preferences — so a hardcoded copy that drifted from
+ * the button would mass-notify a bar every time someone scanned a
+ * bottle. Reading it from the button makes drift impossible, and
+ * renaming the id fails loudly here rather than silently there.
+ */
+val BEER_BUTTON_LABEL: String = DEFAULT_BUTTONS.first { it.id == "restock_beer" }.label
+
 val CUSTOM_REQUEST_BUTTON = ButtonConfig(
     id = "custom_req_btn",
     label = "CUSTOM",

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -16,6 +16,8 @@ class AppContainer(
     val store: KeyValueStore,
     /** The Android `Context`; null elsewhere. */
     platformContext: Any? = null,
+    /** Where the outbound iCal feed is served from, if configured. */
+    val icalFeedBaseUrl: String? = null,
 ) {
     val auth: AuthRepository = FirebaseAuthRepository(firebase.auth)
     val bars: BarRepository = FirebaseBarRepository(firebase.firestore)
@@ -26,6 +28,10 @@ class AppContainer(
     val ownershipClaims: OwnershipClaimRepository =
         FirebaseOwnershipClaimRepository(firebase.firestore, firebase.functions)
     val storage: StorageRepository = FirebaseStorageRepository(firebase.storage)
+    val calendar: CalendarRepository =
+        FirebaseCalendarRepository(firebase.firestore, firebase.functions)
+    val pos: PosRepository = FirebasePosRepository(firebase.firestore, firebase.functions)
+    val urls: UrlOpener = createUrlOpener(platformContext)
 
     /**
      * One client for the whole process. Ktor clients own a connection pool

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -38,7 +38,15 @@ class AppContainer(
      * One client for the whole process. Ktor clients own a connection pool
      * and a dispatcher, so creating one per search would leak both.
      */
-    private val httpClient = createHttpClient()
+    /**
+     * Shared by the place search and the image loader.
+     *
+     * Exposed rather than private so Coil fetches over the engine already
+     * configured for this platform, instead of resolving a second one of
+     * its own — two HTTP stacks in one process is two connection pools and
+     * two sets of timeouts to keep straight.
+     */
+    val httpClient = createHttpClient()
 
     val placeSearch: PlaceSearchRepository =
         DefaultPlaceSearchRepository(firebase.firestore, httpClient)

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -32,6 +32,7 @@ class AppContainer(
         FirebaseCalendarRepository(firebase.firestore, firebase.functions)
     val pos: PosRepository = FirebasePosRepository(firebase.firestore, firebase.functions)
     val urls: UrlOpener = createUrlOpener(platformContext)
+    val bottleRecognizer: BottleRecognizer = createBottleRecognizer(platformContext)
 
     /**
      * One client for the whole process. Ktor clients own a connection pool

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
@@ -30,6 +30,14 @@ data class BarBackerFirebaseConfig(
     val storageBucket: String,
     val messagingSenderId: String,
     val applicationId: String,
+    /**
+     * Where the outbound iCal feed is served from, if anywhere.
+     *
+     * Not part of the Firebase project identity — it is the base of a
+     * Cloud Function's public URL, and a deployment that never enabled
+     * the feed simply has none.
+     */
+    val icalFeedBaseUrl: String? = null,
 ) {
     internal fun toFirebaseOptions() = FirebaseOptions(
         applicationId = applicationId,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.kt
@@ -1,0 +1,45 @@
+package com.hereliesaz.barbacker.data
+
+/**
+ * On-device text recognition for a bottle label.
+ *
+ * On-device is the point, matching the web client's use of tesseract.js:
+ * the photo and the text read off it never leave the device just to
+ * identify a brand. Only the "Send Alert" action uploads anything, and
+ * only to this bar's own bucket.
+ */
+interface BottleRecognizer {
+    /**
+     * Whether this platform can read a label at all.
+     *
+     * False is a supported outcome, not a failure — the desktop build has
+     * no OCR engine, and the scanner falls back to typing the brand.
+     */
+    val isSupported: Boolean
+
+    /**
+     * Lines of text read off [image], trimmed, one-character lines
+     * dropped.
+     *
+     * Returns empty rather than throwing when nothing legible is found: a
+     * blurry photo is an ordinary outcome, and the caller's next step —
+     * offering manual entry — is the same either way.
+     */
+    suspend fun recognizeLines(image: ByteArray): List<String>
+}
+
+expect fun createBottleRecognizer(platformContext: Any?): BottleRecognizer
+
+/**
+ * Splits an OCR engine's blob of text into candidate lines.
+ *
+ * The one-character filter is the web client's, and it earns its place:
+ * OCR routinely emits stray single glyphs from a label's border or
+ * embossing, and each one is another chance for [
+ * com.hereliesaz.barbacker.logic.matchBrand] to find a spurious
+ * substring hit.
+ */
+fun recognizedLinesOf(text: String): List<String> =
+    text.split('\n')
+        .map { it.trim() }
+        .filter { it.length > 1 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/CalendarRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/CalendarRepository.kt
@@ -1,0 +1,282 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.model.CalendarConnectionStatus
+import com.hereliesaz.barbacker.model.CalendarEvent
+import com.hereliesaz.barbacker.model.ICalSubscription
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.Timestamp
+import dev.gitlive.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+
+/** One calendar the connected Google account can mirror. */
+@Serializable
+data class GoogleCalendar(
+    val id: String,
+    val summary: String = "",
+    val primary: Boolean = false,
+)
+
+/**
+ * The editable half of a [CalendarEvent].
+ *
+ * Deliberately does not carry `externalId`, `externalProvider`, or
+ * `lastSyncedAt`. Those are written only by the sync functions through the
+ * Admin SDK, and `firestore.rules` rejects a client write that so much as
+ * mentions `externalProvider` — a draft that could express one would be a
+ * write that always fails.
+ */
+data class CalendarEventDraft(
+    val title: String,
+    /** ISO 8601. */
+    val start: String,
+    /** ISO 8601. */
+    val end: String,
+    val type: String = "event",
+    val description: String? = null,
+)
+
+/**
+ * The bar's calendar: local events, the Google mirror, and iCal in both
+ * directions.
+ *
+ * Event CRUD is a direct Firestore write — Manager+, and only for events
+ * this side owns. Everything touching Google or the feed token goes
+ * through a Cloud Function, because those hold OAuth credentials that
+ * never reach a client.
+ */
+interface CalendarRepository {
+    /**
+     * Events for the bar, soonest first, tombstones excluded.
+     *
+     * Readable by any member, unlike the settings flows below — the floor
+     * needs to see who is on shift.
+     */
+    fun eventsFlow(barId: String?): Flow<List<CalendarEvent>>
+
+    fun googleConnectionFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<CalendarConnectionStatus?>
+
+    fun icalSubscriptionsFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<List<ICalSubscription>>
+
+    /** The outbound feed's opaque token, or null when none has been minted. */
+    fun feedTokenFlow(barId: String?, isManagerPlus: Boolean): Flow<String?>
+
+    suspend fun createEvent(barId: String, draft: CalendarEventDraft)
+    suspend fun updateEvent(barId: String, eventId: String, draft: CalendarEventDraft)
+    suspend fun deleteEvent(barId: String, eventId: String)
+
+    /** Returns the URL to open in a browser to authorise Google. */
+    suspend fun googleAuthorizeUrl(barId: String): String
+    suspend fun listGoogleCalendars(barId: String): List<GoogleCalendar>
+    suspend fun selectGoogleCalendar(barId: String, calendarId: String)
+    suspend fun disconnectGoogle(barId: String)
+
+    suspend fun addICalSubscription(barId: String, url: String, uid: String)
+    suspend fun removeICalSubscription(barId: String, subscriptionId: String)
+
+    /** Mints a new feed token, or revokes the current one outright. */
+    suspend fun rotateFeedToken(barId: String, revoke: Boolean)
+}
+
+class FirebaseCalendarRepository(
+    private val firestore: FirebaseFirestore,
+    private val functions: FirebaseFunctions,
+) : CalendarRepository {
+
+    @Serializable
+    private data class EventWrite(
+        val title: String,
+        val start: String,
+        val end: String,
+        val type: String,
+        val description: String? = null,
+    )
+
+    @Serializable
+    private data class SubscriptionWrite(
+        val url: String,
+        val createdBy: String,
+        val createdAt: Timestamp.ServerTimestamp,
+    )
+
+    @Serializable
+    private data class BarRequest(val barId: String)
+
+    @Serializable
+    private data class SelectCalendarRequest(val barId: String, val calendarId: String)
+
+    @Serializable
+    private data class RotateTokenRequest(val barId: String, val revoke: Boolean)
+
+    @Serializable
+    private data class AuthorizeUrlResponse(val authorizeUrl: String)
+
+    @Serializable
+    private data class CalendarListResponse(val calendars: List<GoogleCalendar> = emptyList())
+
+    override fun eventsFlow(barId: String?): Flow<List<CalendarEvent>> = flow {
+        emit(emptyList())
+        if (barId == null) return@flow
+        emitAll(
+            firestore.collection(Paths.barEvents(barId))
+                .orderBy(Fields.START)
+                .snapshots
+                .map { snapshot ->
+                    snapshot.documents
+                        .mapNotNull { it.toCalendarEvent() }
+                        // Filtered here rather than in the query: a
+                        // tombstone is a field that most events simply do
+                        // not have, and Firestore's inequality filters
+                        // exclude documents missing the field entirely —
+                        // the query would return nothing at all.
+                        .filter { it.deletedAt == null }
+                },
+        )
+    }.catch { e ->
+        logWarning("Calendar events listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override fun googleConnectionFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<CalendarConnectionStatus?> = flow {
+        emit(null)
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.document(Paths.barCalendarConnection(barId, GOOGLE_PROVIDER))
+                .snapshots
+                .map { it.toCalendarConnection(GOOGLE_PROVIDER) },
+        )
+    }.catch { e ->
+        logWarning("Calendar connection listener failed for $barId", e)
+        emit(null)
+    }
+
+    override fun icalSubscriptionsFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<List<ICalSubscription>> = flow {
+        emit(emptyList())
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.collection(Paths.barICalSubscriptions(barId))
+                .snapshots
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toICalSubscription() } },
+        )
+    }.catch { e ->
+        logWarning("iCal subscription listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override fun feedTokenFlow(barId: String?, isManagerPlus: Boolean): Flow<String?> = flow {
+        emit(null)
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.document(Paths.barICalFeedConfig(barId))
+                .snapshots
+                .map { snapshot ->
+                    if (snapshot.exists) snapshot.field<String>(Fields.TOKEN) else null
+                },
+        )
+    }.catch { e ->
+        logWarning("iCal feed listener failed for $barId", e)
+        emit(null)
+    }
+
+    override suspend fun createEvent(barId: String, draft: CalendarEventDraft) {
+        firestore.collection(Paths.barEvents(barId)).add(draft.toWrite()) {
+            // `externalProvider` must be ABSENT, not null: the create rule
+            // reads `get('externalProvider', null) == null`, and while a
+            // written null would satisfy that, it would then make the
+            // event look externally owned to the inbound sync function.
+            encodeDefaults = false
+        }
+    }
+
+    override suspend fun updateEvent(barId: String, eventId: String, draft: CalendarEventDraft) {
+        firestore.collection(Paths.barEvents(barId)).document(eventId)
+            .set(draft.toWrite(), merge = true) { encodeDefaults = false }
+    }
+
+    override suspend fun deleteEvent(barId: String, eventId: String) {
+        firestore.collection(Paths.barEvents(barId)).document(eventId).delete()
+    }
+
+    override suspend fun googleAuthorizeUrl(barId: String): String =
+        functions.httpsCallable("calendarGetAuthorizeUrl")
+            .invoke(BarRequest(barId))
+            .data<AuthorizeUrlResponse>()
+            .authorizeUrl
+
+    override suspend fun listGoogleCalendars(barId: String): List<GoogleCalendar> =
+        functions.httpsCallable("calendarListCalendars")
+            .invoke(BarRequest(barId))
+            .data<CalendarListResponse>()
+            .calendars
+
+    override suspend fun selectGoogleCalendar(barId: String, calendarId: String) {
+        functions.httpsCallable("calendarSelectCalendar")
+            .invoke(SelectCalendarRequest(barId, calendarId))
+    }
+
+    override suspend fun disconnectGoogle(barId: String) {
+        functions.httpsCallable("calendarDisconnect").invoke(BarRequest(barId))
+    }
+
+    override suspend fun addICalSubscription(barId: String, url: String, uid: String) {
+        firestore.collection(Paths.barICalSubscriptions(barId)).add(
+            SubscriptionWrite(
+                url = url.trim(),
+                createdBy = uid,
+                createdAt = Timestamp.ServerTimestamp,
+            ),
+        )
+    }
+
+    override suspend fun removeICalSubscription(barId: String, subscriptionId: String) {
+        firestore.collection(Paths.barICalSubscriptions(barId)).document(subscriptionId).delete()
+    }
+
+    override suspend fun rotateFeedToken(barId: String, revoke: Boolean) {
+        functions.httpsCallable("rotateICalFeedToken")
+            .invoke(RotateTokenRequest(barId, revoke))
+    }
+
+    private fun CalendarEventDraft.toWrite() = EventWrite(
+        title = title.trim(),
+        start = start,
+        end = end,
+        type = type,
+        description = description?.trim()?.takeIf { it.isNotEmpty() },
+    )
+
+    private companion object {
+        const val GOOGLE_PROVIDER = "google"
+    }
+}
+
+/**
+ * Builds the URL an external calendar app subscribes to.
+ *
+ * [baseUrl] is a separate setting rather than derived from anything the
+ * app already knows, and returning null when it is absent is the point:
+ * the feed is served by a Cloud Function, which is a different host from
+ * wherever any client is running. Guessing would produce a URL that looks
+ * right and 404s — worse than saying it is not configured.
+ */
+fun icalFeedUrl(baseUrl: String?, barId: String, token: String?): String? {
+    if (baseUrl.isNullOrBlank() || token.isNullOrBlank()) return null
+    return "${baseUrl.trimEnd('/')}/ical/$barId/$token.ics"
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
@@ -23,15 +23,26 @@ internal object FirebaseConfigKeys {
     const val MESSAGING_SENDER_ID = "VITE_FIREBASE_MESSAGING_SENDER_ID"
     const val APP_ID = "VITE_FIREBASE_APP_ID"
 
+    /**
+     * Where the outbound iCal feed is actually served from.
+     *
+     * OPTIONAL, and absent from [ALL] on purpose: the feed is a Cloud
+     * Function on a different host from everything else, and a deployment
+     * that never turned it on should still run. Calendar Settings says the
+     * feed is unconfigured rather than handing out a URL that 404s.
+     */
+    const val ICAL_FEED_BASE_URL = "VITE_ICAL_FEED_BASE_URL"
+
     val ALL = listOf(
         API_KEY, AUTH_DOMAIN, PROJECT_ID, STORAGE_BUCKET, MESSAGING_SENDER_ID, APP_ID,
     )
 
-    /** Builds a config from a lookup, or null if any value is missing. */
+    /** Builds a config from a lookup, or null if any REQUIRED value is missing. */
     fun build(lookup: (String) -> String?): BarBackerFirebaseConfig? {
         val values = ALL.associateWith { lookup(it)?.takeIf(String::isNotBlank) }
         if (values.values.any { it == null }) return null
         return BarBackerFirebaseConfig(
+            icalFeedBaseUrl = lookup(ICAL_FEED_BASE_URL)?.takeIf(String::isNotBlank),
             apiKey = values.getValue(API_KEY)!!,
             authDomain = values.getValue(AUTH_DOMAIN)!!,
             projectId = values.getValue(PROJECT_ID)!!,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Paths.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Paths.kt
@@ -44,6 +44,9 @@ object Paths {
         "bars/$barId/calendarConnection/$provider"
     fun barICalSubscriptions(barId: String) = "bars/$barId/icalSubscriptions"
 
+    /** Holds the opaque token that appears in the outbound feed URL. */
+    fun barICalFeedConfig(barId: String) = "bars/$barId/icalFeed/config"
+
     /** Storage object path for a bottle-scanner photo. */
     fun bottlePhoto(barId: String, uid: String, epochMillis: Long) =
         "bottlePhotos/$barId/${uid}_$epochMillis.jpg"
@@ -93,4 +96,28 @@ object Fields {
     const val CREATED_BY = "createdBy"
     const val CREATED_BY_NAME = "createdByName"
     const val CREATED_AT = "createdAt"
+    const val TITLE = "title"
+    const val END = "end"
+    const val TYPE = "type"
+    const val DESCRIPTION = "description"
+    const val ASSIGNED_TO = "assignedTo"
+    const val EXTERNAL_ID = "externalId"
+    const val EXTERNAL_PROVIDER = "externalProvider"
+    const val LAST_SYNCED_AT = "lastSyncedAt"
+    const val DELETED_AT = "deletedAt"
+    const val URL = "url"
+    const val TOKEN = "token"
+    const val CONNECTED = "connected"
+    const val CALENDAR_ID = "calendarId"
+    const val MERCHANT_ID = "merchantId"
+    const val ERROR = "error"
+    const val CONNECTED_AT = "connectedAt"
+    const val LAST_POLLED_AT = "lastPolledAt"
+    const val LAST_ERROR = "lastError"
+    const val LAST_SYNCED_COUNT = "lastSyncedCount"
+    const val NAME = "name"
+    const val PRICE = "price"
+    const val CATEGORY = "category"
+    const val PROVIDER = "provider"
+    const val SYNCED_AT = "syncedAt"
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PosRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/PosRepository.kt
@@ -1,0 +1,174 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.model.POSConnectionStatus
+import com.hereliesaz.barbacker.model.POSMenuItem
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+
+/** Gross takings over a window, as reported by the connected POS. */
+@Serializable
+data class POSSales(
+    /** Integer cents, so the arithmetic stays exact. */
+    val grossCents: Long = 0,
+    val orderCount: Int = 0,
+)
+
+/**
+ * A bar's point-of-sale integration.
+ *
+ * Every call to a POS vendor happens in a Cloud Function. This client
+ * reads two Firestore collections — connection status and the synced menu,
+ * both write-denied to clients — and invokes the callables that drive
+ * connect, sync, and reporting. Nothing here ever holds a credential: the
+ * OAuth tokens live in `posSecrets`, which no client can read.
+ */
+interface PosRepository {
+    fun connectionsFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<Map<String, POSConnectionStatus>>
+
+    fun menuFlow(barId: String?, isManagerPlus: Boolean): Flow<List<POSMenuItem>>
+
+    /** Returns the Square URL to open in a browser to authorise. */
+    suspend fun squareAuthorizeUrl(barId: String): String
+
+    /**
+     * Connects Toast with credentials the merchant pastes in.
+     *
+     * Toast has no OAuth redirect flow for this integration, so the
+     * secret does pass through the client on its way to the function that
+     * encrypts and stores it. It is never persisted locally.
+     */
+    suspend fun connectToast(
+        barId: String,
+        clientId: String,
+        clientSecret: String,
+        restaurantGuid: String,
+    )
+
+    suspend fun disconnect(barId: String, provider: String)
+
+    /** Returns how many menu items were pulled in. */
+    suspend fun syncMenu(barId: String, provider: String): Int
+
+    /** @param start and [end] are ISO 8601 instants. */
+    suspend fun getSales(barId: String, provider: String, start: String, end: String): POSSales
+}
+
+class FirebasePosRepository(
+    private val firestore: FirebaseFirestore,
+    private val functions: FirebaseFunctions,
+) : PosRepository {
+
+    @Serializable
+    private data class BarRequest(val barId: String)
+
+    @Serializable
+    private data class ProviderRequest(val barId: String, val provider: String)
+
+    @Serializable
+    private data class ToastRequest(
+        val barId: String,
+        val clientId: String,
+        val clientSecret: String,
+        val restaurantGuid: String,
+    )
+
+    @Serializable
+    private data class SalesRequest(
+        val barId: String,
+        val provider: String,
+        val start: String,
+        val end: String,
+    )
+
+    @Serializable
+    private data class AuthorizeUrlResponse(val authorizeUrl: String)
+
+    @Serializable
+    private data class SyncResponse(val count: Int = 0)
+
+    override fun connectionsFlow(
+        barId: String?,
+        isManagerPlus: Boolean,
+    ): Flow<Map<String, POSConnectionStatus>> = flow {
+        emit(emptyMap())
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.collection(Paths.barPosConnection(barId))
+                .snapshots
+                .map { snapshot ->
+                    // The document id IS the provider — there is no
+                    // `provider` field to read back.
+                    snapshot.documents
+                        .mapNotNull { it.toPosConnection(it.id) }
+                        .associateBy { it.provider }
+                },
+        )
+    }.catch { e ->
+        logWarning("POS connection listener failed for $barId", e)
+        emit(emptyMap())
+    }
+
+    override fun menuFlow(barId: String?, isManagerPlus: Boolean): Flow<List<POSMenuItem>> = flow {
+        emit(emptyList())
+        if (barId == null || !isManagerPlus) return@flow
+        emitAll(
+            firestore.collection(Paths.barMenu(barId))
+                .snapshots
+                .map { snapshot -> snapshot.documents.mapNotNull { it.toPosMenuItem() } },
+        )
+    }.catch { e ->
+        logWarning("POS menu listener failed for $barId", e)
+        emit(emptyList())
+    }
+
+    override suspend fun squareAuthorizeUrl(barId: String): String =
+        functions.httpsCallable("posGetAuthorizeUrl")
+            .invoke(BarRequest(barId))
+            .data<AuthorizeUrlResponse>()
+            .authorizeUrl
+
+    override suspend fun connectToast(
+        barId: String,
+        clientId: String,
+        clientSecret: String,
+        restaurantGuid: String,
+    ) {
+        functions.httpsCallable("posConnectToast").invoke(
+            ToastRequest(
+                barId = barId,
+                clientId = clientId.trim(),
+                clientSecret = clientSecret.trim(),
+                restaurantGuid = restaurantGuid.trim(),
+            ),
+        )
+    }
+
+    override suspend fun disconnect(barId: String, provider: String) {
+        functions.httpsCallable("posDisconnect").invoke(ProviderRequest(barId, provider))
+    }
+
+    override suspend fun syncMenu(barId: String, provider: String): Int =
+        functions.httpsCallable("posSyncMenu")
+            .invoke(ProviderRequest(barId, provider))
+            .data<SyncResponse>()
+            .count
+
+    override suspend fun getSales(
+        barId: String,
+        provider: String,
+        start: String,
+        end: String,
+    ): POSSales = functions.httpsCallable("posGetSales")
+        .invoke(SalesRequest(barId, provider, start, end))
+        .data<POSSales>()
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Snapshots.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/Snapshots.kt
@@ -8,13 +8,18 @@ import com.hereliesaz.barbacker.model.BarTheme
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.ButtonAction
 import com.hereliesaz.barbacker.model.ButtonConfig
+import com.hereliesaz.barbacker.model.CalendarConnectionStatus
+import com.hereliesaz.barbacker.model.CalendarEvent
 import com.hereliesaz.barbacker.model.ChatMessage
 import com.hereliesaz.barbacker.model.EightySixEntry
 import com.hereliesaz.barbacker.model.EightySixVisibility
+import com.hereliesaz.barbacker.model.ICalSubscription
 import com.hereliesaz.barbacker.model.JobTitle
 import com.hereliesaz.barbacker.model.JoinPolicy
 import com.hereliesaz.barbacker.model.MemberStatus
 import com.hereliesaz.barbacker.model.OwnershipClaim
+import com.hereliesaz.barbacker.model.POSConnectionStatus
+import com.hereliesaz.barbacker.model.POSMenuItem
 import com.hereliesaz.barbacker.model.Request
 import com.hereliesaz.barbacker.model.RequestStatus
 import com.hereliesaz.barbacker.model.SubscriptionTier
@@ -187,5 +192,73 @@ internal fun DocumentSnapshot.toOwnershipClaim(barId: String): OwnershipClaim? {
         justification = field<String>("justification"),
         status = com.hereliesaz.barbacker.model.ClaimStatus.fromWire(field<String>(Fields.STATUS)),
         createdAt = timestampMillis("createdAt"),
+    )
+}
+
+internal fun DocumentSnapshot.toCalendarEvent(): CalendarEvent? {
+    if (!exists) return null
+    return CalendarEvent(
+        id = id,
+        title = field<String>(Fields.TITLE).orEmpty(),
+        start = field<String>(Fields.START).orEmpty(),
+        end = field<String>(Fields.END).orEmpty(),
+        description = field<String>(Fields.DESCRIPTION),
+        type = field<String>(Fields.TYPE) ?: "event",
+        assignedTo = field<List<String>>(Fields.ASSIGNED_TO),
+        externalId = field<String>(Fields.EXTERNAL_ID),
+        externalProvider = field<String>(Fields.EXTERNAL_PROVIDER),
+        lastSyncedAt = timestampMillis(Fields.LAST_SYNCED_AT),
+        deletedAt = timestampMillis(Fields.DELETED_AT),
+    )
+}
+
+internal fun DocumentSnapshot.toCalendarConnection(provider: String): CalendarConnectionStatus? {
+    if (!exists) return null
+    return CalendarConnectionStatus(
+        provider = provider,
+        connected = field<Boolean>(Fields.CONNECTED) ?: false,
+        calendarId = field<String>(Fields.CALENDAR_ID),
+        error = field<String>(Fields.ERROR),
+        connectedAt = timestampMillis(Fields.CONNECTED_AT),
+    )
+}
+
+internal fun DocumentSnapshot.toICalSubscription(): ICalSubscription? {
+    if (!exists) return null
+    return ICalSubscription(
+        id = id,
+        url = field<String>(Fields.URL).orEmpty(),
+        createdBy = field<String>(Fields.CREATED_BY).orEmpty(),
+        createdAt = timestampMillis(Fields.CREATED_AT),
+        lastPolledAt = timestampMillis(Fields.LAST_POLLED_AT),
+        lastError = field<String>(Fields.LAST_ERROR),
+    )
+}
+
+internal fun DocumentSnapshot.toPosConnection(provider: String): POSConnectionStatus? {
+    if (!exists) return null
+    return POSConnectionStatus(
+        provider = provider,
+        connected = field<Boolean>(Fields.CONNECTED) ?: false,
+        merchantId = field<String>(Fields.MERCHANT_ID),
+        error = field<String>(Fields.ERROR),
+        connectedAt = timestampMillis(Fields.CONNECTED_AT),
+        lastSyncedAt = timestampMillis(Fields.LAST_SYNCED_AT),
+        lastSyncedCount = field<Int>(Fields.LAST_SYNCED_COUNT),
+    )
+}
+
+internal fun DocumentSnapshot.toPosMenuItem(): POSMenuItem? {
+    if (!exists) return null
+    return POSMenuItem(
+        id = id,
+        name = field<String>(Fields.NAME).orEmpty(),
+        // Integer cents. A price that arrived as a float from an older
+        // writer would fail to decode as Int and degrade to zero rather
+        // than killing the listener for the whole menu.
+        price = field<Int>(Fields.PRICE) ?: 0,
+        category = field<String>(Fields.CATEGORY),
+        provider = field<String>(Fields.PROVIDER).orEmpty(),
+        syncedAt = timestampMillis(Fields.SYNCED_AT),
     )
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/StorageRepository.kt
@@ -25,6 +25,9 @@ class PickedImage(
 /** Mirrors the web client's 2MB check; `storage.rules` enforces it too. */
 const val MAX_LOGO_BYTES: Int = 2 * 1024 * 1024
 
+/** The bottle-photo cap in `storage.rules`. Larger than a logo's, on purpose. */
+const val MAX_BOTTLE_PHOTO_BYTES: Int = 5 * 1024 * 1024
+
 /**
  * Extension to MIME type for the formats a logo may be in.
  *
@@ -100,6 +103,22 @@ interface StorageRepository {
      *   anyway, but as an opaque permission error.
      */
     suspend fun uploadBarLogo(barId: String, image: PickedImage): String
+
+    /**
+     * Uploads a scanned bottle photo and returns its download URL.
+     *
+     * Any member may write here, not just Manager+ — the whole point is a
+     * barback flagging something to a manager. The URL never expires and
+     * is stored un-redacted on the request document, which is why
+     * `storage.rules` scopes READ to that bar's members rather than to any
+     * signed-in user.
+     */
+    suspend fun uploadBottlePhoto(
+        barId: String,
+        uid: String,
+        epochMillis: Long,
+        jpegBytes: ByteArray,
+    ): String
 }
 
 class FirebaseStorageRepository(private val storage: FirebaseStorage) : StorageRepository {
@@ -115,6 +134,22 @@ class FirebaseStorageRepository(private val storage: FirebaseStorage) : StorageR
             // storage rule checks `contentType.matches('image/.*')`, and an
             // upload that arrives as application/octet-stream is rejected.
             metadata = storageMetadata { contentType = image.contentType },
+        )
+        return reference.getDownloadUrl()
+    }
+
+    override suspend fun uploadBottlePhoto(
+        barId: String,
+        uid: String,
+        epochMillis: Long,
+        jpegBytes: ByteArray,
+    ): String {
+        require(jpegBytes.size <= MAX_BOTTLE_PHOTO_BYTES) { "Photo must be under 5MB." }
+
+        val reference = storage.reference(Paths.bottlePhoto(barId, uid, epochMillis))
+        reference.putData(
+            data = storageDataOf(jpegBytes),
+            metadata = storageMetadata { contentType = "image/jpeg" },
         )
         return reference.getDownloadUrl()
     }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.kt
@@ -1,0 +1,19 @@
+package com.hereliesaz.barbacker.data
+
+/**
+ * Hands a URL to the platform's browser.
+ *
+ * Used for the two OAuth consent screens (Square, Google Calendar). The
+ * web client navigates the whole page and gets redirected back; there is
+ * no equivalent here, so the flow finishes in the browser and this client
+ * learns the outcome from its Firestore listener when the user returns.
+ * The screens say so rather than leaving someone waiting on a spinner
+ * that will never resolve.
+ */
+interface UrlOpener {
+    /** Returns false if no browser could be opened. */
+    fun open(url: String): Boolean
+}
+
+/** @param platformContext the Android `Context`; null elsewhere. */
+expect fun createUrlOpener(platformContext: Any?): UrlOpener

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/EventTime.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/logic/EventTime.kt
@@ -1,0 +1,177 @@
+package com.hereliesaz.barbacker.logic
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+// Extensions, not members — they do not come in with the type imports.
+import kotlinx.datetime.atTime
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Calendar events are stored as ISO 8601 instants, which is the only form
+ * that survives a round trip through Google and an `.ics` feed. Everything
+ * a person sees or edits is local wall-clock time, so every screen needs
+ * both directions of this conversion.
+ *
+ * Kept out of the UI layer so the conversions can be tested: an event that
+ * lands an hour off, or on the wrong day near midnight, is the kind of bug
+ * that only shows up on someone's roster.
+ */
+
+/** The wall-clock fields a date and time picker actually manipulates. */
+data class EventTimeParts(
+    val year: Int,
+    /** 1-12. */
+    val month: Int,
+    /** 1-31. */
+    val day: Int,
+    /** 0-23. */
+    val hour: Int,
+    val minute: Int,
+)
+
+/**
+ * Parses a stored instant, tolerating what the sync functions write.
+ *
+ * Returns null rather than throwing: an unparseable `start` on one event
+ * must not take down the whole list, and the caller renders it as
+ * "unknown time" instead.
+ */
+@OptIn(ExperimentalTime::class)
+fun parseEventInstant(
+    iso: String,
+    /**
+     * Only consulted for the all-day fallback below. It is a parameter
+     * rather than the system zone because every caller here already
+     * threads a zone through, and resolving "which midnight" against a
+     * different one than the display uses puts all-day events on the
+     * wrong day by exactly the offset between them.
+     */
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): Instant? = try {
+    Instant.parse(iso)
+} catch (_: IllegalArgumentException) {
+    // Google's all-day events carry a date with no time at all. Treated
+    // as local midnight, which is what an all-day event means to someone
+    // reading the roster — parsing it as UTC midnight would show the day
+    // before for anyone west of Greenwich.
+    try {
+        LocalDate.parse(iso).atTime(0, 0).toInstant(zone)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
+
+@OptIn(ExperimentalTime::class)
+fun eventTimePartsOf(
+    iso: String,
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): EventTimeParts? {
+    val local = parseEventInstant(iso, zone)?.toLocalDateTime(zone) ?: return null
+    return EventTimeParts(
+        year = local.year,
+        month = local.month.number,
+        day = local.day,
+        hour = local.hour,
+        minute = local.minute,
+    )
+}
+
+/** Turns picker output back into the stored form. */
+@OptIn(ExperimentalTime::class)
+fun isoFromEventTimeParts(
+    parts: EventTimeParts,
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): String = LocalDateTime(
+    LocalDate(parts.year, parts.month, parts.day),
+    LocalTime(parts.hour, parts.minute),
+).toInstant(zone).toString()
+
+/** The instant [millis] after the epoch, as picker fields. */
+@OptIn(ExperimentalTime::class)
+fun eventTimePartsFromMillis(
+    millis: Long,
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): EventTimeParts {
+    val local = Instant.fromEpochMilliseconds(millis).toLocalDateTime(zone)
+    return EventTimeParts(
+        year = local.year,
+        month = local.month.number,
+        day = local.day,
+        hour = local.hour,
+        minute = local.minute,
+    )
+}
+
+/** Epoch millis for [parts], for seeding a Material date picker. */
+@OptIn(ExperimentalTime::class)
+fun epochMillisOf(
+    parts: EventTimeParts,
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): Long = LocalDateTime(
+    LocalDate(parts.year, parts.month, parts.day),
+    LocalTime(parts.hour, parts.minute),
+).toInstant(zone).toEpochMilliseconds()
+
+/** Epoch millis as an ISO instant, for the callables that take a window. */
+@OptIn(ExperimentalTime::class)
+fun isoFromEpochMillis(millis: Long): String =
+    Instant.fromEpochMilliseconds(millis).toString()
+
+private val WEEKDAYS = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+private val MONTHS = listOf(
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+)
+
+/**
+ * Renders one instant as "Fri 22 Aug, 6:00 PM".
+ *
+ * Hand-rolled rather than locale-aware: bar shifts are read at a glance
+ * across a counter, and a fixed short form is legible in a way a
+ * platform-default long date is not. The 12-hour clock matches the
+ * PWA's `toLocaleString` output for its actual users.
+ */
+fun formatEventTime(iso: String, zone: TimeZone = TimeZone.currentSystemDefault()): String {
+    val parts = eventTimePartsOf(iso, zone) ?: return "Unknown time"
+    val date = LocalDate(parts.year, parts.month, parts.day)
+    val weekday = WEEKDAYS[date.dayOfWeek.isoDayNumber - 1]
+    val month = MONTHS[parts.month - 1]
+    return "$weekday ${parts.day} $month, ${formatClockTime(parts.hour, parts.minute)}"
+}
+
+/**
+ * Renders a range, collapsing the second date when it is the same day.
+ *
+ * A shift is almost always within one day, and repeating the date on both
+ * ends makes the line long enough to wrap on a phone.
+ */
+fun formatEventRange(
+    startIso: String,
+    endIso: String,
+    zone: TimeZone = TimeZone.currentSystemDefault(),
+): String {
+    val start = eventTimePartsOf(startIso, zone) ?: return "Unknown time"
+    val end = eventTimePartsOf(endIso, zone) ?: return formatEventTime(startIso, zone)
+    val sameDay = start.year == end.year && start.month == end.month && start.day == end.day
+    return if (sameDay) {
+        "${formatEventTime(startIso, zone)} – ${formatClockTime(end.hour, end.minute)}"
+    } else {
+        "${formatEventTime(startIso, zone)} – ${formatEventTime(endIso, zone)}"
+    }
+}
+
+/** 24-hour input to a 12-hour label; midnight is 12 AM, noon is 12 PM. */
+fun formatClockTime(hour: Int, minute: Int): String {
+    val suffix = if (hour < 12) "AM" else "PM"
+    val display = when {
+        hour % 12 == 0 -> 12
+        else -> hour % 12
+    }
+    return "$display:${minute.toString().padStart(2, '0')} $suffix"
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/BottleRecognizerTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/BottleRecognizerTest.kt
@@ -1,0 +1,57 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logic.matchBrand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RecognizedLinesTest {
+
+    @Test
+    fun splits_and_trims() {
+        assertEquals(
+            listOf("JAMESON", "IRISH WHISKEY", "750ML"),
+            recognizedLinesOf("  JAMESON \n IRISH WHISKEY\n750ML  "),
+        )
+    }
+
+    @Test
+    fun blank_lines_are_dropped() {
+        assertEquals(listOf("CORONA"), recognizedLinesOf("\n\n  \nCORONA\n\n"))
+    }
+
+    /**
+     * OCR routinely emits a stray glyph from a label's border or
+     * embossing. Each one is another chance for [matchBrand] to find a
+     * spurious substring hit, so single characters never reach it.
+     */
+    @Test
+    fun single_character_lines_are_dropped() {
+        assertEquals(listOf("GIN"), recognizedLinesOf("|\nGIN\n®\n7"))
+    }
+
+    @Test
+    fun nothing_legible_yields_an_empty_list() {
+        assertTrue(recognizedLinesOf("").isEmpty())
+        assertTrue(recognizedLinesOf("\n \n|").isEmpty())
+    }
+
+    /**
+     * The two halves have to work together: the filter must not strip a
+     * line the matcher needed, and the matcher must survive the noise the
+     * filter lets through.
+     */
+    @Test
+    fun a_realistic_label_resolves_to_the_brand() {
+        val ocr = "|\nJAMESON\nIRISH WHISKEY\n750ML 40% ABV\n®"
+        val candidates = listOf("Jameson", "Jack Daniel's", "Tanqueray")
+        assertEquals("Jameson", matchBrand(recognizedLinesOf(ocr), candidates))
+    }
+
+    @Test
+    fun an_unrelated_label_resolves_to_nothing() {
+        val ocr = "SPARKLING MINERAL WATER\n1 LITRE"
+        assertNull(matchBrand(recognizedLinesOf(ocr), listOf("Jameson", "Tanqueray")))
+    }
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/EventTimeTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/logic/EventTimeTest.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.barbacker.logic
+
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EventTimeTest {
+
+    /** Fixed rather than the device's, so the assertions mean something. */
+    private val newYork = TimeZone.of("America/New_York")
+    private val utc = TimeZone.UTC
+
+    @Test
+    fun a_stored_instant_becomes_local_wall_clock_fields() {
+        // 2026-08-22T02:30Z is the evening of the 21st in New York.
+        val parts = eventTimePartsOf("2026-08-22T02:30:00Z", newYork)
+        assertEquals(EventTimeParts(2026, 8, 21, 22, 30), parts)
+    }
+
+    @Test
+    fun picker_fields_round_trip_through_the_stored_form() {
+        val parts = EventTimeParts(2026, 12, 31, 23, 45)
+        val iso = isoFromEventTimeParts(parts, newYork)
+        assertEquals(parts, eventTimePartsOf(iso, newYork))
+    }
+
+    /**
+     * Google writes all-day events as a bare date. Read as UTC midnight
+     * it would land on the previous day for anyone west of Greenwich —
+     * a shift showing up on the wrong date is worse than showing no time.
+     */
+    @Test
+    fun a_bare_date_is_read_as_local_midnight() {
+        val parts = eventTimePartsOf("2026-08-22", newYork)
+        assertEquals(EventTimeParts(2026, 8, 22, 0, 0), parts)
+    }
+
+    @Test
+    fun an_unparseable_instant_yields_null_rather_than_throwing() {
+        assertNull(eventTimePartsOf("next tuesday", utc))
+        assertNull(eventTimePartsOf("", utc))
+        assertEquals("Unknown time", formatEventTime("not a date", utc))
+    }
+
+    @Test
+    fun a_same_day_range_prints_the_date_once() {
+        assertEquals(
+            "Sat 22 Aug, 6:00 PM – 11:30 PM",
+            formatEventRange("2026-08-22T18:00:00Z", "2026-08-22T23:30:00Z", utc),
+        )
+    }
+
+    /** A close-down shift crosses midnight, and both dates have to show. */
+    @Test
+    fun a_range_crossing_midnight_prints_both_dates() {
+        assertEquals(
+            "Sat 22 Aug, 8:00 PM – Sun 23 Aug, 2:00 AM",
+            formatEventRange("2026-08-22T20:00:00Z", "2026-08-23T02:00:00Z", utc),
+        )
+    }
+
+    @Test
+    fun midnight_and_noon_are_twelve_not_zero() {
+        assertEquals("12:00 AM", formatClockTime(0, 0))
+        assertEquals("12:05 PM", formatClockTime(12, 5))
+        assertEquals("1:00 PM", formatClockTime(13, 0))
+        assertEquals("11:59 PM", formatClockTime(23, 59))
+    }
+
+    @Test
+    fun epoch_millis_round_trip() {
+        val parts = EventTimeParts(2026, 3, 1, 9, 15)
+        assertEquals(parts, eventTimePartsFromMillis(epochMillisOf(parts, newYork), newYork))
+    }
+}

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.desktop.kt
@@ -1,0 +1,21 @@
+package com.hereliesaz.barbacker.data
+
+/**
+ * No OCR on the JVM build.
+ *
+ * ML Kit is Android-only and Vision is Apple-only; the alternatives are a
+ * bundled Tesseract native library per desktop platform or a cloud vision
+ * API, and the latter would break the on-device promise the other two
+ * platforms keep.
+ *
+ * Reported explicitly rather than returning an empty result, so the
+ * scanner can say the brand has to be typed rather than looking as though
+ * it read a label and found nothing.
+ */
+private object UnsupportedBottleRecognizer : BottleRecognizer {
+    override val isSupported: Boolean = false
+    override suspend fun recognizeLines(image: ByteArray): List<String> = emptyList()
+}
+
+actual fun createBottleRecognizer(platformContext: Any?): BottleRecognizer =
+    UnsupportedBottleRecognizer

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.desktop.kt
@@ -1,0 +1,25 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import java.awt.Desktop
+import java.net.URI
+
+private class DesktopUrlOpener : UrlOpener {
+    override fun open(url: String): Boolean = try {
+        // Headless JVMs and several Linux desktops without a registered
+        // handler report BROWSE as unsupported; calling anyway throws.
+        if (Desktop.isDesktopSupported() &&
+            Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+        ) {
+            Desktop.getDesktop().browse(URI(url))
+            true
+        } else {
+            false
+        }
+    } catch (e: Exception) {
+        logWarning("Could not open a browser", e)
+        false
+    }
+}
+
+actual fun createUrlOpener(platformContext: Any?): UrlOpener = DesktopUrlOpener()

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/BottleRecognizer.ios.kt
@@ -1,0 +1,70 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.Vision.VNImageRequestHandler
+import platform.Vision.VNRecognizeTextRequest
+import platform.Vision.VNRecognizedTextObservation
+import platform.Vision.VNRequestTextRecognitionLevelAccurate
+import kotlin.coroutines.resume
+
+/**
+ * Apple's Vision framework, on-device.
+ *
+ * Unverified. There is no Xcode project in this repository (see
+ * `cmp/iosApp/README.md`) and CI has no macOS runner, so this file has
+ * never been compiled. Treat it as a first draft of the iOS path.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private class IosBottleRecognizer : BottleRecognizer {
+
+    override val isSupported: Boolean = true
+
+    override suspend fun recognizeLines(image: ByteArray): List<String> =
+        suspendCancellableCoroutine { continuation ->
+            val request = VNRecognizeTextRequest { request, error ->
+                if (error != null) {
+                    logWarning("Vision text recognition failed: ${error.localizedDescription}")
+                    if (continuation.isActive) continuation.resume(emptyList())
+                    return@VNRecognizeTextRequest
+                }
+                val lines = request?.results.orEmpty()
+                    .filterIsInstance<VNRecognizedTextObservation>()
+                    // topCandidates(1) is the highest-confidence reading
+                    // of each observed line; anything below that is noise
+                    // for a brand match.
+                    .mapNotNull { it.topCandidates(1u).firstOrNull() }
+                    .mapNotNull { candidate ->
+                        (candidate as? platform.Vision.VNRecognizedText)?.string
+                    }
+                if (continuation.isActive) {
+                    continuation.resume(recognizedLinesOf(lines.joinToString("\n")))
+                }
+            }
+            request.recognitionLevel = VNRequestTextRecognitionLevelAccurate
+
+            val handler = VNImageRequestHandler(image.toNSData(), mapOf<Any?, Any?>())
+            try {
+                handler.performRequests(listOf(request), null)
+            } catch (e: Exception) {
+                logWarning("Could not run Vision over the captured photo", e)
+                if (continuation.isActive) continuation.resume(emptyList())
+            }
+        }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun ByteArray.toNSData(): NSData {
+    if (isEmpty()) return NSData()
+    return usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = size.toULong())
+    }
+}
+
+actual fun createBottleRecognizer(platformContext: Any?): BottleRecognizer =
+    IosBottleRecognizer()

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/UrlOpener.ios.kt
@@ -1,0 +1,16 @@
+package com.hereliesaz.barbacker.data
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+private class IosUrlOpener : UrlOpener {
+    override fun open(url: String): Boolean {
+        val target = NSURL.URLWithString(url) ?: return false
+        val application = UIApplication.sharedApplication
+        if (!application.canOpenURL(target)) return false
+        application.openURL(target)
+        return true
+    }
+}
+
+actual fun createUrlOpener(platformContext: Any?): UrlOpener = IosUrlOpener()

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -276,7 +276,8 @@ Working end to end:
   on premium, and inviting staff or managers by email
 - The theme editor: brand colours, font, and a logo uploaded to Storage
 - Drag-to-reorder on the main grid and inside every sub-menu, held behind
-  a long press so a tap still sends a page
+  a long press so a tap still sends a page, and operable from a keyboard:
+  Space or Enter picks a tile up, the arrow keys move it, Escape cancels
 - The calendar: an agenda of the bar's events, Manager+ create/edit/delete,
   and the settings screen for Google, the outbound iCal feed, and inbound
   `.ics` subscriptions
@@ -284,6 +285,8 @@ Working end to end:
   sales summary
 - The bottle scanner on Android — camera, on-device OCR, and the
   add-to-menu / 86 / send-alert actions
+- Remote images: the bar's logo in the theme editor, and a scanned
+  bottle's photo on the request row it is attached to
 
 Not built yet — the PWA remains the complete client:
 
@@ -310,11 +313,6 @@ Not built yet — the PWA remains the complete client:
   looking broken; the in-app alert loop is what pages a desktop user.
 - **ntfy deep linking.** The notification-settings screen shows the
   topic for manual subscription but has no `ntfy://` link.
-- **Keyboard-operable reordering.** The web client can reorder with the
-  arrow keys; here the gesture is pointer-only.
-- **Logo previews.** The theme editor shows the uploaded logo's URL, not
-  the image — rendering a remote image needs an image-loading library
-  this build does not carry.
 - **Google and Apple sign-in.** Email/password only.
 
 Deliberately absent, because the PWA has no such feature either:

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -72,6 +72,18 @@ VITE_FIREBASE_MESSAGING_SENDER_ID
 VITE_FIREBASE_APP_ID
 ```
 
+One more is optional:
+
+```
+VITE_ICAL_FEED_BASE_URL
+```
+
+It names where the outbound iCal feed is actually served from — a Cloud
+Function, on a different host from everything else. Deliberately outside
+the required set, so a deployment that never enabled the feed still runs;
+Calendar Settings then says the link cannot be shown rather than
+constructing one that 404s.
+
 Where each platform looks for them:
 
 | Platform | Source |
@@ -196,11 +208,11 @@ without the refresh, every role-gated read stays denied for up to an hour.
 
 ## Testing
 
-`./gradlew :shared:desktopTest` runs the shared suite: 102 tests covering
+`./gradlew :shared:desktopTest` runs the shared suite: 116 tests covering
 the ported pure logic — contrast colour, brand matching, the button label
 resolver, sort order, sub-menu synthesis, tap classification, reorder
-arithmetic, picked-image identity, the request visibility filter, and
-alert eligibility.
+arithmetic, picked-image identity, OCR line filtering, event-time
+conversion, the request visibility filter, and alert eligibility.
 
 These are the pieces where a silent divergence from the PWA would be
 hardest to notice, so each behavioural subtlety is pinned by a test that
@@ -230,6 +242,12 @@ fails if it is lost:
 - The synthesised tiles are stripped from a saved order on the way to
   Firestore, not before the drag, so the indices the gesture works in
   stay aligned with what is on screen.
+- An all-day calendar event arrives as a bare date. Which midnight that
+  means has to be resolved against the SAME zone the display uses, or the
+  event lands on the wrong day by exactly the offset between them.
+- OCR emits stray single glyphs from a label's border. Each one is
+  another chance for the brand matcher to find a spurious substring hit,
+  so one-character lines never reach it.
 
 ## Status
 
@@ -259,19 +277,34 @@ Working end to end:
 - The theme editor: brand colours, font, and a logo uploaded to Storage
 - Drag-to-reorder on the main grid and inside every sub-menu, held behind
   a long press so a tap still sends a page
+- The calendar: an agenda of the bar's events, Manager+ create/edit/delete,
+  and the settings screen for Google, the outbound iCal feed, and inbound
+  `.ics` subscriptions
+- POS integration: connect Square or Toast, sync the menu, and a seven-day
+  sales summary
+- The bottle scanner on Android — camera, on-device OCR, and the
+  add-to-menu / 86 / send-alert actions
 
 Not built yet — the PWA remains the complete client:
 
-- **Calendar, POS settings, and the bottle scanner.** The domain models
-  are ported; the screens are not.
 - **iOS push delivery.** The token code is shared with Android, but iOS
   needs an APNs capability and entitlement configured in an Xcode
   project that does not exist yet (see `cmp/iosApp/README.md`). Until
   then iOS falls back to the in-app alert loop.
-- **The iOS file picker is unverified.** `ImagePicker.ios.kt` is written
-  against `UIDocumentPickerViewController`, but with no macOS runner and
-  no Xcode project it has never been compiled. Treat it as a first draft
-  of that path. Android and desktop are built in CI.
+- **The iOS UIKit interop is unverified.** `ImagePicker.ios.kt`,
+  `PhotoCapture.ios.kt`, and `BottleRecognizer.ios.kt` are written
+  against `UIDocumentPickerViewController`, `UIImagePickerController`,
+  and Vision respectively, but with no macOS runner and no Xcode project
+  none has ever been compiled. Treat them as first drafts. The camera one
+  also needs an `NSCameraUsageDescription` in `Info.plist`, or iOS
+  terminates the app the moment the picker opens. Android and desktop are
+  built in CI.
+- **The bottle scanner needs a camera and OCR, so desktop has neither
+  half.** ML Kit is Android-only and Vision is Apple-only; the
+  alternatives were bundling a Tesseract native library per desktop
+  platform or calling a cloud vision API, and the second would break the
+  on-device promise the other platforms keep. The scanner reports itself
+  unsupported there rather than offering a dead button.
 - **Desktop push.** There is no FCM transport for a JVM app. The
   provider reports this explicitly rather than registering nothing and
   looking broken; the in-app alert loop is what pages a desktop user.


### PR DESCRIPTION
Ports the last feature screens the Compose client was missing, then closes the remaining documented gaps against the PWA. After this, every screen the web app has exists here except Google/Apple sign-in.

Three commits: calendar + POS, the scanner, then keyboard reordering + remote images.

---

# 1. Calendar and POS

An agenda-style calendar with Manager+ event CRUD, the Google/iCal settings screen, and POS connect / menu sync / seven-day insights.

Neither integration talks to a vendor from the device. The OAuth credentials live in `posSecrets` and `calendarSecrets`, which no client can read; this client reads two write-denied Firestore collections and invokes the callables that hold the credentials.

## The OAuth flows work differently here, and the screens say so

The web client sets `window.location.href` and is redirected back by the callback. There is no redirect into a Compose app, so **Connect** opens the platform browser and the flow finishes there. The connection document is written server-side, and the listener on this screen picks it up when the user returns.

That is a real behavioural difference, so both screens state it in the UI rather than leaving someone watching a button that appears to do nothing. A platform with no browser to open — a headless JVM, a Linux desktop with no registered handler — reports that as a failure instead of swallowing it.

## A defect the tests caught

Date handling lives in `shared` with tests, because an event that lands an hour off, or on the wrong day near midnight, is only ever noticed on someone's roster.

Writing those tests found a real one: Google writes all-day events as a bare date with no time, and the fallback that turns those into instants resolved "which midnight" against the **system** zone while every other conversion used the caller's. An all-day event landed off by the offset between them — the day before, for anyone west of Greenwich. The zone is now a parameter, and a test pins it.

## Two other things that are not obvious

**Material's date picker deals in UTC midnights**, not instants — the value it returns is the picked calendar day at 00:00Z. Seeding and reading it back both go through `TimeZone.UTC`; without that, a date picked late in the evening lands on the following day.

**Event writes omit `externalProvider` rather than writing null.** The create rule reads `get('externalProvider', null) == null`, which a written null would satisfy — but `inboundSync` keys off the field's *presence*, so a null would make a locally created event look externally owned, and nobody could edit it again.

## Configuration

`VITE_ICAL_FEED_BASE_URL` joins the config as an **optional** value, deliberately absent from the required set: the outbound feed is a Cloud Function on a different host, and a deployment that never enabled it should still run. When a token exists but the base URL does not, the settings screen says the link cannot be shown rather than constructing one that 404s.

The calendar is an agenda, not a month grid, matching the web client. Externally-owned events render read-only with a badge — not a styling preference, since `firestore.rules` rejects a client write to any event carrying an `externalProvider`.

---

# 2. The bottle scanner

Camera capture, on-device OCR, and the three actions the web client offers: add the scanned bottle to the menu, 86 it, or page the floor with the photo attached.

On-device is the point, matching tesseract.js in the PWA: the photo and the text read off it never leave the device to identify a brand. Only **Send Alert** uploads anything, and only to this bar's own bucket.

## Platform coverage is uneven, and the UI says so

| Platform | Camera | OCR |
|---|---|---|
| Android | `ACTION_IMAGE_CAPTURE` + FileProvider | ML Kit, bundled model |
| iOS | `UIImagePickerController` — **unverified** | Vision — **unverified** |
| Desktop | none | none |

ML Kit's **bundled** recogniser, not the Play-Services-downloaded one: a bar's back-of-house Wi-Fi is exactly where a first-use model download fails.

Desktop reports itself unsupported rather than offering a dead button. The alternatives were bundling a Tesseract native library per desktop platform or calling a cloud vision API, and the second would break the on-device promise the other platforms keep.

## Two details that are load-bearing

**The alert's label is derived, not hardcoded.** It is prefixed with the stock BEER button's label read straight from `DEFAULT_BUTTONS`. A request whose label resolves to no button id is treated as "cannot tell who this is for" and paged to the whole floor past everyone's preferences — so a hardcoded copy that drifted would mass-notify a bar on every scan.

**Adding an already-stocked brand takes the arrayUnion path, not the merge-set one.** The merge-set writes the whole array for that key, so scanning a second type of a beer already on the menu would have wiped the types already recorded against it.

`ACTION_IMAGE_CAPTURE` with a FileProvider Uri rather than `TakePicturePreview` — the latter returns a thumbnail, and OCR on a thumbnail reads a label as noise. The manifest already declared `CAMERA`, which means the intent requires it *granted*, so the launcher requests it first and reports a denial rather than doing nothing.

## A gating bug I fixed on the second pass

I first nested the scanner's menu entry under premium **and** Manager+. The web client gates it on premium alone — a barback scanning a bottle and paging the floor is the staff-facing half, and only "Add to Menu" and "86 It" need Manager+ (which the dialog gates itself). Nesting it would have removed the staff path entirely.

---

# 3. Keyboard reordering and remote images

Two documented gaps, one of which the previous commit opened.

## Keyboard-operable reordering

Space or Enter picks a tile up, the arrow keys move it — left/right by one slot, up/down by a row — and Escape puts it back. This is the same gap the web client's `SortableButton` had to be fixed for: dnd-kit gives a div `role="button"` and a tabIndex, but the browser does not synthesize activation for a non-native element, so the grid had no keyboard path at all. A pointer is not the only way people use a tablet wedged behind a bar.

Arrow keys fire on **KeyUp**, because a held-down arrow otherwise repeats at the platform's key-repeat rate and skids the tile across the grid faster than anyone can follow. Escape is consumed only when it actually cancelled a hold, so it still closes an enclosing dialog otherwise. And the row stride is one constant shared with the layout — two hardcoded `2`s is how the arrow keys quietly stop matching what is on screen.

## Remote images

**The scanner in commit 2 uploaded evidence nobody could look at.** It writes a photo URL onto the request, and nothing in this client could display it. That is a half-finished feature rather than a missing nicety, so the request row now renders the thumbnail the web client shows. The theme editor's logo becomes an actual image too, instead of the URL text standing in for it.

Coil fetches over the Ktor client this app already builds for its place search rather than resolving an engine of its own — two HTTP stacks in one process is two connection pools and two sets of timeouts to keep straight, and on iOS the second may not resolve an engine at all.

Loading and failure both draw something rather than leaving a blank box. For a Storage URL, failure usually means the reader is not a member of that bar, and an empty frame gives no way to tell that from "still loading".

---

## Still not built

`docs/CMP.md` updated throughout. Remaining: iOS push delivery, `ntfy://` deep linking, and Google/Apple sign-in.

The iOS UIKit interop across `ImagePicker.ios.kt`, `PhotoCapture.ios.kt`, and `BottleRecognizer.ios.kt` has **never been compiled** — no macOS runner, no Xcode project. Treat those three as first drafts; the camera one additionally needs an `NSCameraUsageDescription` in `Info.plist` or iOS terminates the app when the picker opens.

The standing runtime caveat holds: these paths compile and match the rules but have not been exercised against live Firebase from this client.

## Verification

Clean build: Android APK ✅, desktop JAR ✅, shared suite **116 tests / 0 failures**, no warnings in project code.