### PR TITLE
Finish CMP parity: social sign-in, ntfy, Apple on every platform, and an iOS project spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,8 @@ cmp/build/
 cmp/*/build/
 cmp/local.properties
 cmp/.kotlin/
-cmp/iosApp/iosApp.xcodeproj/project.xcworkspace/
-cmp/iosApp/iosApp.xcodeproj/xcuserdata/
+# The whole project is generated from project.yml by XcodeGen, so it is
+# a build output rather than a source file — see cmp/iosApp/README.md.
+cmp/iosApp/iosApp.xcodeproj/
+# Firebase project values, like the PWA's .env.
+cmp/iosApp/Config.xcconfig

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -80,6 +80,7 @@ fun App(platformContext: Any? = null) {
             platformContext = platformContext,
             icalFeedBaseUrl = config.icalFeedBaseUrl,
             googleOAuth = config.googleOAuth,
+            appleWebSignIn = config.appleWebSignIn,
         )
     }
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/App.kt
@@ -79,6 +79,7 @@ fun App(platformContext: Any? = null) {
             store = createKeyValueStore(platformContext),
             platformContext = platformContext,
             icalFeedBaseUrl = config.icalFeedBaseUrl,
+            googleOAuth = config.googleOAuth,
         )
     }
 
@@ -101,6 +102,7 @@ private fun BarBackerApp(container: AppContainer) {
             pos = container.pos,
             urls = container.urls,
             bottleRecognizer = container.bottleRecognizer,
+            socialSignIn = container.socialSignIn,
             icalFeedBaseUrl = container.icalFeedBaseUrl,
             placeSearch = container.placeSearch,
             pushTokens = container.pushTokens,
@@ -138,7 +140,9 @@ private fun BarBackerApp(container: AppContainer) {
                     Screen.SignIn -> SignInScreen(
                         isRegistering = state.isRegistering,
                         authError = state.authError,
+                        socialProviders = viewModel.availableSocialProviders,
                         onSetRegistering = viewModel::setRegistering,
+                        onSocialSignIn = viewModel::signInWith,
                         onSubmit = viewModel::signIn,
                     )
 
@@ -272,7 +276,8 @@ private fun DashboardDialogs(state: AppUiState, viewModel: AppViewModel) {
                 ?: state.membership?.role?.wire.orEmpty(),
             currentPreferences = state.notificationPreferences,
             buttons = state.buttons,
-            ntfyTopic = null,
+            ntfyTopic = state.ntfyTopic,
+            onSubscribeNtfy = viewModel::subscribeToNtfy,
             onSave = viewModel::saveNotificationPreferences,
             onClose = viewModel::closeDialog,
         )

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppUiState.kt
@@ -155,6 +155,14 @@ data class AppUiState(
     /** Keyed by provider id. Manager+ only. */
     val posConnections: Map<String, POSConnectionStatus> = emptyMap(),
     val posMenu: List<POSMenuItem> = emptyList(),
+
+    /**
+     * This account's ntfy topic, for the iOS push fallback.
+     *
+     * Account-level rather than per-bar: it is what the server-side fanout
+     * publishes to, and an iOS user subscribes to it once.
+     */
+    val ntfyTopic: String? = null,
 ) {
     val currentUser get() = (auth as? AuthState.SignedIn)?.user
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/AppViewModel.kt
@@ -40,6 +40,9 @@ import com.hereliesaz.barbacker.data.PlaceSearchRepository
 import com.hereliesaz.barbacker.data.POSSales
 import com.hereliesaz.barbacker.data.PosRepository
 import com.hereliesaz.barbacker.data.PushTokenProvider
+import com.hereliesaz.barbacker.data.SocialProvider
+import com.hereliesaz.barbacker.data.SocialSignIn
+import com.hereliesaz.barbacker.data.SocialSignInCancelledException
 import com.hereliesaz.barbacker.data.RequestAlreadyClaimedException
 import com.hereliesaz.barbacker.data.RequestRepository
 import com.hereliesaz.barbacker.data.StorageRepository
@@ -105,6 +108,7 @@ class AppViewModel(
     private val pos: PosRepository,
     private val urls: UrlOpener,
     private val bottleRecognizer: BottleRecognizer,
+    private val socialSignIn: SocialSignIn,
     private val placeSearch: PlaceSearchRepository,
     private val pushTokens: PushTokenProvider,
     private val alerter: Alerter,
@@ -343,6 +347,7 @@ class AppViewModel(
             icalFeedBaseUrl = icalFeedBaseUrl,
             posConnections = integrations.pos.connections,
             posMenu = integrations.pos.menu,
+            ntfyTopic = account.ntfyTopic,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppUiState())
 
@@ -570,6 +575,42 @@ class AppViewModel(
      * otherwise become null — on a shared tablet behind a bar, that leaves
      * the previous person's floor still rendered.
      */
+    /**
+     * Which social buttons the sign-in screen should offer.
+     *
+     * Computed once rather than per recomposition: it depends only on the
+     * build's OAuth config and the platform, neither of which changes
+     * while the app is running.
+     */
+    val availableSocialProviders: List<SocialProvider> =
+        SocialProvider.entries.filter(socialSignIn::isSupported)
+
+    /**
+     * Runs a platform sign-in flow, then hands the tokens to Firebase.
+     *
+     * A cancel clears the error rather than setting one — someone backing
+     * out of the account picker has not failed at anything, and an error
+     * banner for it is just noise.
+     */
+    fun signInWith(provider: SocialProvider) {
+        localState.update { it.copy(authError = null) }
+        viewModelScope.launch {
+            try {
+                auth.signInWithSocial(socialSignIn.authenticate(provider))
+            } catch (e: SocialSignInCancelledException) {
+                // Deliberate. Nothing to report.
+            } catch (e: Exception) {
+                logWarning("${provider.label} sign-in failed", e)
+                localState.update {
+                    it.copy(
+                        authError = e.message
+                            ?: "${provider.label} sign-in failed. Please try again.",
+                    )
+                }
+            }
+        }
+    }
+
     fun signOut() {
         viewModelScope.launch {
             auth.signOut()
@@ -1330,6 +1371,11 @@ class AppViewModel(
     // --- Dialogs --------------------------------------------------------
 
     fun openDialog(dialog: ActiveDialog) {
+        // Minted lazily, when the screen that shows it opens, rather than
+        // on every sign-in: most accounts never touch ntfy, and writing a
+        // topic nobody asked for is a write per account for nothing.
+        if (dialog == ActiveDialog.NotificationSettings) mintNtfyTopicIfNeeded()
+
         if (dialog == ActiveDialog.Chat) {
             // Stamp the read watermark on open, which is what clears the
             // unread dot. Clock-based rather than server-based on purpose:
@@ -1347,6 +1393,23 @@ class AppViewModel(
     }
 
     fun closeDialog() = localState.update { it.copy(activeDialog = ActiveDialog.None) }
+
+    private fun mintNtfyTopicIfNeeded() {
+        val current = state.value
+        if (current.ntfyTopic != null) return
+        val uid = current.currentUser?.uid ?: return
+        viewModelScope.launch {
+            runCatching { memberships.ensureNtfyTopic(uid) }
+                // The account listener delivers the new value, so nothing
+                // is assigned here. A failure is logged rather than shown:
+                // the screen's other half — the per-button toggles — still
+                // works, and ntfy is a fallback most users never use.
+                .onFailure { logWarning("Could not mint an ntfy topic", it) }
+        }
+    }
+
+    /** Opens the ntfy app on this topic. Returns false if nothing could handle it. */
+    fun subscribeToNtfy(topic: String): Boolean = urls.open("ntfy://subscribe/$topic")
 
     // --- Chat -----------------------------------------------------------
 

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/NotificationSettingsDialog.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/NotificationSettingsDialog.kt
@@ -10,7 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -24,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.hereliesaz.barbacker.NOTIFICATION_DEFAULTS_BY_TITLE
 import com.hereliesaz.barbacker.model.ButtonConfig
 import com.hereliesaz.barbacker.ui.iconForName
@@ -46,12 +50,15 @@ fun NotificationSettingsDialog(
     currentPreferences: List<String>,
     buttons: List<ButtonConfig>,
     ntfyTopic: String?,
+    /** Opens the ntfy app on this topic. False if nothing handled the link. */
+    onSubscribeNtfy: (String) -> Boolean,
     onSave: (List<String>) -> Unit,
     onClose: () -> Unit,
 ) {
     // Seeded once per open. Every toggle is local until Save, so Cancel
     // genuinely discards rather than leaving half-applied changes.
     var preferences by remember { mutableStateOf(currentPreferences.toSet()) }
+    var ntfyError by remember { mutableStateOf<String?>(null) }
 
     BarBackerDialog(
         title = "Notification Settings",
@@ -99,12 +106,48 @@ fun NotificationSettingsDialog(
                         style = MaterialTheme.typography.labelLarge,
                         color = BarBackerColors.OnSurface,
                     )
-                    // Shown so it can be copied into the ntfy app by hand.
-                    // Subscribing via the ntfy:// deep link is not wired up
-                    // on this client yet.
+                    // Shown as well as linked: the deep link only works
+                    // if the ntfy app is installed, and the topic still
+                    // has to be readable so it can be typed in by hand on
+                    // a device that does not have it yet.
                     Text(
                         text = ntfyTopic,
                         style = MaterialTheme.typography.bodySmall,
+                        color = BarBackerColors.OnSurfaceVariant,
+                    )
+                    OutlinedButton(
+                        onClick = {
+                            // False means nothing on this device claims
+                            // ntfy:// — almost always that the app is not
+                            // installed. Said plainly rather than left as
+                            // a button that appears to do nothing.
+                            if (!onSubscribeNtfy(ntfyTopic)) {
+                                ntfyError = "Install the ntfy app first, then try again."
+                            } else {
+                                ntfyError = null
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(
+                            Icons.Filled.NotificationsActive,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.size(8.dp))
+                        Text("Subscribe in ntfy")
+                    }
+                    ntfyError?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = BarBackerColors.Warning,
+                        )
+                    }
+                    Text(
+                        text = "Free, and the only way an iOS device is paged " +
+                            "until this app ships its own APNs build.",
+                        fontSize = 10.sp,
                         color = BarBackerColors.OnSurfaceVariant,
                     )
                 }

--- a/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/SignInScreen.kt
+++ b/cmp/composeApp/src/commonMain/kotlin/com/hereliesaz/barbacker/ui/screens/SignInScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,6 +34,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.hereliesaz.barbacker.data.SocialProvider
 import com.hereliesaz.barbacker.ui.theme.BarBackerColors
 
 /**
@@ -57,7 +60,10 @@ fun RestoringScreen() {
 fun SignInScreen(
     isRegistering: Boolean,
     authError: String?,
+    /** Providers this platform and build can actually run. Often empty. */
+    socialProviders: List<SocialProvider>,
     onSetRegistering: (Boolean) -> Unit,
+    onSocialSignIn: (SocialProvider) -> Unit,
     onSubmit: (email: String, password: String) -> Unit,
 ) {
     var email by rememberSaveable { mutableStateOf("") }
@@ -126,6 +132,48 @@ fun SignInScreen(
                     modifier = Modifier.fillMaxWidth().height(56.dp),
                 ) {
                     Text(if (isRegistering) "Create Account" else "Clock In")
+                }
+            }
+
+            // Only providers this platform and build can actually run.
+            // A "Sign in with Apple" button on Android would open a flow
+            // that needs a confidential client secret this app has no
+            // safe place to keep, so it is absent rather than broken.
+            if (socialProviders.isNotEmpty()) {
+                Spacer(Modifier.height(20.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    HorizontalDivider(
+                        color = BarBackerColors.Outline,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = "OR",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = BarBackerColors.OnSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                    HorizontalDivider(
+                        color = BarBackerColors.Outline,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+
+                socialProviders.forEach { provider ->
+                    OutlinedButton(
+                        onClick = { onSocialSignIn(provider) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .padding(bottom = 8.dp),
+                    ) {
+                        Text("Continue with ${provider.label}")
+                    }
                 }
             }
 

--- a/cmp/gradle/libs.versions.toml
+++ b/cmp/gradle/libs.versions.toml
@@ -46,6 +46,13 @@ mlkitTextRecognition = "16.0.1"
 # configured per platform rather than pulling in a second HTTP stack.
 coil = "3.3.0"
 
+# Credential Manager + Google's ID-token helper, for Google sign-in on
+# Android. The modern replacement for the deprecated Google Sign-In SDK;
+# needs Play Services on the device, which every Android build here
+# already assumes for FCM.
+androidxCredentials = "1.3.0"
+googleId = "1.1.1"
+
 # HTTP, for the OpenStreetMap place lookup. Engines differ per platform:
 # OkHttp on Android, CIO on desktop, Darwin on iOS.
 ktor = "3.5.2"
@@ -68,6 +75,10 @@ firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = 
 firebase-storage = { module = "dev.gitlive:firebase-storage", version.ref = "gitliveFirebase" }
 firebase-functions = { module = "dev.gitlive:firebase-functions", version.ref = "gitliveFirebase" }
 firebase-messaging = { module = "dev.gitlive:firebase-messaging", version.ref = "gitliveFirebase" }
+
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
+androidx-credentials-play-services = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "androidxCredentials" }
+google-id = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
 
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }

--- a/cmp/iosApp/Config.example.xcconfig
+++ b/cmp/iosApp/Config.example.xcconfig
@@ -1,0 +1,36 @@
+// Copy to Config.xcconfig and fill in. The copy is gitignored: this
+// client reads its Firebase project from configuration the same way the
+// PWA does, so nothing project-specific is committed here either.
+//
+//     cp Config.example.xcconfig Config.xcconfig
+//
+// Values reach the app through Info.plist, which project.yml points at
+// these settings — see docs/CMP.md for what each one is.
+//
+// Two traps in this file format, both silent:
+//
+//   * `//` starts a comment ANYWHERE on a line, so a value containing a
+//     URL is truncated at the scheme's slashes. That is why there is no
+//     VITE_ICAL_FEED_BASE_URL here; if you need one, define
+//     SLASHES = /$()/ and write https:$(SLASHES)example.com.
+//   * Values are not quoted. Trailing whitespace is part of the value,
+//     and an API key with a stray space fails as an invalid key.
+
+VITE_FIREBASE_API_KEY =
+VITE_FIREBASE_AUTH_DOMAIN =
+VITE_FIREBASE_PROJECT_ID =
+VITE_FIREBASE_STORAGE_BUCKET =
+VITE_FIREBASE_MESSAGING_SENDER_ID =
+VITE_FIREBASE_APP_ID =
+
+// Optional — Google sign-in. BOTH are needed: the client's Google config
+// hangs off the server (web) client id, so an iOS client id on its own
+// leaves the button hidden. The reversed form is the client id with its
+// dot-separated parts in reverse order, and is the redirect scheme.
+VITE_GOOGLE_SERVER_CLIENT_ID =
+VITE_GOOGLE_IOS_CLIENT_ID =
+GOOGLE_REVERSED_CLIENT_ID =
+
+// Your Apple Developer team id, for signing. Also settable in Xcode's
+// Signing & Capabilities pane instead.
+BARBACKER_DEVELOPMENT_TEAM =

--- a/cmp/iosApp/README.md
+++ b/cmp/iosApp/README.md
@@ -1,48 +1,74 @@
 # iOS app shell
 
 The Compose UI is shared; this directory holds the thin Swift layer that
-hosts it, plus the Xcode project that builds an `.ipa`.
+hosts it, plus the spec the Xcode project is generated from.
 
 ## What is here
 
+- `project.yml` — the Xcode project, as [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+  reads it. Capabilities, entitlements, `Info.plist`, the Firebase
+  package dependencies, and the Gradle build phase all live here.
+- `Config.example.xcconfig` — the Firebase project values, to be copied
+  and filled in. The copy is gitignored.
 - `iosApp/iOSApp.swift` — the SwiftUI `@main` entry point.
 - `iosApp/ContentView.swift` — a `UIViewControllerRepresentable` wrapping
-  `MainViewController()`, the Kotlin function exported by the `ComposeApp`
-  framework.
+  `MainViewController()`, the Kotlin function exported by the
+  `ComposeApp` framework.
+- `iosApp/iosApp.debug.entitlements` / `iosApp.release.entitlements` —
+  Push Notifications and Sign in with Apple. Two files because
+  `aps-environment` differs, and getting it wrong means every page fails
+  with `BadDeviceToken`.
 
-## What is not here
-
-There is no `iosApp.xcodeproj` in the repository. An Xcode project file is
-a large generated artifact that cannot be built or verified on a Linux CI
-host, and committing an unverified one is worse than committing none —
-it would look supported while failing on the first real build.
-
-## Creating the project
+## Generating the project
 
 On a Mac with Xcode:
 
-1. Create a new iOS App project in this directory named `iosApp`, with
-   SwiftUI as the interface. Replace its generated `iOSApp.swift` and
-   `ContentView.swift` with the ones here.
+```sh
+brew install xcodegen
+cd cmp/iosApp
+cp Config.example.xcconfig Config.xcconfig   # then fill it in
+xcodegen generate
+open iosApp.xcodeproj
+```
 
-2. Add a **Run Script** build phase, ordered *before* "Compile Sources":
+Then set the signing team, in `Config.xcconfig` or in Xcode's
+Signing & Capabilities pane.
 
-   ```sh
-   cd "$SRCROOT/.."
-   ./gradlew :composeApp:embedAndSignAppleFrameworkForXcode
-   ```
+`iosApp.xcodeproj` is gitignored, because it is a build output. Edit
+`project.yml` and regenerate; edits made in Xcode's project editor are
+silently reverted by the next `xcodegen generate`.
 
-3. In Build Settings, add to **Framework Search Paths**:
+## Why the project is not committed
 
-   ```
-   $(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
-   ```
+An `.xcodeproj` is a directory of generated XML full of opaque UUIDs. It
+cannot be reviewed in a diff, and it cannot be built or verified on the
+Linux hosts this repository's CI runs on — so committing one would mean
+committing something nobody working here could check. `project.yml` says
+the same thing in a form a person can read and a tool can turn back into
+the real project deterministically.
 
-4. Add the six `VITE_FIREBASE_*` keys to `Info.plist` — the client reads
-   its Firebase configuration from there. See [../../docs/CMP.md](../../docs/CMP.md).
+## Caveats
 
-5. Set the bundle identifier and signing team.
+**None of this has been generated or built.** There is no macOS runner
+in CI and no Mac in the loop, so `project.yml`, the entitlements, and the
+Swift and Kotlin iOS sources are all written blind. Treat the first real
+build as a review rather than a formality. The same applies to the iOS
+halves of the shared code — `ImagePicker.ios.kt`, `PhotoCapture.ios.kt`,
+`BottleRecognizer.ios.kt`, and `SocialSignIn.ios.kt` are first drafts
+against UIKit, Vision, and AuthenticationServices.
 
 Simulator builds need an Apple Silicon Mac: Compose Multiplatform 1.11.x
 publishes no Intel-simulator (`iosX64`) artifacts, so only
 `iosSimulatorArm64` and `iosArm64` are configured.
+
+The Firebase iOS SDK is pulled in over Swift Package Manager, and its
+major version has to match the one GitLive's cinterop bindings were
+generated against. A mismatch shows up as missing selectors at link
+time, not as a version warning.
+
+Push registration is driven from Kotlin (`PushTokens.ios.kt`), not from
+an app delegate. FCM cannot mint a token before Firebase is configured,
+and Firebase is configured in the first composition rather than at
+launch — so registering in `didFinishLaunching` races with it, usually
+wins, and when it loses looks like a device that simply never receives
+pages.

--- a/cmp/iosApp/iosApp/iosApp.debug.entitlements
+++ b/cmp/iosApp/iosApp/iosApp.debug.entitlements
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Development APNs. A build signed with this entitlement gets a
+	     device token from Apple's sandbox gateway, which is a different
+	     token space from production: sending a sandbox token to the
+	     production gateway fails with BadDeviceToken rather than with
+	     anything that names the mismatch. Release uses the other file. -->
+	<key>aps-environment</key>
+	<string>development</string>
+
+	<!-- Sign in with Apple. Without this the native sheet in
+	     SocialSignIn.ios.kt fails at ASAuthorizationController with an
+	     unknown-error rather than saying the capability is missing. -->
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/cmp/iosApp/iosApp/iosApp.release.entitlements
+++ b/cmp/iosApp/iosApp/iosApp.release.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Production APNs, for TestFlight and the App Store. The token
+	     space differs from development's: a build shipped with
+	     `development` here registers against Apple's sandbox gateway,
+	     and every page sent to it fails with BadDeviceToken. -->
+	<key>aps-environment</key>
+	<string>production</string>
+
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/cmp/iosApp/project.yml
+++ b/cmp/iosApp/project.yml
@@ -1,0 +1,176 @@
+# XcodeGen spec for the iOS app shell.
+#
+# An .xcodeproj is a directory of generated XML full of opaque UUIDs —
+# unreviewable in a diff, and unbuildable on the Linux hosts this
+# repository's CI runs on, so committing one would mean committing
+# something nobody here could verify. This file is the same project
+# expressed as something a person can read, and `xcodegen generate`
+# turns it into the real thing on a Mac:
+#
+#     brew install xcodegen && cd cmp/iosApp && xcodegen generate
+#
+# Regenerating is safe and expected — the .xcodeproj is a build output,
+# not a source file, and is gitignored as one. Change this file, not the
+# project, or the next regeneration silently reverts you.
+#
+# Everything below is written blind: there is no macOS runner here, so
+# none of it has been generated or built. Treat the first run as a
+# review, not a formality.
+
+name: iosApp
+
+options:
+  bundleIdPrefix: com.hereliesaz
+  deploymentTarget:
+    iOS: "15.0"
+  createIntermediateGroups: true
+  defaultConfig: Debug
+
+configs:
+  Debug: debug
+  Release: release
+
+packages:
+  # GitLive's Firebase bindings are cinterop headers over the real
+  # Firebase iOS SDK; the SDK itself still has to be linked into the app.
+  #
+  # The major version has to match what GitLive 2.6.0's cinterop was
+  # generated against — a mismatch surfaces as missing selectors at
+  # link time, not as a version warning. Check the upstream
+  # firebase-kotlin-sdk release notes before moving this.
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk
+    from: "11.0.0"
+
+targets:
+  iosApp:
+    type: application
+    platform: iOS
+
+    sources:
+      - path: iosApp
+        excludes:
+          # Neither is a resource. Left in, XcodeGen files them under
+          # Resources and they ship inside the app — the entitlements as
+          # a readable copy of what the app is allowed to do, and the
+          # Info.plist (which XcodeGen writes here) as a second copy of
+          # itself.
+          - "*.entitlements"
+          - "Info.plist"
+
+    dependencies:
+      # One product per Firebase service the shared code touches. Listing
+      # only FirebaseCore would compile and then fail to link the moment
+      # the Kotlin side calls Firestore.
+      - package: Firebase
+        product: FirebaseAuth
+      - package: Firebase
+        product: FirebaseFirestore
+      - package: Firebase
+        product: FirebaseFunctions
+      - package: Firebase
+        product: FirebaseStorage
+      - package: Firebase
+        product: FirebaseMessaging
+
+    # Project configuration lives in a file that is NOT committed, the
+    # same way every other client here reads its Firebase project from
+    # the environment rather than from a checked-in artifact. Copy
+    # Config.example.xcconfig to Config.xcconfig before generating.
+    configFiles:
+      Debug: Config.xcconfig
+      Release: Config.xcconfig
+
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.hereliesaz.barbacker
+        MARKETING_VERSION: "1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        # Where embedAndSignAppleFrameworkForXcode leaves ComposeApp.framework.
+        FRAMEWORK_SEARCH_PATHS: $(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
+        # Kotlin/Native writes the framework into composeApp/build, well
+        # outside the target's sandbox. Xcode 15 turned script
+        # sandboxing on by default, which turns the write this build
+        # phase exists to perform into a permission error partway
+        # through the build.
+        ENABLE_USER_SCRIPT_SANDBOXING: NO
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        # Set to your team, or fill it in in Xcode's Signing pane. Left
+        # empty here because a team id is account-specific and belongs no
+        # more in this repository than an API key does.
+        DEVELOPMENT_TEAM: $(BARBACKER_DEVELOPMENT_TEAM)
+      configs:
+        # Two files rather than one with a build-setting placeholder:
+        # `aps-environment` is read by the signing machinery before build
+        # settings are substituted, so a placeholder there yields a
+        # provisioning error that names nothing useful.
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.debug.entitlements
+        Release:
+          CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.release.entitlements
+
+    info:
+      path: iosApp/Info.plist
+      properties:
+        CFBundleDisplayName: BarBacker
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        # Answers App Store Connect's export-compliance question up front.
+        # HTTPS to Firebase is exempt; without this every upload stops to
+        # ask the same question again.
+        ITSAppUsesNonExemptEncryption: false
+
+        # Wakes the app for a page that arrives while it is backgrounded.
+        UIBackgroundModes:
+          - remote-notification
+
+        # iOS terminates the app the instant a picker opens without the
+        # matching usage description — not a permission denial, a crash.
+        NSCameraUsageDescription: >-
+          BarBacker uses the camera to read a bottle label so it can be
+          added to the menu or 86'd without typing.
+        NSPhotoLibraryUsageDescription: >-
+          BarBacker needs your photo library to set your bar's logo.
+
+        # The client reads its Firebase project from here, matching the
+        # PWA's VITE_* names so one .env drives every client. The values
+        # come from Config.xcconfig and are substituted at build time, so
+        # nothing project-specific is committed.
+        VITE_FIREBASE_API_KEY: $(VITE_FIREBASE_API_KEY)
+        VITE_FIREBASE_AUTH_DOMAIN: $(VITE_FIREBASE_AUTH_DOMAIN)
+        VITE_FIREBASE_PROJECT_ID: $(VITE_FIREBASE_PROJECT_ID)
+        VITE_FIREBASE_STORAGE_BUCKET: $(VITE_FIREBASE_STORAGE_BUCKET)
+        VITE_FIREBASE_MESSAGING_SENDER_ID: $(VITE_FIREBASE_MESSAGING_SENDER_ID)
+        VITE_FIREBASE_APP_ID: $(VITE_FIREBASE_APP_ID)
+
+        # Optional. Each feature reports itself unsupported rather than
+        # failing when its value is absent — see docs/CMP.md. Google
+        # sign-in needs BOTH ids: the config object hangs off the server
+        # one, so an iOS client id alone leaves it switched off.
+        VITE_GOOGLE_SERVER_CLIENT_ID: $(VITE_GOOGLE_SERVER_CLIENT_ID)
+        VITE_GOOGLE_IOS_CLIENT_ID: $(VITE_GOOGLE_IOS_CLIENT_ID)
+
+        # Google's iOS convention: the redirect scheme is the client id
+        # with its dot-separated parts reversed.
+        # ASWebAuthenticationSession claims a scheme without help from
+        # Info.plist, so this is belt and braces — but it is what every
+        # other tool looking at the bundle expects to find.
+        CFBundleURLTypes:
+          - CFBundleURLName: com.googleusercontent.apps
+            CFBundleURLSchemes:
+              - $(GOOGLE_REVERSED_CLIENT_ID)
+
+    preBuildScripts:
+      # Must run before "Compile Sources": the Swift here imports
+      # ComposeApp, which this phase is what produces.
+      - name: Build the Compose framework
+        basedOnDependencyAnalysis: false
+        script: |
+          cd "$SRCROOT/.."
+          ./gradlew :composeApp:embedAndSignAppleFrameworkForXcode

--- a/cmp/shared/build.gradle.kts
+++ b/cmp/shared/build.gradle.kts
@@ -62,6 +62,9 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
             implementation(libs.mlkit.text.recognition)
+            implementation(libs.androidx.credentials)
+            implementation(libs.androidx.credentials.play.services)
+            implementation(libs.google.id)
         }
 
         val desktopMain by getting

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/SecureRandom.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/SecureRandom.android.kt
@@ -1,0 +1,8 @@
+package com.hereliesaz.barbacker
+
+import java.security.SecureRandom
+
+private val random = SecureRandom()
+
+actual fun secureRandomHex(byteCount: Int): String =
+    ByteArray(byteCount).also(random::nextBytes).toHexString()

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/Sha256.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/Sha256.android.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.barbacker
+
+import java.security.MessageDigest
+
+actual fun sha256(value: String): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(value.encodeToByteArray())

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.android.kt
@@ -1,0 +1,96 @@
+package com.hereliesaz.barbacker.data
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import com.hereliesaz.barbacker.secureRandomHex
+import io.ktor.client.HttpClient
+
+/**
+ * Google sign-in through Credential Manager.
+ *
+ * `GetSignInWithGoogleOption`, not `GetGoogleIdOption`: the latter shows a
+ * one-tap sheet that silently returns nothing when the device has no
+ * eligible account, which reads as a dead button. This one always shows
+ * the full account picker, which is what someone tapping "Sign in with
+ * Google" expects.
+ *
+ * Apple is not offered here. Apple's web flow requires a client secret
+ * that is a JWT signed with a private key — a genuine confidential
+ * credential, which an app shipped to devices has no safe place to keep.
+ * Doing it properly would mean a Cloud Function to run the exchange, and
+ * that does not exist.
+ */
+private class AndroidSocialSignIn(
+    private val context: Context?,
+    private val config: GoogleOAuthConfig,
+) : SocialSignIn {
+
+    override fun isSupported(provider: SocialProvider): Boolean =
+        provider == SocialProvider.Google && context != null
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential {
+        if (provider != SocialProvider.Google) {
+            throw SocialSignInException("Apple sign-in is not available on Android.")
+        }
+        val host = context ?: throw SocialSignInException("Could not open the account picker.")
+
+        val option = GetSignInWithGoogleOption
+            .Builder(config.serverClientId)
+            // Binds this request to a value the server also sees, so a
+            // response captured from another request cannot be replayed
+            // into this one.
+            .setNonce(secureRandomHex(NONCE_BYTES))
+            .build()
+
+        val response = try {
+            CredentialManager.create(host).getCredential(
+                context = host,
+                request = GetCredentialRequest.Builder().addCredentialOption(option).build(),
+            )
+        } catch (e: GetCredentialCancellationException) {
+            throw SocialSignInCancelledException()
+        } catch (e: NoCredentialException) {
+            // Distinct from a cancel: there was nothing to choose from.
+            throw SocialSignInException("No Google account is available on this device.", e)
+        } catch (e: GetCredentialException) {
+            throw SocialSignInException("Google sign-in failed.", e)
+        }
+
+        val credential = response.credential
+        if (credential.type != GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+            throw SocialSignInException("Google sign-in returned an unexpected credential.")
+        }
+
+        val googleCredential = try {
+            GoogleIdTokenCredential.createFrom(credential.data)
+        } catch (e: GoogleIdTokenParsingException) {
+            throw SocialSignInException("Google sign-in returned a token we could not read.", e)
+        }
+
+        return SocialCredential(
+            provider = SocialProvider.Google,
+            idToken = googleCredential.idToken,
+        )
+    }
+
+    private companion object {
+        const val NONCE_BYTES = 16
+    }
+}
+
+actual fun createSocialSignIn(
+    platformContext: Any?,
+    config: GoogleOAuthConfig?,
+    httpClient: HttpClient,
+    urls: UrlOpener,
+): SocialSignIn = when {
+    config == null -> UnsupportedSocialSignIn
+    else -> AndroidSocialSignIn(platformContext as? Context, config)
+}

--- a/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.android.kt
+++ b/cmp/shared/src/androidMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.android.kt
@@ -21,11 +21,11 @@ import io.ktor.client.HttpClient
  * the full account picker, which is what someone tapping "Sign in with
  * Google" expects.
  *
- * Apple is not offered here. Apple's web flow requires a client secret
- * that is a JWT signed with a private key — a genuine confidential
- * credential, which an app shipped to devices has no safe place to keep.
- * Doing it properly would mean a Cloud Function to run the exchange, and
- * that does not exist.
+ * Apple is absent from this class rather than unavailable on Android.
+ * Its flow runs through the browser and is identical on every platform
+ * without a native sheet, so it lives in common code — see
+ * [AppleWebSignIn], which [CombinedSocialSignIn] layers on top of this
+ * one when the server half is deployed. Nothing here needs to know.
  */
 private class AndroidSocialSignIn(
     private val context: Context?,
@@ -36,8 +36,11 @@ private class AndroidSocialSignIn(
         provider == SocialProvider.Google && context != null
 
     override suspend fun authenticate(provider: SocialProvider): SocialCredential {
+        // Only reachable if something called this for a provider
+        // isSupported already said no to; Apple is handled by the
+        // fallback this class is composed with, not here.
         if (provider != SocialProvider.Google) {
-            throw SocialSignInException("Apple sign-in is not available on Android.")
+            throw SocialSignInException("${provider.label} sign-in is not available here.")
         }
         val host = context ?: throw SocialSignInException("Could not open the account picker.")
 

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Base64Url.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Base64Url.kt
@@ -1,0 +1,49 @@
+package com.hereliesaz.barbacker
+
+private const val ALPHABET =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+/**
+ * Base64url with no padding, as PKCE's `code_challenge` requires.
+ *
+ * Hand-rolled because the platforms disagree: the JVM has
+ * `Base64.getUrlEncoder()`, Kotlin/Native has nothing, and Foundation's
+ * base64 uses the standard alphabet with padding — which Google's token
+ * endpoint rejects outright.
+ *
+ * Kept here, in common code, specifically so it can be tested. The two
+ * tail cases (one and two leftover bytes) are where a hand-rolled base64
+ * goes wrong, and getting one of them wrong yields a challenge that
+ * fails only for certain digests — which looks like an intermittent
+ * sign-in bug rather than an encoder bug.
+ */
+internal fun ByteArray.base64UrlEncode(): String {
+    val out = StringBuilder((size + 2) / 3 * 4)
+    var index = 0
+    while (index + 2 < size) {
+        val chunk = (this[index].toInt() and 0xFF shl 16) or
+            (this[index + 1].toInt() and 0xFF shl 8) or
+            (this[index + 2].toInt() and 0xFF)
+        out.append(ALPHABET[chunk shr 18 and 0x3F])
+        out.append(ALPHABET[chunk shr 12 and 0x3F])
+        out.append(ALPHABET[chunk shr 6 and 0x3F])
+        out.append(ALPHABET[chunk and 0x3F])
+        index += 3
+    }
+    when (size - index) {
+        1 -> {
+            val chunk = this[index].toInt() and 0xFF shl 16
+            out.append(ALPHABET[chunk shr 18 and 0x3F])
+            out.append(ALPHABET[chunk shr 12 and 0x3F])
+        }
+
+        2 -> {
+            val chunk = (this[index].toInt() and 0xFF shl 16) or
+                (this[index + 1].toInt() and 0xFF shl 8)
+            out.append(ALPHABET[chunk shr 18 and 0x3F])
+            out.append(ALPHABET[chunk shr 12 and 0x3F])
+            out.append(ALPHABET[chunk shr 6 and 0x3F])
+        }
+    }
+    return out.toString()
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/SecureRandom.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/SecureRandom.kt
@@ -1,0 +1,19 @@
+package com.hereliesaz.barbacker
+
+/**
+ * Cryptographically secure random bytes, as lowercase hex.
+ *
+ * Not `kotlin.random.Random`, and the distinction matters here rather
+ * than being pedantry: the one caller is the ntfy topic, and an ntfy
+ * topic is a bearer secret — anyone who knows the string can subscribe to
+ * that person's pages. A seeded PRNG's output is predictable from any
+ * other sample of it, which would make topics guessable across accounts.
+ */
+expect fun secureRandomHex(byteCount: Int): String
+
+/** Renders bytes as lowercase hex, shared by every platform's implementation. */
+internal fun ByteArray.toHexString(): String =
+    joinToString("") { byte ->
+        val value = byte.toInt() and 0xFF
+        value.toString(16).padStart(2, '0')
+    }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Sha256.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/Sha256.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.barbacker
+
+/**
+ * SHA-256 of a string's UTF-8 bytes.
+ *
+ * Per-platform because there is no multiplatform digest in the standard
+ * library and none of the three targets can borrow another's: the JVM has
+ * `MessageDigest`, Apple has CommonCrypto, and neither is reachable from
+ * common code.
+ *
+ * Three of the four callers hash something whose *un*-hashed form is the
+ * actual secret — a PKCE verifier, an Apple nonce, a sign-in claim secret
+ * — which is why this exists rather than each flow rolling its own.
+ */
+expect fun sha256(value: String): ByteArray
+
+/** SHA-256 as lowercase hex, the form both the nonce and the claim secret travel in. */
+fun sha256Hex(value: String): String = sha256(value).toHexString()

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -21,6 +21,9 @@ class AppContainer(
 
     /** Google OAuth client ids, absent when this build has none. */
     googleOAuth: GoogleOAuthConfig? = null,
+
+    /** Whether the Apple sign-in Cloud Functions are deployed for this project. */
+    appleWebSignIn: Boolean = false,
 ) {
     val auth: AuthRepository = FirebaseAuthRepository(firebase.auth)
     val bars: BarRepository = FirebaseBarRepository(firebase.firestore)
@@ -55,7 +58,17 @@ class AppContainer(
     // properties in declaration order and the browser-based flows take
     // both — moving this up yields a null client at construction time.
     val socialSignIn: SocialSignIn =
-        createSocialSignIn(platformContext, googleOAuth, httpClient, urls)
+        createSocialSignIn(platformContext, googleOAuth, httpClient, urls).let { platform ->
+            // Apple's web flow is entirely common code, so it is layered
+            // on here rather than duplicated into each `actual`. iOS's
+            // native sheet already supports Apple and therefore keeps
+            // winning; only Android and desktop fall through to it.
+            if (appleWebSignIn) {
+                CombinedSocialSignIn(platform, AppleWebSignIn(firebase.functions, urls))
+            } else {
+                platform
+            }
+        }
 
     val pushTokens: PushTokenProvider = createPushTokenProvider(platformContext)
     val alerter: Alerter = createAlerter(platformContext)

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppContainer.kt
@@ -18,6 +18,9 @@ class AppContainer(
     platformContext: Any? = null,
     /** Where the outbound iCal feed is served from, if configured. */
     val icalFeedBaseUrl: String? = null,
+
+    /** Google OAuth client ids, absent when this build has none. */
+    googleOAuth: GoogleOAuthConfig? = null,
 ) {
     val auth: AuthRepository = FirebaseAuthRepository(firebase.auth)
     val bars: BarRepository = FirebaseBarRepository(firebase.firestore)
@@ -36,10 +39,7 @@ class AppContainer(
 
     /**
      * One client for the whole process. Ktor clients own a connection pool
-     * and a dispatcher, so creating one per search would leak both.
-     */
-    /**
-     * Shared by the place search and the image loader.
+     * and a dispatcher, so creating one per caller would leak both.
      *
      * Exposed rather than private so Coil fetches over the engine already
      * configured for this platform, instead of resolving a second one of
@@ -50,6 +50,12 @@ class AppContainer(
 
     val placeSearch: PlaceSearchRepository =
         DefaultPlaceSearchRepository(firebase.firestore, httpClient)
+
+    // Declared after httpClient and urls, because Kotlin initialises
+    // properties in declaration order and the browser-based flows take
+    // both — moving this up yields a null client at construction time.
+    val socialSignIn: SocialSignIn =
+        createSocialSignIn(platformContext, googleOAuth, httpClient, urls)
 
     val pushTokens: PushTokenProvider = createPushTokenProvider(platformContext)
     val alerter: Alerter = createAlerter(platformContext)

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppleWebSignIn.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AppleWebSignIn.kt
@@ -1,0 +1,209 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.secureRandomHex
+import com.hereliesaz.barbacker.sha256Hex
+import dev.gitlive.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
+
+/**
+ * Apple sign-in on the platforms with no native sheet, through the
+ * browser and three Cloud Functions.
+ *
+ * iOS has `ASAuthorizationController` and needs none of this. Android and
+ * desktop have to run Apple's web flow, and the received wisdom about
+ * that flow — that it needs a client secret which is a JWT signed with a
+ * .p8 private key, and therefore a confidential credential no shipped app
+ * can hold — is true only of the *token exchange*. Asking Apple for
+ * `response_type=code id_token` returns the identity token directly in
+ * the callback, and the identity token is the only thing Firebase wants.
+ * The exchange, and the private key it would need, are skipped entirely.
+ *
+ * What is still needed is a public HTTPS endpoint, because Apple refuses
+ * to redirect to a custom scheme or to loopback, so the redirect cannot
+ * land on the device. Hence the round trip through
+ * `appleAuthBegin` / `appleAuthCallback` / `appleAuthClaim`: the browser
+ * finishes at a Cloud Function, and this polls for the result.
+ *
+ * All of it is common code. That is the payoff of routing through the
+ * browser rather than a platform SDK — one implementation covers both
+ * targets, and the only per-platform part is [UrlOpener], which every
+ * target already had.
+ */
+internal class AppleWebSignIn(
+    private val functions: FirebaseFunctions,
+    private val urls: UrlOpener,
+) : SocialSignIn {
+
+    @Serializable
+    private data class BeginRequest(
+        val sessionId: String,
+        val claimSecretHash: String,
+        val nonce: String,
+    )
+
+    @Serializable
+    private data class BeginResponse(val authorizeUrl: String)
+
+    @Serializable
+    private data class ClaimRequest(val sessionId: String, val claimSecret: String)
+
+    @Serializable
+    private data class ClaimResponse(
+        val status: String,
+        val idToken: String? = null,
+        val message: String? = null,
+    )
+
+    override fun isSupported(provider: SocialProvider): Boolean =
+        provider == SocialProvider.Apple
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential {
+        if (provider != SocialProvider.Apple) {
+            throw SocialSignInException("${provider.label} sign-in is not available here.")
+        }
+
+        // Three separate secrets, because they defend against three
+        // different things. The session id is public — it goes to Apple
+        // as `state` and therefore into the browser's history. The claim
+        // secret never leaves this process except as a hash, and is what
+        // stops anyone else collecting the token. The nonce goes to Apple
+        // hashed and to Firebase raw, which is what stops an identity
+        // token issued for someone else's request being replayed here.
+        val sessionId = secureRandomHex(SESSION_ID_BYTES)
+        val claimSecret = secureRandomHex(CLAIM_SECRET_BYTES)
+        val rawNonce = secureRandomHex(NONCE_BYTES)
+
+        val authorizeUrl = try {
+            functions.httpsCallable("appleAuthBegin")
+                .invoke(
+                    BeginRequest(
+                        sessionId = sessionId,
+                        claimSecretHash = sha256Hex(claimSecret),
+                        nonce = sha256Hex(rawNonce),
+                    ),
+                )
+                .data<BeginResponse>()
+                .authorizeUrl
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw SocialSignInException("Could not start sign-in with Apple.", e)
+        }
+
+        if (!urls.open(authorizeUrl)) {
+            throw SocialSignInException("Could not open a browser for sign-in.")
+        }
+
+        return awaitCredential(sessionId, claimSecret, rawNonce)
+    }
+
+    /**
+     * Polls until the browser half finishes, or the wait runs out.
+     *
+     * Polling rather than a Firestore listener because the document being
+     * waited on holds an identity token, so the rules deny the client any
+     * read of it — and there is no signed-in identity to scope such a
+     * read to, this being sign-in.
+     *
+     * Any failure of the poll itself is terminal rather than retried. A
+     * dropped connection mid-consent does mean starting over, which is
+     * the cost of not swallowing the one error that says what actually
+     * went wrong — a session collected twice, or expired, reports itself
+     * exactly once.
+     */
+    private suspend fun awaitCredential(
+        sessionId: String,
+        claimSecret: String,
+        rawNonce: String,
+    ): SocialCredential {
+        val response = try {
+            withTimeout(CONSENT_TIMEOUT_MILLIS) {
+                var result: ClaimResponse
+                do {
+                    delay(POLL_INTERVAL_MILLIS)
+                    result = try {
+                        functions.httpsCallable("appleAuthClaim")
+                            .invoke(ClaimRequest(sessionId, claimSecret))
+                            .data<ClaimResponse>()
+                    } catch (e: CancellationException) {
+                        // The timeout below, or the screen going away.
+                        // Swallowing this would report a cancelled wait
+                        // as a server failure and leave the coroutine
+                        // running past its own cancellation.
+                        throw e
+                    } catch (e: Exception) {
+                        throw SocialSignInException("Sign-in with Apple could not be completed.", e)
+                    }
+                } while (result.status == STATUS_PENDING)
+                result
+            }
+        } catch (e: TimeoutCancellationException) {
+            throw SocialSignInException("Sign-in timed out.", e)
+        }
+
+        return when (response.status) {
+            STATUS_READY -> SocialCredential(
+                provider = SocialProvider.Apple,
+                idToken = response.idToken
+                    ?: throw SocialSignInException("Apple returned no identity token."),
+                // Raw, never the hash. Firebase re-hashes this and
+                // compares it against the token's nonce claim; sending
+                // the hash fails with a generic invalid-credential error
+                // that says nothing about why.
+                rawNonce = rawNonce,
+            )
+
+            STATUS_CANCELLED -> throw SocialSignInCancelledException()
+
+            else -> throw SocialSignInException(
+                response.message ?: "Sign-in with Apple could not be completed.",
+            )
+        }
+    }
+
+    private companion object {
+        const val SESSION_ID_BYTES = 16
+        const val CLAIM_SECRET_BYTES = 32
+        const val NONCE_BYTES = 16
+
+        const val STATUS_PENDING = "pending"
+        const val STATUS_READY = "ready"
+        const val STATUS_CANCELLED = "cancelled"
+
+        /**
+         * Matched to the server's session TTL. Waiting longer would only
+         * poll a document that has already been swept.
+         */
+        const val CONSENT_TIMEOUT_MILLIS = 10L * 60 * 1000
+        const val POLL_INTERVAL_MILLIS = 2_000L
+    }
+}
+
+/**
+ * Adds a provider the platform flow cannot do itself.
+ *
+ * The platform's own implementation always wins where it supports a
+ * provider, so iOS keeps its native Apple sheet and only Android and
+ * desktop fall through to the browser flow. Composed here rather than
+ * threaded into `createSocialSignIn` so no `actual` has to know the web
+ * flow exists.
+ */
+internal class CombinedSocialSignIn(
+    private val platform: SocialSignIn,
+    private val fallback: SocialSignIn,
+) : SocialSignIn {
+
+    override fun isSupported(provider: SocialProvider): Boolean =
+        platform.isSupported(provider) || fallback.isSupported(provider)
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential =
+        if (platform.isSupported(provider)) {
+            platform.authenticate(provider)
+        } else {
+            fallback.authenticate(provider)
+        }
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AuthRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/AuthRepository.kt
@@ -2,6 +2,8 @@ package com.hereliesaz.barbacker.data
 
 import com.hereliesaz.barbacker.logWarning
 import dev.gitlive.firebase.auth.FirebaseAuth
+import dev.gitlive.firebase.auth.GoogleAuthProvider
+import dev.gitlive.firebase.auth.OAuthProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -31,6 +33,18 @@ interface AuthRepository {
 
     suspend fun signIn(email: String, password: String)
     suspend fun register(email: String, password: String)
+
+    /**
+     * Signs in with tokens a platform sign-in flow already obtained.
+     *
+     * Firebase links by verified email, so signing in with Google using
+     * the address of an existing password account attaches the provider
+     * to that same account rather than creating a second one — which is
+     * what keeps a bartender's memberships from vanishing because they
+     * tapped a different button this time.
+     */
+    suspend fun signInWithSocial(credential: SocialCredential)
+
     suspend fun signOut()
 
     /**
@@ -74,6 +88,26 @@ class FirebaseAuthRepository(private val auth: FirebaseAuth) : AuthRepository {
 
     override suspend fun register(email: String, password: String) {
         auth.createUserWithEmailAndPassword(email, password)
+    }
+
+    override suspend fun signInWithSocial(credential: SocialCredential) {
+        val authCredential = when (credential.provider) {
+            SocialProvider.Google -> GoogleAuthProvider.credential(
+                idToken = credential.idToken,
+                accessToken = credential.accessToken,
+            )
+
+            // rawNonce, not the hash that went to Apple: Firebase hashes
+            // this itself and compares, and passing the already-hashed
+            // value fails as a generic invalid-credential error.
+            SocialProvider.Apple -> OAuthProvider.credential(
+                providerId = credential.provider.wire,
+                accessToken = credential.accessToken,
+                idToken = credential.idToken,
+                rawNonce = credential.rawNonce,
+            )
+        }
+        auth.signInWithCredential(authCredential)
     }
 
     override suspend fun signOut() {

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
@@ -38,6 +38,9 @@ data class BarBackerFirebaseConfig(
      * the feed simply has none.
      */
     val icalFeedBaseUrl: String? = null,
+
+    /** Google OAuth client ids, absent when this build has none. */
+    val googleOAuth: GoogleOAuthConfig? = null,
 ) {
     internal fun toFirebaseOptions() = FirebaseOptions(
         applicationId = applicationId,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/BarBackerFirebase.kt
@@ -41,6 +41,13 @@ data class BarBackerFirebaseConfig(
 
     /** Google OAuth client ids, absent when this build has none. */
     val googleOAuth: GoogleOAuthConfig? = null,
+
+    /**
+     * Whether the Apple sign-in Cloud Functions are deployed for this
+     * project. Off means Android and desktop hide the Apple button; iOS
+     * has its own native flow and ignores this entirely.
+     */
+    val appleWebSignIn: Boolean = false,
 ) {
     internal fun toFirebaseOptions() = FirebaseOptions(
         applicationId = applicationId,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
@@ -52,9 +52,37 @@ internal object FirebaseConfigKeys {
     const val GOOGLE_DESKTOP_CLIENT_SECRET = "VITE_GOOGLE_DESKTOP_CLIENT_SECRET"
     const val GOOGLE_IOS_CLIENT_ID = "VITE_GOOGLE_IOS_CLIENT_ID"
 
+    /**
+     * Whether the Apple sign-in Cloud Functions are deployed, OPTIONAL.
+     *
+     * A flag rather than a client id because the client needs nothing
+     * from Apple: `appleAuthBegin` builds the authorize URL server-side,
+     * where the Service ID lives. All this answers is whether there is a
+     * server half to talk to — which `isSupported` has to answer without
+     * a round trip, since it decides whether to draw the button at all.
+     *
+     * It therefore has to be set to match the deployment. Setting it
+     * where the functions are absent yields a button that opens a browser
+     * to nothing; leaving it unset where they are present just hides a
+     * feature.
+     */
+    const val APPLE_SIGN_IN = "VITE_APPLE_SIGN_IN"
+
     val ALL = listOf(
         API_KEY, AUTH_DOMAIN, PROJECT_ID, STORAGE_BUCKET, MESSAGING_SENDER_ID, APP_ID,
     )
+
+    /**
+     * Reads a boolean flag out of a string-valued config source.
+     *
+     * All three platforms hand these over as strings — an `Info.plist`
+     * entry, a Gradle `buildConfigField`, a JVM system property — and a
+     * plain `== "true"` would quietly treat the `1` someone typed in a
+     * `.env` as off. Anything unrecognised is off, since a flag nobody
+     * set should not turn a feature on.
+     */
+    internal fun isTruthy(value: String?): Boolean =
+        value?.trim()?.lowercase() in setOf("1", "true", "yes", "on")
 
     /** Builds a config from a lookup, or null if any REQUIRED value is missing. */
     fun build(lookup: (String) -> String?): BarBackerFirebaseConfig? {
@@ -63,6 +91,7 @@ internal object FirebaseConfigKeys {
         val serverClientId = lookup(GOOGLE_SERVER_CLIENT_ID)?.takeIf(String::isNotBlank)
         return BarBackerFirebaseConfig(
             icalFeedBaseUrl = lookup(ICAL_FEED_BASE_URL)?.takeIf(String::isNotBlank),
+            appleWebSignIn = isTruthy(lookup(APPLE_SIGN_IN)),
             googleOAuth = serverClientId?.let {
                 GoogleOAuthConfig(
                     serverClientId = it,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigLoader.kt
@@ -33,6 +33,25 @@ internal object FirebaseConfigKeys {
      */
     const val ICAL_FEED_BASE_URL = "VITE_ICAL_FEED_BASE_URL"
 
+    /**
+     * Google OAuth client ids, all OPTIONAL.
+     *
+     * Absent means Google sign-in reports itself unsupported rather than
+     * failing at the point someone taps it. `SERVER_CLIENT_ID` is the
+     * project's **web** client id — Android's Credential Manager wants
+     * that one, because it is the audience Firebase expects in the ID
+     * token, and the Android client id yields a token Firebase rejects.
+     *
+     * The desktop "secret" is not confidential: an installed-app client
+     * ships it inside the binary, and PKCE is what actually protects that
+     * flow. It is here because Google's token endpoint asks for it, not
+     * because it protects anything.
+     */
+    const val GOOGLE_SERVER_CLIENT_ID = "VITE_GOOGLE_SERVER_CLIENT_ID"
+    const val GOOGLE_DESKTOP_CLIENT_ID = "VITE_GOOGLE_DESKTOP_CLIENT_ID"
+    const val GOOGLE_DESKTOP_CLIENT_SECRET = "VITE_GOOGLE_DESKTOP_CLIENT_SECRET"
+    const val GOOGLE_IOS_CLIENT_ID = "VITE_GOOGLE_IOS_CLIENT_ID"
+
     val ALL = listOf(
         API_KEY, AUTH_DOMAIN, PROJECT_ID, STORAGE_BUCKET, MESSAGING_SENDER_ID, APP_ID,
     )
@@ -41,8 +60,18 @@ internal object FirebaseConfigKeys {
     fun build(lookup: (String) -> String?): BarBackerFirebaseConfig? {
         val values = ALL.associateWith { lookup(it)?.takeIf(String::isNotBlank) }
         if (values.values.any { it == null }) return null
+        val serverClientId = lookup(GOOGLE_SERVER_CLIENT_ID)?.takeIf(String::isNotBlank)
         return BarBackerFirebaseConfig(
             icalFeedBaseUrl = lookup(ICAL_FEED_BASE_URL)?.takeIf(String::isNotBlank),
+            googleOAuth = serverClientId?.let {
+                GoogleOAuthConfig(
+                    serverClientId = it,
+                    desktopClientId = lookup(GOOGLE_DESKTOP_CLIENT_ID)?.takeIf(String::isNotBlank),
+                    desktopClientSecret =
+                        lookup(GOOGLE_DESKTOP_CLIENT_SECRET)?.takeIf(String::isNotBlank),
+                    iosClientId = lookup(GOOGLE_IOS_CLIENT_ID)?.takeIf(String::isNotBlank),
+                )
+            },
             apiKey = values.getValue(API_KEY)!!,
             authDomain = values.getValue(AUTH_DOMAIN)!!,
             projectId = values.getValue(PROJECT_ID)!!,

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/MembershipRepository.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/MembershipRepository.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.barbacker.data
 
 import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.secureRandomHex
 import com.hereliesaz.barbacker.model.BarRole
 import com.hereliesaz.barbacker.model.BarUser
 import com.hereliesaz.barbacker.model.MemberStatus
@@ -44,6 +45,17 @@ interface MembershipRepository {
     fun rosterFlow(barId: String?): Flow<List<BarUser>>
 
     fun accountFlow(uid: String?): Flow<AccountProfile>
+
+    /**
+     * Mints and stores an ntfy topic for this account if it has none.
+     *
+     * One topic per ACCOUNT, not per bar or per device: it is what the
+     * server-side fanout publishes to, and an iOS user subscribes to it
+     * once in the ntfy app. Existing accounts keep whatever topic they
+     * already have — regenerating would silently orphan a subscription
+     * someone set up months ago and stop their pages arriving.
+     */
+    suspend fun ensureNtfyTopic(uid: String): String
 
     /**
      * Writes the membership document that admits [uid] to the bar.
@@ -196,6 +208,21 @@ class FirebaseMembershipRepository(
         emit(AccountProfile())
     }
 
+    override suspend fun ensureNtfyTopic(uid: String): String {
+        val reference = firestore.document(Paths.user(uid))
+        val existing = reference.get().field<String>(Fields.NTFY_TOPIC)
+        if (!existing.isNullOrBlank()) return existing
+
+        // 16 bytes of CSPRNG output. The topic is a bearer secret —
+        // whoever knows it can subscribe to this account's pages — so it
+        // has to be unguessable rather than merely unique.
+        val topic = "$NTFY_TOPIC_PREFIX${secureRandomHex(NTFY_TOPIC_BYTES)}"
+        // Merge-set rather than update: the account document may not
+        // exist yet for someone who has never joined a bar.
+        reference.set(mapOf(Fields.NTFY_TOPIC to topic), merge = true)
+        return topic
+    }
+
     override suspend fun join(
         barId: String,
         uid: String,
@@ -330,5 +357,10 @@ class FirebaseMembershipRepository(
             merge = true,
         )
         return true
+    }
+
+    private companion object {
+        const val NTFY_TOPIC_PREFIX = "barbacker-"
+        const val NTFY_TOPIC_BYTES = 16
     }
 }

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.kt
@@ -1,0 +1,118 @@
+package com.hereliesaz.barbacker.data
+
+import io.ktor.client.HttpClient
+
+/** The identity providers this client can sign in with, besides email. */
+enum class SocialProvider(
+    /** Firebase's provider id, and the label shown on the button. */
+    val wire: String,
+    val label: String,
+) {
+    Google("google.com", "Google"),
+    Apple("apple.com", "Apple"),
+}
+
+/**
+ * What a platform sign-in flow produced, ready to hand to Firebase.
+ *
+ * Deliberately just tokens. Every platform gets these a different way —
+ * Credential Manager, a browser round trip, a native Apple sheet — and the
+ * only thing the shared layer needs is the result.
+ */
+class SocialCredential(
+    val provider: SocialProvider,
+    val idToken: String,
+    val accessToken: String? = null,
+    /**
+     * Apple only: the UN-hashed nonce whose SHA-256 was sent in the
+     * request.
+     *
+     * Firebase re-hashes this and compares, which is what stops a stolen
+     * identity token being replayed. Sending the hash here instead — an
+     * easy mistake, since the hash is what went to Apple — fails with a
+     * generic invalid-credential error that says nothing about why.
+     */
+    val rawNonce: String? = null,
+)
+
+/**
+ * The user backed out of the platform's sign-in sheet.
+ *
+ * Distinct from a failure because it is not one, and the UI must not show
+ * an error for it — someone changing their mind is the flow working.
+ */
+class SocialSignInCancelledException : Exception("Sign-in cancelled")
+
+/** No credential could be obtained, with a reason worth showing. */
+class SocialSignInException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
+
+interface SocialSignIn {
+    /**
+     * Whether [provider] can actually be used on this platform and build.
+     *
+     * False is an ordinary answer, not a defect: Apple's flow needs a
+     * confidential client secret away from Android and iOS, and Google's
+     * needs an OAuth client id this build may not have been given. The
+     * sign-in screen hides a button rather than offering one that fails.
+     */
+    fun isSupported(provider: SocialProvider): Boolean
+
+    /**
+     * @throws SocialSignInCancelledException if the user backed out.
+     * @throws SocialSignInException on anything else.
+     */
+    suspend fun authenticate(provider: SocialProvider): SocialCredential
+}
+
+/**
+ * OAuth client ids for Google sign-in.
+ *
+ * Absent for a build that was never given them, in which case Google
+ * sign-in reports itself unsupported. These are client ids, not secrets —
+ * a desktop OAuth client's "secret" is explicitly not confidential, since
+ * it ships inside the binary; PKCE is what actually protects that flow.
+ */
+data class GoogleOAuthConfig(
+    /**
+     * The **web** client id from the Firebase project.
+     *
+     * Android's Credential Manager wants this one — not the Android client
+     * id — because it is the audience Firebase expects in the ID token.
+     * Passing the Android client id yields a token Firebase rejects.
+     */
+    val serverClientId: String,
+
+    /** Desktop's own "Desktop app" OAuth client, if this build has one. */
+    val desktopClientId: String? = null,
+    val desktopClientSecret: String? = null,
+
+    /** iOS's own OAuth client, if this build has one. */
+    val iosClientId: String? = null,
+)
+
+/**
+ * @param httpClient and [urls] are passed in rather than built here so the
+ *   browser-based flows reuse the engine, timeouts, and user agent the
+ *   rest of the app already uses. Android ignores both — Credential
+ *   Manager does its own transport.
+ */
+expect fun createSocialSignIn(
+    platformContext: Any?,
+    config: GoogleOAuthConfig?,
+    httpClient: HttpClient,
+    urls: UrlOpener,
+): SocialSignIn
+
+/**
+ * A [SocialSignIn] that can do nothing, for a build with no OAuth config.
+ *
+ * Shared by every platform's fallback path so the "not configured" answer
+ * is identical everywhere rather than three near-copies.
+ */
+internal object UnsupportedSocialSignIn : SocialSignIn {
+    override fun isSupported(provider: SocialProvider): Boolean = false
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential =
+        throw SocialSignInException("${provider.label} sign-in is not configured in this build.")
+}

--- a/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.kt
+++ b/cmp/shared/src/commonMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.kt
@@ -51,10 +51,11 @@ interface SocialSignIn {
     /**
      * Whether [provider] can actually be used on this platform and build.
      *
-     * False is an ordinary answer, not a defect: Apple's flow needs a
-     * confidential client secret away from Android and iOS, and Google's
-     * needs an OAuth client id this build may not have been given. The
-     * sign-in screen hides a button rather than offering one that fails.
+     * False is an ordinary answer, not a defect: Google's flow needs an
+     * OAuth client id this build may not have been given, and Apple's,
+     * away from iOS, needs Cloud Functions this project may not have
+     * deployed. The sign-in screen hides a button rather than offering
+     * one that fails.
      */
     fun isSupported(provider: SocialProvider): Boolean
 

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/Base64UrlTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/Base64UrlTest.kt
@@ -1,0 +1,73 @@
+package com.hereliesaz.barbacker
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Vectors from RFC 4648 §10, with `+`/`/` mapped to `-`/`_` and the
+ * padding stripped, since that is exactly the difference between standard
+ * base64 and the base64url PKCE wants.
+ */
+class Base64UrlTest {
+
+    private fun encode(text: String) = text.encodeToByteArray().base64UrlEncode()
+
+    @Test
+    fun empty_input_encodes_to_nothing() {
+        assertEquals("", encode(""))
+    }
+
+    /** Length ≡ 0 (mod 3): the whole-chunk path, no tail. */
+    @Test
+    fun exact_multiples_of_three_bytes() {
+        assertEquals("Zm9v", encode("foo"))
+        assertEquals("Zm9vYmFy", encode("foobar"))
+    }
+
+    /** Length ≡ 1 (mod 3): the two-character tail, where padding would go. */
+    @Test
+    fun one_leftover_byte_yields_two_characters() {
+        assertEquals("Zg", encode("f"))
+        assertEquals("Zm9vYg", encode("foob"))
+    }
+
+    /** Length ≡ 2 (mod 3): the three-character tail. */
+    @Test
+    fun two_leftover_bytes_yield_three_characters() {
+        assertEquals("Zm8", encode("fo"))
+        assertEquals("Zm9vYmE", encode("fooba"))
+    }
+
+    @Test
+    fun never_emits_padding() {
+        for (length in 0..24) {
+            val encoded = ByteArray(length) { it.toByte() }.base64UrlEncode()
+            assertTrue('=' !in encoded, "padding leaked at length $length: $encoded")
+        }
+    }
+
+    /**
+     * The whole reason this is not Foundation's base64: `+` and `/` are
+     * valid there and would be re-interpreted by Google's token endpoint,
+     * which takes the challenge straight out of a URL.
+     */
+    @Test
+    fun uses_the_url_safe_alphabet() {
+        // 0xFB 0xFF encodes to "+/8=" in standard base64.
+        val encoded = byteArrayOf(0xFB.toByte(), 0xFF.toByte()).base64UrlEncode()
+        assertEquals("-_8", encoded)
+    }
+
+    @Test
+    fun output_length_is_the_unpadded_formula() {
+        for (length in 0..24) {
+            val expected = (length * 8 + 5) / 6
+            assertEquals(
+                expected,
+                ByteArray(length).base64UrlEncode().length,
+                "wrong length for $length input bytes",
+            )
+        }
+    }
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/CombinedSocialSignInTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/CombinedSocialSignInTest.kt
@@ -1,0 +1,87 @@
+package com.hereliesaz.barbacker.data
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The decorator that lets Apple's browser flow reach Android and desktop
+ * without any `actual` knowing it exists.
+ *
+ * Which half runs is the whole behaviour, and getting it backwards would
+ * send iOS — the one platform with a native Apple sheet — out to a
+ * browser round trip instead.
+ */
+class CombinedSocialSignInTest {
+
+    private class Fake(
+        private val supported: Set<SocialProvider>,
+        private val name: String,
+    ) : SocialSignIn {
+        override fun isSupported(provider: SocialProvider) = provider in supported
+
+        override suspend fun authenticate(provider: SocialProvider) =
+            SocialCredential(provider = provider, idToken = name)
+    }
+
+    private val googleOnly = Fake(setOf(SocialProvider.Google), "platform")
+    private val appleOnly = Fake(setOf(SocialProvider.Apple), "fallback")
+
+    @Test
+    fun supports_the_union_of_both_halves() {
+        val combined = CombinedSocialSignIn(googleOnly, appleOnly)
+        assertTrue(combined.isSupported(SocialProvider.Google))
+        assertTrue(combined.isSupported(SocialProvider.Apple))
+    }
+
+    @Test
+    fun supports_nothing_neither_half_does() {
+        val combined = CombinedSocialSignIn(
+            Fake(emptySet(), "platform"),
+            Fake(emptySet(), "fallback"),
+        )
+        assertFalse(combined.isSupported(SocialProvider.Google))
+        assertFalse(combined.isSupported(SocialProvider.Apple))
+    }
+
+    @Test
+    fun routes_a_provider_to_the_half_that_supports_it() = runTest {
+        val combined = CombinedSocialSignIn(googleOnly, appleOnly)
+        assertEquals("platform", combined.authenticate(SocialProvider.Google).idToken)
+        assertEquals("fallback", combined.authenticate(SocialProvider.Apple).idToken)
+    }
+
+    /**
+     * iOS is the case this protects. Its native sheet supports Apple, and
+     * the fallback must not get a look in — a browser round trip on a
+     * platform with `ASAuthorizationController` would be a worse flow and
+     * would need server configuration iOS does not otherwise require.
+     */
+    @Test
+    fun the_platform_half_wins_wherever_both_support_a_provider() = runTest {
+        val combined = CombinedSocialSignIn(
+            Fake(setOf(SocialProvider.Google, SocialProvider.Apple), "platform"),
+            appleOnly,
+        )
+        assertEquals("platform", combined.authenticate(SocialProvider.Apple).idToken)
+    }
+
+    /**
+     * With neither half supporting it, the call still has to fail
+     * somewhere. It falls through, so the message comes from the
+     * fallback — an error, not a silently absent credential.
+     */
+    @Test
+    fun an_unsupported_provider_still_fails_rather_than_returning_nothing() = runTest {
+        val combined = CombinedSocialSignIn(
+            Fake(emptySet(), "platform"),
+            UnsupportedSocialSignIn,
+        )
+        assertFailsWith<SocialSignInException> {
+            combined.authenticate(SocialProvider.Apple)
+        }
+    }
+}

--- a/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigKeysTest.kt
+++ b/cmp/shared/src/commonTest/kotlin/com/hereliesaz/barbacker/data/FirebaseConfigKeysTest.kt
@@ -1,0 +1,96 @@
+package com.hereliesaz.barbacker.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FirebaseConfigKeysTest {
+
+    private val required = FirebaseConfigKeys.ALL.associateWith { "value-for-$it" }
+
+    private fun build(extra: Map<String, String> = emptyMap()) =
+        FirebaseConfigKeys.build { key -> (required + extra)[key] }
+
+    @Test
+    fun a_complete_lookup_produces_a_config() {
+        assertNotNull(build())
+    }
+
+    /**
+     * A missing required value is a null config, not a partial one — the
+     * app shows a "not configured" screen instead of failing somewhere
+     * inside the Firebase SDK with the first call that needs the value.
+     */
+    @Test
+    fun a_missing_required_value_produces_nothing() {
+        val incomplete = required - FirebaseConfigKeys.API_KEY
+        assertNull(FirebaseConfigKeys.build { key -> incomplete[key] })
+    }
+
+    // A resource lookup that finds an empty string is a value that was
+    // never filled in, and treating it as present would send an empty
+    // API key to Firebase.
+    @Test
+    fun a_blank_required_value_counts_as_missing() {
+        assertNull(build(mapOf(FirebaseConfigKeys.API_KEY to "   ")))
+    }
+
+    @Test
+    fun optional_values_are_absent_rather_than_fatal() {
+        val config = assertNotNull(build())
+        assertNull(config.icalFeedBaseUrl)
+        assertNull(config.googleOAuth)
+        assertFalse(config.appleWebSignIn)
+    }
+
+    /**
+     * The Google block hangs off the server client id: without it there
+     * is no Credential Manager audience, so the rest is unusable even
+     * when a desktop client id is present.
+     */
+    @Test
+    fun google_config_appears_only_with_a_server_client_id() {
+        assertNull(build(mapOf(FirebaseConfigKeys.GOOGLE_DESKTOP_CLIENT_ID to "d")).let { it?.googleOAuth })
+
+        val config = assertNotNull(
+            build(
+                mapOf(
+                    FirebaseConfigKeys.GOOGLE_SERVER_CLIENT_ID to "web-id",
+                    FirebaseConfigKeys.GOOGLE_DESKTOP_CLIENT_ID to "desktop-id",
+                ),
+            ),
+        )
+        assertEquals("web-id", config.googleOAuth?.serverClientId)
+        assertEquals("desktop-id", config.googleOAuth?.desktopClientId)
+        assertNull(config.googleOAuth?.iosClientId)
+    }
+
+    @Test
+    fun the_apple_flag_reads_the_spellings_a_dotenv_actually_contains() {
+        for (value in listOf("true", "TRUE", " true ", "1", "yes", "on")) {
+            assertTrue(
+                assertNotNull(build(mapOf(FirebaseConfigKeys.APPLE_SIGN_IN to value))).appleWebSignIn,
+                "expected $value to enable Apple sign-in",
+            )
+        }
+    }
+
+    /**
+     * Anything unrecognised is off. A flag nobody deliberately set must
+     * not draw a button whose server half may not be deployed — and
+     * "false" landing in a `== "true"`-style check that someone later
+     * inverts is exactly how that goes wrong.
+     */
+    @Test
+    fun the_apple_flag_is_off_for_anything_else() {
+        for (value in listOf("false", "0", "no", "off", "", "  ", "maybe")) {
+            assertFalse(
+                assertNotNull(build(mapOf(FirebaseConfigKeys.APPLE_SIGN_IN to value))).appleWebSignIn,
+                "expected $value to leave Apple sign-in off",
+            )
+        }
+    }
+}

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/SecureRandom.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/SecureRandom.desktop.kt
@@ -1,0 +1,8 @@
+package com.hereliesaz.barbacker
+
+import java.security.SecureRandom
+
+private val random = SecureRandom()
+
+actual fun secureRandomHex(byteCount: Int): String =
+    ByteArray(byteCount).also(random::nextBytes).toHexString()

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/Sha256.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/Sha256.desktop.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.barbacker
+
+import java.security.MessageDigest
+
+actual fun sha256(value: String): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(value.encodeToByteArray())

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.desktop.kt
@@ -1,6 +1,8 @@
 package com.hereliesaz.barbacker.data
 
+import com.hereliesaz.barbacker.base64UrlEncode
 import com.hereliesaz.barbacker.logWarning
+import com.hereliesaz.barbacker.sha256
 import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +18,6 @@ import io.ktor.http.Parameters
 import java.net.InetSocketAddress
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
 
@@ -45,9 +46,11 @@ private const val CONSENT_TIMEOUT_MILLIS = 5L * 60 * 1000
  * constant. Google allows any port on a loopback redirect precisely so
  * installed apps do not have to squat on one.
  *
- * Apple is not offered. Its flow requires a client secret that is a JWT
- * signed with a private key — a real confidential credential, which a
- * program shipped to users has nowhere safe to keep.
+ * Apple is absent from this class rather than unavailable on desktop.
+ * Its flow runs through the browser and is identical on every platform
+ * without a native sheet, so it lives in common code — see
+ * [AppleWebSignIn], which [CombinedSocialSignIn] layers on top of this
+ * one when the server half is deployed. Nothing here needs to know.
  */
 private class DesktopSocialSignIn(
     private val config: GoogleOAuthConfig,
@@ -65,8 +68,11 @@ private class DesktopSocialSignIn(
         provider == SocialProvider.Google && config.desktopClientId != null
 
     override suspend fun authenticate(provider: SocialProvider): SocialCredential {
+        // Only reachable if something called this for a provider
+        // isSupported already said no to; Apple is handled by the
+        // fallback this class is composed with, not here.
         if (provider != SocialProvider.Google) {
-            throw SocialSignInException("Apple sign-in is not available on desktop.")
+            throw SocialSignInException("${provider.label} sign-in is not available here.")
         }
         val clientId = config.desktopClientId
             ?: throw SocialSignInException("Google sign-in is not configured in this build.")
@@ -227,10 +233,7 @@ private fun randomUrlSafe(byteCount: Int): String =
     Base64.getUrlEncoder().withoutPadding()
         .encodeToString(ByteArray(byteCount).also(random::nextBytes))
 
-private fun String.sha256UrlSafe(): String =
-    Base64.getUrlEncoder().withoutPadding().encodeToString(
-        MessageDigest.getInstance("SHA-256").digest(toByteArray(StandardCharsets.US_ASCII)),
-    )
+private fun String.sha256UrlSafe(): String = sha256(this).base64UrlEncode()
 
 /** Splits a raw query string. Values are percent-decoded; keys are not expected to need it. */
 private fun String.parseQuery(): Map<String, String> =

--- a/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.desktop.kt
+++ b/cmp/shared/src/desktopMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.desktop.kt
@@ -1,0 +1,265 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.logWarning
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.submitForm
+import io.ktor.http.Parameters
+import java.net.InetSocketAddress
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+private const val AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+private const val TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+/** How long to wait at the loopback listener before giving the port back. */
+private const val CONSENT_TIMEOUT_MILLIS = 5L * 60 * 1000
+
+/**
+ * Google sign-in over a loopback redirect with PKCE.
+ *
+ * This is the flow Google documents for installed applications, and the
+ * only one available to a desktop app: there is no Credential Manager, and
+ * embedding a web view for OAuth is both against Google's policy and a
+ * phishing surface. So the system browser runs the consent screen and
+ * redirects to a one-shot HTTP listener on 127.0.0.1.
+ *
+ * PKCE is what makes that safe. The redirect lands on the loopback
+ * interface, which any local process could in principle race for — the
+ * code alone is useless without the verifier, which never leaves this
+ * process.
+ *
+ * The port is **not** fixed: it is whatever the OS hands out, which is why
+ * the redirect URI is built after the server is bound rather than being a
+ * constant. Google allows any port on a loopback redirect precisely so
+ * installed apps do not have to squat on one.
+ *
+ * Apple is not offered. Its flow requires a client secret that is a JWT
+ * signed with a private key — a real confidential credential, which a
+ * program shipped to users has nowhere safe to keep.
+ */
+private class DesktopSocialSignIn(
+    private val config: GoogleOAuthConfig,
+    private val httpClient: HttpClient,
+    private val urls: UrlOpener,
+) : SocialSignIn {
+
+    @Serializable
+    private data class TokenResponse(
+        @SerialName("id_token") val idToken: String? = null,
+        @SerialName("access_token") val accessToken: String? = null,
+    )
+
+    override fun isSupported(provider: SocialProvider): Boolean =
+        provider == SocialProvider.Google && config.desktopClientId != null
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential {
+        if (provider != SocialProvider.Google) {
+            throw SocialSignInException("Apple sign-in is not available on desktop.")
+        }
+        val clientId = config.desktopClientId
+            ?: throw SocialSignInException("Google sign-in is not configured in this build.")
+
+        val verifier = randomUrlSafe(CODE_VERIFIER_BYTES)
+        val challenge = verifier.sha256UrlSafe()
+        // Echoed back by Google and compared, so a redirect this app did
+        // not start cannot complete a sign-in it did.
+        val expectedState = randomUrlSafe(STATE_BYTES)
+
+        val server = withContext(Dispatchers.IO) {
+            // Port 0 asks the OS for any free port.
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        }
+        val redirectUri = "http://127.0.0.1:${server.address.port}"
+        val code = CompletableDeferred<Result<String>>()
+
+        server.createContext("/") { exchange ->
+            val query = exchange.requestURI.rawQuery.orEmpty().parseQuery()
+            val body = when {
+                query["state"] != expectedState ->
+                    "Sign-in could not be verified. Close this tab and try again."
+
+                query["error"] != null ->
+                    "Sign-in was declined. Close this tab and try again."
+
+                query["code"] == null -> "Sign-in returned nothing. Close this tab."
+                else -> "Signed in. You can close this tab and go back to BarBacker."
+            }
+            val bytes = body.toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "text/plain; charset=utf-8")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+
+            when {
+                query["state"] != expectedState -> code.complete(
+                    Result.failure(SocialSignInException("Sign-in could not be verified.")),
+                )
+
+                query["error"] == "access_denied" ->
+                    code.complete(Result.failure(SocialSignInCancelledException()))
+
+                query["error"] != null -> code.complete(
+                    Result.failure(SocialSignInException("Google declined the sign-in.")),
+                )
+
+                else -> {
+                    val value = query["code"]
+                    code.complete(
+                        if (value == null) {
+                            Result.failure(SocialSignInException("Google returned no code."))
+                        } else {
+                            Result.success(value)
+                        },
+                    )
+                }
+            }
+        }
+        server.start()
+
+        try {
+            val opened = urls.open(
+                buildAuthUrl(clientId = clientId, redirectUri = redirectUri, challenge = challenge, state = expectedState),
+            )
+            if (!opened) throw SocialSignInException("Could not open a browser for sign-in.")
+
+            // Bounded, so an abandoned tab eventually releases the port
+            // and the coroutine instead of pinning both until the app
+            // exits.
+            val authorizationCode = try {
+                withTimeout(CONSENT_TIMEOUT_MILLIS) { code.await() }
+            } catch (e: TimeoutCancellationException) {
+                throw SocialSignInException("Sign-in timed out.", e)
+            }.getOrElse { throw it }
+
+            return exchangeCode(
+                clientId = clientId,
+                code = authorizationCode,
+                verifier = verifier,
+                redirectUri = redirectUri,
+            )
+        } finally {
+            // Always: the listener holds a port and a thread pool, and
+            // leaking one per abandoned attempt would eventually exhaust
+            // both.
+            runCatching { server.stop(0) }
+                .onFailure { logWarning("Could not stop the sign-in listener", it) }
+        }
+    }
+
+    private fun buildAuthUrl(
+        clientId: String,
+        redirectUri: String,
+        challenge: String,
+        state: String,
+    ): String {
+        val parameters = mapOf(
+            "client_id" to clientId,
+            "redirect_uri" to redirectUri,
+            "response_type" to "code",
+            "scope" to "openid email profile",
+            "code_challenge" to challenge,
+            "code_challenge_method" to "S256",
+            "state" to state,
+            // Without this an already-signed-in browser skips straight
+            // past the picker, so a second account can never be chosen.
+            "prompt" to "select_account",
+        )
+        return parameters.entries.joinToString("&", prefix = "$AUTH_ENDPOINT?") { (key, value) ->
+            "$key=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+        }
+    }
+
+    private suspend fun exchangeCode(
+        clientId: String,
+        code: String,
+        verifier: String,
+        redirectUri: String,
+    ): SocialCredential {
+        val response = try {
+            httpClient.submitForm(
+                url = TOKEN_ENDPOINT,
+                formParameters = Parameters.build {
+                    append("client_id", clientId)
+                    // Present because Google's token endpoint asks for it
+                    // on a desktop client, not because it protects
+                    // anything — it ships in the binary. PKCE is the
+                    // actual protection.
+                    config.desktopClientSecret?.let { append("client_secret", it) }
+                    append("code", code)
+                    append("code_verifier", verifier)
+                    append("grant_type", "authorization_code")
+                    append("redirect_uri", redirectUri)
+                },
+            ).body<TokenResponse>()
+        } catch (e: Exception) {
+            throw SocialSignInException("Could not complete sign-in with Google.", e)
+        }
+
+        val idToken = response.idToken
+            ?: throw SocialSignInException("Google returned no identity token.")
+        return SocialCredential(
+            provider = SocialProvider.Google,
+            idToken = idToken,
+            accessToken = response.accessToken,
+        )
+    }
+
+    private companion object {
+        const val CODE_VERIFIER_BYTES = 64
+        const val STATE_BYTES = 16
+    }
+}
+
+private val random = SecureRandom()
+
+private fun randomUrlSafe(byteCount: Int): String =
+    Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(ByteArray(byteCount).also(random::nextBytes))
+
+private fun String.sha256UrlSafe(): String =
+    Base64.getUrlEncoder().withoutPadding().encodeToString(
+        MessageDigest.getInstance("SHA-256").digest(toByteArray(StandardCharsets.US_ASCII)),
+    )
+
+/** Splits a raw query string. Values are percent-decoded; keys are not expected to need it. */
+private fun String.parseQuery(): Map<String, String> =
+    split('&')
+        .filter { it.isNotEmpty() }
+        .mapNotNull { pair ->
+            val index = pair.indexOf('=')
+            if (index <= 0) {
+                null
+            } else {
+                val key = pair.substring(0, index)
+                val value = java.net.URLDecoder.decode(
+                    pair.substring(index + 1),
+                    StandardCharsets.UTF_8,
+                )
+                key to value
+            }
+        }
+        .toMap()
+
+actual fun createSocialSignIn(
+    platformContext: Any?,
+    config: GoogleOAuthConfig?,
+    httpClient: HttpClient,
+    urls: UrlOpener,
+): SocialSignIn = when {
+    // No desktop OAuth client means no flow to run. Reported as
+    // unsupported so the sign-in screen hides the button rather than
+    // offering one that opens a browser to an error page.
+    config?.desktopClientId == null -> UnsupportedSocialSignIn
+    else -> DesktopSocialSignIn(config, httpClient, urls)
+}

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/SecureRandom.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/SecureRandom.ios.kt
@@ -1,0 +1,24 @@
+package com.hereliesaz.barbacker
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Security.SecRandomCopyBytes
+import platform.Security.kSecRandomDefault
+
+/**
+ * `SecRandomCopyBytes`, the system CSPRNG.
+ *
+ * A non-zero return means the generator failed, which is not something to
+ * paper over with a fallback: silently handing back weak bytes for a value
+ * used as a bearer secret is worse than not producing one at all.
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual fun secureRandomHex(byteCount: Int): String {
+    val bytes = ByteArray(byteCount)
+    val status = bytes.usePinned { pinned ->
+        SecRandomCopyBytes(kSecRandomDefault, byteCount.toULong(), pinned.addressOf(0))
+    }
+    check(status == 0) { "SecRandomCopyBytes failed with status $status" }
+    return bytes.toHexString()
+}

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/Sha256.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/Sha256.ios.kt
@@ -1,0 +1,35 @@
+package com.hereliesaz.barbacker
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+
+/**
+ * CommonCrypto's one-shot digest.
+ *
+ * The empty-string case is pinned separately from the rest: pinning a
+ * zero-length ByteArray and taking `addressOf(0)` is not valid, so the
+ * input is only pinned when there is something to point at.
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual fun sha256(value: String): ByteArray {
+    val input = value.encodeToByteArray()
+    val digest = ByteArray(CC_SHA256_DIGEST_LENGTH)
+    digest.usePinned { out ->
+        if (input.isEmpty()) {
+            CC_SHA256(null, 0u, out.addressOf(0).reinterpret())
+        } else {
+            input.usePinned { source ->
+                CC_SHA256(
+                    source.addressOf(0),
+                    input.size.toUInt(),
+                    out.addressOf(0).reinterpret(),
+                )
+            }
+        }
+    }
+    return digest
+}

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/PushTokens.ios.kt
@@ -3,18 +3,45 @@ package com.hereliesaz.barbacker.data
 import com.hereliesaz.barbacker.logWarning
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.messaging.messaging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.UIKit.UIApplication
+import platform.UserNotifications.UNAuthorizationOptionAlert
+import platform.UserNotifications.UNAuthorizationOptionBadge
+import platform.UserNotifications.UNAuthorizationOptionSound
+import platform.UserNotifications.UNUserNotificationCenter
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 /**
- * iOS push depends on an APNs capability and entitlement configured in the
- * Xcode project, plus a Firebase iOS SDK linked through SPM or CocoaPods.
- * Until that project exists (see cmp/iosApp/README.md), `getToken()` will
- * simply fail here and the app falls back to the in-app alert loop.
+ * APNs, then FCM on top of it.
+ *
+ * Registration is driven from here rather than from the Swift app
+ * delegate, and that is the point rather than a convenience. FCM cannot
+ * mint a token until the APNs device token has reached the Firebase
+ * Messaging instance, and Messaging only exists once Firebase has been
+ * configured — which happens in the first composition, not at launch. An
+ * app delegate that registers in `didFinishLaunching` therefore races:
+ * APNs usually answers later, so it usually works, and when it does not
+ * the failure looks like a device that just never receives pages.
+ * Registering from here cannot lose that race, because nothing calls
+ * this until Firebase is up.
+ *
+ * Needs the Push Notifications capability and an `aps-environment`
+ * entitlement on the Xcode target — see `cmp/iosApp/project.yml`.
+ * Without them the registration call fails and this reports no token,
+ * which leaves the in-app alert loop as the only thing paging the user.
  */
 private class IosPushTokenProvider : PushTokenProvider {
     override val isSupported: Boolean = true
 
+    private var registered = false
+
     override suspend fun currentToken(): String? = try {
-        Firebase.messaging.getToken()
+        // A denied prompt is a real answer, not an error: no token means
+        // the app falls back to the in-app alert loop, which is the
+        // honest outcome of someone declining notifications.
+        if (!ensureRegisteredForRemoteNotifications()) null else Firebase.messaging.getToken()
     } catch (e: Exception) {
         logWarning("Could not obtain an APNs/FCM token", e)
         null
@@ -26,6 +53,36 @@ private class IosPushTokenProvider : PushTokenProvider {
         } catch (e: Exception) {
             logWarning("Could not delete the push token", e)
         }
+    }
+
+    /** @return whether this device is permitted to receive notifications. */
+    private suspend fun ensureRegisteredForRemoteNotifications(): Boolean {
+        // The system remembers the answer, so this prompts once and
+        // afterwards returns the stored decision without any UI.
+        val granted = suspendCoroutine { continuation ->
+            UNUserNotificationCenter.currentNotificationCenter()
+                .requestAuthorizationWithOptions(
+                    UNAuthorizationOptionAlert or
+                        UNAuthorizationOptionSound or
+                        UNAuthorizationOptionBadge,
+                ) { granted, error ->
+                    if (error != null) {
+                        logWarning("Notification authorization failed: ${error.localizedDescription}")
+                    }
+                    continuation.resume(granted && error == null)
+                }
+        }
+        if (!granted) return false
+
+        if (!registered) {
+            // UIKit, so main thread. Off it, this is undefined behaviour
+            // rather than a clean failure.
+            withContext(Dispatchers.Main) {
+                UIApplication.sharedApplication.registerForRemoteNotifications()
+            }
+            registered = true
+        }
+        return true
     }
 }
 

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.ios.kt
@@ -1,0 +1,300 @@
+package com.hereliesaz.barbacker.data
+
+import com.hereliesaz.barbacker.base64UrlEncode
+import com.hereliesaz.barbacker.secureRandomHex
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.submitForm
+import io.ktor.http.Parameters
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import platform.AuthenticationServices.ASAuthorization
+import platform.AuthenticationServices.ASAuthorizationAppleIDCredential
+import platform.AuthenticationServices.ASAuthorizationAppleIDProvider
+import platform.AuthenticationServices.ASAuthorizationController
+import platform.AuthenticationServices.ASAuthorizationControllerDelegateProtocol
+import platform.AuthenticationServices.ASAuthorizationScopeEmail
+import platform.AuthenticationServices.ASAuthorizationScopeFullName
+import platform.AuthenticationServices.ASWebAuthenticationSession
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.Foundation.NSError
+import platform.Foundation.NSString
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLComponents
+import platform.Foundation.NSURLQueryItem
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.dataUsingEncoding
+import platform.darwin.NSObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+private const val AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+private const val TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+/**
+ * Google via `ASWebAuthenticationSession`, Apple via the native sheet.
+ *
+ * **Unverified.** There is no Xcode project in this repository (see
+ * `cmp/iosApp/README.md`) and CI has no macOS runner, so this file has
+ * never been compiled. Treat it as a first draft.
+ *
+ * Google needs an iOS OAuth client, whose redirect is the reversed client
+ * id as a custom URL scheme — that scheme must also be listed under
+ * `CFBundleURLTypes` in `Info.plist`, or the browser sheet completes and
+ * nothing comes back. Apple additionally needs the "Sign in with Apple"
+ * capability on the target.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private class IosSocialSignIn(
+    private val config: GoogleOAuthConfig,
+    private val httpClient: HttpClient,
+) : SocialSignIn {
+
+    @Serializable
+    private data class TokenResponse(
+        @SerialName("id_token") val idToken: String? = null,
+        @SerialName("access_token") val accessToken: String? = null,
+    )
+
+    // Held for the lifetime of this object: ASWebAuthenticationSession and
+    // ASAuthorizationController are both retained only weakly by UIKit
+    // while presenting, and a collected one silently never calls back.
+    private var webSession: ASWebAuthenticationSession? = null
+    private var appleDelegate: AppleSignInDelegate? = null
+
+    override fun isSupported(provider: SocialProvider): Boolean = when (provider) {
+        SocialProvider.Google -> config.iosClientId != null
+        // Native on iOS, so it needs no OAuth client of ours at all.
+        SocialProvider.Apple -> true
+    }
+
+    override suspend fun authenticate(provider: SocialProvider): SocialCredential =
+        when (provider) {
+            SocialProvider.Google -> authenticateGoogle()
+            SocialProvider.Apple -> authenticateApple()
+        }
+
+    private suspend fun authenticateGoogle(): SocialCredential {
+        val clientId = config.iosClientId
+            ?: throw SocialSignInException("Google sign-in is not configured in this build.")
+
+        val verifier = secureRandomHex(CODE_VERIFIER_BYTES)
+        val challenge = verifier.sha256Base64Url()
+        val expectedState = secureRandomHex(STATE_BYTES)
+
+        // Google's iOS convention: the redirect scheme is the client id
+        // with its dot-separated parts reversed.
+        val scheme = clientId.split('.').reversed().joinToString(".")
+        val redirectUri = "$scheme:/oauth2redirect"
+
+        val callback = suspendCancellableCoroutine { continuation ->
+            val session = ASWebAuthenticationSession(
+                uRL = NSURL(string = buildAuthUrl(clientId, redirectUri, challenge, expectedState)),
+                callbackURLScheme = scheme,
+            ) { url, error ->
+                when {
+                    // Any error here is a cancel in practice: the only
+                    // other outcome ASWebAuthenticationSession reports is
+                    // "presentation context invalid", which a user cannot
+                    // cause and cannot act on.
+                    error != null -> continuation.resumeWithException(
+                        SocialSignInCancelledException(),
+                    )
+
+                    url == null -> continuation.resumeWithException(
+                        SocialSignInException("Google returned nothing."),
+                    )
+
+                    else -> continuation.resume(url)
+                }
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            webSession = session
+            if (!session.start()) {
+                continuation.resumeWithException(
+                    SocialSignInException("Could not open the sign-in sheet."),
+                )
+            }
+            continuation.invokeOnCancellation { session.cancel() }
+        }
+
+        val query = NSURLComponents(uRL = callback, resolvingAgainstBaseURL = false)
+            .queryItems
+            .orEmpty()
+            .filterIsInstance<NSURLQueryItem>()
+            .associate { it.name to it.value }
+
+        if (query["state"] != expectedState) {
+            throw SocialSignInException("Sign-in could not be verified.")
+        }
+        if (query["error"] != null) throw SocialSignInCancelledException()
+        val code = query["code"] ?: throw SocialSignInException("Google returned no code.")
+
+        val response = try {
+            httpClient.submitForm(
+                url = TOKEN_ENDPOINT,
+                formParameters = Parameters.build {
+                    append("client_id", clientId)
+                    append("code", code)
+                    append("code_verifier", verifier)
+                    append("grant_type", "authorization_code")
+                    append("redirect_uri", redirectUri)
+                },
+            ).body<TokenResponse>()
+        } catch (e: Exception) {
+            throw SocialSignInException("Could not complete sign-in with Google.", e)
+        }
+
+        val idToken = response.idToken
+            ?: throw SocialSignInException("Google returned no identity token.")
+        return SocialCredential(SocialProvider.Google, idToken, response.accessToken)
+    }
+
+    private suspend fun authenticateApple(): SocialCredential {
+        // Apple signs the HASH; Firebase re-hashes the raw value and
+        // compares. Both have to be kept: send the hash, keep the raw.
+        val rawNonce = secureRandomHex(NONCE_BYTES)
+
+        val identityToken = suspendCancellableCoroutine { continuation ->
+            val request = ASAuthorizationAppleIDProvider().createRequest().apply {
+                requestedScopes = listOf(ASAuthorizationScopeEmail, ASAuthorizationScopeFullName)
+                nonce = rawNonce.sha256Hex()
+            }
+            val delegate = AppleSignInDelegate(
+                onToken = { continuation.resume(it) },
+                onError = { continuation.resumeWithException(it) },
+            )
+            appleDelegate = delegate
+
+            ASAuthorizationController(authorizationRequests = listOf(request)).apply {
+                this.delegate = delegate
+                performRequests()
+            }
+        }
+
+        return SocialCredential(
+            provider = SocialProvider.Apple,
+            idToken = identityToken,
+            rawNonce = rawNonce,
+        )
+    }
+
+    private fun buildAuthUrl(
+        clientId: String,
+        redirectUri: String,
+        challenge: String,
+        state: String,
+    ): String {
+        val parameters = listOf(
+            "client_id" to clientId,
+            "redirect_uri" to redirectUri,
+            "response_type" to "code",
+            "scope" to "openid email profile",
+            "code_challenge" to challenge,
+            "code_challenge_method" to "S256",
+            "state" to state,
+        )
+        return parameters.joinToString("&", prefix = "$AUTH_ENDPOINT?") { (key, value) ->
+            "$key=${value.percentEncoded()}"
+        }
+    }
+
+    private companion object {
+        const val CODE_VERIFIER_BYTES = 48
+        const val STATE_BYTES = 16
+        const val NONCE_BYTES = 16
+    }
+}
+
+private class AppleSignInDelegate(
+    private val onToken: (String) -> Unit,
+    private val onError: (Throwable) -> Unit,
+) : NSObject(), ASAuthorizationControllerDelegateProtocol {
+
+    override fun authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization: ASAuthorization,
+    ) {
+        val credential = didCompleteWithAuthorization.credential as? ASAuthorizationAppleIDCredential
+        if (credential == null) {
+            onError(SocialSignInException("Apple returned an unexpected credential."))
+            return
+        }
+        val token = credential.identityToken?.utf8String()
+        if (token == null) {
+            onError(SocialSignInException("Apple returned no identity token."))
+            return
+        }
+        onToken(token)
+    }
+
+    override fun authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError: NSError,
+    ) {
+        // Apple reports a user-initiated cancel as error 1001. Everything
+        // else is worth surfacing.
+        if (didCompleteWithError.code == APPLE_CANCELLED) {
+            onError(SocialSignInCancelledException())
+        } else {
+            onError(SocialSignInException(didCompleteWithError.localizedDescription))
+        }
+    }
+
+    private companion object {
+        const val APPLE_CANCELLED = 1001L
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun platform.Foundation.NSData.utf8String(): String? =
+    platform.Foundation.NSString.create(data = this, encoding = NSUTF8StringEncoding) as String?
+
+@OptIn(ExperimentalForeignApi::class)
+private fun String.sha256(): ByteArray {
+    val data = (this as NSString).dataUsingEncoding(NSUTF8StringEncoding)
+        ?: return ByteArray(0)
+    val digest = ByteArray(CC_SHA256_DIGEST_LENGTH)
+    digest.usePinned { pinned ->
+        CC_SHA256(data.bytes, data.length.toUInt(), pinned.addressOf(0).reinterpret())
+    }
+    return digest
+}
+
+private fun String.sha256Hex(): String =
+    sha256().joinToString("") { byte ->
+        (byte.toInt() and 0xFF).toString(16).padStart(2, '0')
+    }
+
+/** Base64url with no padding, as PKCE requires. */
+private fun String.sha256Base64Url(): String =
+    sha256().base64UrlEncode()
+
+/** Percent-encodes everything outside the unreserved set. */
+private fun String.percentEncoded(): String = buildString {
+    for (byte in encodeToByteArray()) {
+        val value = byte.toInt() and 0xFF
+        val char = value.toChar()
+        if (char.isLetterOrDigit() && value < 0x80 || char in "-._~") {
+            append(char)
+        } else {
+            append('%')
+            append(value.toString(16).uppercase().padStart(2, '0'))
+        }
+    }
+}
+
+actual fun createSocialSignIn(
+    platformContext: Any?,
+    config: GoogleOAuthConfig?,
+    httpClient: HttpClient,
+    urls: UrlOpener,
+): SocialSignIn = when {
+    config == null -> UnsupportedSocialSignIn
+    else -> IosSocialSignIn(config, httpClient)
+}

--- a/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.ios.kt
+++ b/cmp/shared/src/iosMain/kotlin/com/hereliesaz/barbacker/data/SocialSignIn.ios.kt
@@ -2,13 +2,13 @@ package com.hereliesaz.barbacker.data
 
 import com.hereliesaz.barbacker.base64UrlEncode
 import com.hereliesaz.barbacker.secureRandomHex
+import com.hereliesaz.barbacker.sha256
+import com.hereliesaz.barbacker.sha256Hex
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.submitForm
 import io.ktor.http.Parameters
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -20,15 +20,14 @@ import platform.AuthenticationServices.ASAuthorizationControllerDelegateProtocol
 import platform.AuthenticationServices.ASAuthorizationScopeEmail
 import platform.AuthenticationServices.ASAuthorizationScopeFullName
 import platform.AuthenticationServices.ASWebAuthenticationSession
-import platform.CoreCrypto.CC_SHA256
-import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.Foundation.NSData
 import platform.Foundation.NSError
 import platform.Foundation.NSString
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLComponents
 import platform.Foundation.NSURLQueryItem
 import platform.Foundation.NSUTF8StringEncoding
-import platform.Foundation.dataUsingEncoding
+import platform.Foundation.create
 import platform.darwin.NSObject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -163,7 +162,7 @@ private class IosSocialSignIn(
         val identityToken = suspendCancellableCoroutine { continuation ->
             val request = ASAuthorizationAppleIDProvider().createRequest().apply {
                 requestedScopes = listOf(ASAuthorizationScopeEmail, ASAuthorizationScopeFullName)
-                nonce = rawNonce.sha256Hex()
+                nonce = sha256Hex(rawNonce)
             }
             val delegate = AppleSignInDelegate(
                 onToken = { continuation.resume(it) },
@@ -252,28 +251,11 @@ private class AppleSignInDelegate(
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun platform.Foundation.NSData.utf8String(): String? =
-    platform.Foundation.NSString.create(data = this, encoding = NSUTF8StringEncoding) as String?
-
-@OptIn(ExperimentalForeignApi::class)
-private fun String.sha256(): ByteArray {
-    val data = (this as NSString).dataUsingEncoding(NSUTF8StringEncoding)
-        ?: return ByteArray(0)
-    val digest = ByteArray(CC_SHA256_DIGEST_LENGTH)
-    digest.usePinned { pinned ->
-        CC_SHA256(data.bytes, data.length.toUInt(), pinned.addressOf(0).reinterpret())
-    }
-    return digest
-}
-
-private fun String.sha256Hex(): String =
-    sha256().joinToString("") { byte ->
-        (byte.toInt() and 0xFF).toString(16).padStart(2, '0')
-    }
+private fun NSData.utf8String(): String? =
+    NSString.create(data = this, encoding = NSUTF8StringEncoding) as String?
 
 /** Base64url with no padding, as PKCE requires. */
-private fun String.sha256Base64Url(): String =
-    sha256().base64UrlEncode()
+private fun String.sha256Base64Url(): String = sha256(this).base64UrlEncode()
 
 /** Percent-encodes everything outside the unreserved set. */
 private fun String.percentEncoded(): String = buildString {

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -72,17 +72,32 @@ VITE_FIREBASE_MESSAGING_SENDER_ID
 VITE_FIREBASE_APP_ID
 ```
 
-One more is optional:
+These are optional, and each feature reports itself unsupported rather
+than failing when its value is absent:
 
 ```
 VITE_ICAL_FEED_BASE_URL
+VITE_GOOGLE_SERVER_CLIENT_ID
+VITE_GOOGLE_DESKTOP_CLIENT_ID
+VITE_GOOGLE_DESKTOP_CLIENT_SECRET
+VITE_GOOGLE_IOS_CLIENT_ID
 ```
 
-It names where the outbound iCal feed is actually served from — a Cloud
-Function, on a different host from everything else. Deliberately outside
-the required set, so a deployment that never enabled the feed still runs;
-Calendar Settings then says the link cannot be shown rather than
+`VITE_ICAL_FEED_BASE_URL` names where the outbound iCal feed is actually
+served from — a Cloud Function, on a different host from everything else.
+Without it, Calendar Settings says the link cannot be shown rather than
 constructing one that 404s.
+
+The `VITE_GOOGLE_*` values are OAuth client ids for Google sign-in, and
+which one each platform needs is not interchangeable:
+
+| Value | Used by | Notes |
+|---|---|---|
+| `SERVER_CLIENT_ID` | Android | The project's **web** client id, not the Android one — it is the audience Firebase expects in the ID token, and the Android client id yields a token Firebase rejects. |
+| `DESKTOP_CLIENT_ID` / `_SECRET` | Desktop | A "Desktop app" client. The secret is **not** confidential — it ships in the binary, and PKCE is what protects the flow; Google's token endpoint simply asks for it. |
+| `IOS_CLIENT_ID` | iOS | Its reversed form is the redirect scheme, and must also appear under `CFBundleURLTypes` in `Info.plist`. |
+
+With none of them set, the sign-in screen shows email and password only.
 
 Where each platform looks for them:
 
@@ -208,7 +223,7 @@ without the refresh, every role-gated read stays denied for up to an hour.
 
 ## Testing
 
-`./gradlew :shared:desktopTest` runs the shared suite: 116 tests covering
+`./gradlew :shared:desktopTest` runs the shared suite: 123 tests covering
 the ported pure logic — contrast colour, brand matching, the button label
 resolver, sort order, sub-menu synthesis, tap classification, reorder
 arithmetic, picked-image identity, OCR line filtering, event-time
@@ -248,6 +263,11 @@ fails if it is lost:
 - OCR emits stray single glyphs from a label's border. Each one is
   another chance for the brand matcher to find a spurious substring hit,
   so one-character lines never reach it.
+- PKCE's `code_challenge` is base64url with no padding, and the platforms
+  disagree enough that it is hand-rolled. Both tail cases are pinned:
+  getting one wrong yields a challenge that fails only for some digests,
+  which looks like an intermittent sign-in bug rather than an encoder
+  one.
 
 ## Status
 
@@ -287,6 +307,10 @@ Working end to end:
   add-to-menu / 86 / send-alert actions
 - Remote images: the bar's logo in the theme editor, and a scanned
   bottle's photo on the request row it is attached to
+- Google sign-in on Android (Credential Manager) and desktop (a loopback
+  redirect with PKCE), alongside email and password
+- The ntfy deep link: the notification screen mints an account topic on
+  first open and hands it straight to the ntfy app
 
 Not built yet — the PWA remains the complete client:
 
@@ -298,10 +322,12 @@ Not built yet — the PWA remains the complete client:
   `PhotoCapture.ios.kt`, and `BottleRecognizer.ios.kt` are written
   against `UIDocumentPickerViewController`, `UIImagePickerController`,
   and Vision respectively, but with no macOS runner and no Xcode project
-  none has ever been compiled. Treat them as first drafts. The camera one
-  also needs an `NSCameraUsageDescription` in `Info.plist`, or iOS
-  terminates the app the moment the picker opens. Android and desktop are
-  built in CI.
+  none has ever been compiled. `SocialSignIn.ios.kt` joins them —
+  `ASWebAuthenticationSession` for Google, `ASAuthorizationController` for
+  Apple. Treat them all as first drafts. The camera one also needs an
+  `NSCameraUsageDescription` in `Info.plist`, or iOS terminates the app
+  the moment the picker opens, and Apple sign-in needs the "Sign in with
+  Apple" capability on the target. Android and desktop are built in CI.
 - **The bottle scanner needs a camera and OCR, so desktop has neither
   half.** ML Kit is Android-only and Vision is Apple-only; the
   alternatives were bundling a Tesseract native library per desktop
@@ -311,9 +337,12 @@ Not built yet — the PWA remains the complete client:
 - **Desktop push.** There is no FCM transport for a JVM app. The
   provider reports this explicitly rather than registering nothing and
   looking broken; the in-app alert loop is what pages a desktop user.
-- **ntfy deep linking.** The notification-settings screen shows the
-  topic for manual subscription but has no `ntfy://` link.
-- **Google and Apple sign-in.** Email/password only.
+- **Apple sign-in away from iOS.** Apple's web flow needs a client
+  secret that is a JWT signed with a private key — a real confidential
+  credential, which an app shipped to devices has nowhere safe to keep.
+  Doing it properly needs a Cloud Function to run the exchange, and that
+  does not exist. The button is hidden on Android and desktop rather than
+  offered and broken.
 
 Deliberately absent, because the PWA has no such feature either:
 inventory *removal*. Wells, brands, and types are added from the grid's

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -81,6 +81,7 @@ VITE_GOOGLE_SERVER_CLIENT_ID
 VITE_GOOGLE_DESKTOP_CLIENT_ID
 VITE_GOOGLE_DESKTOP_CLIENT_SECRET
 VITE_GOOGLE_IOS_CLIENT_ID
+VITE_APPLE_SIGN_IN
 ```
 
 `VITE_ICAL_FEED_BASE_URL` names where the outbound iCal feed is actually
@@ -98,6 +99,18 @@ which one each platform needs is not interchangeable:
 | `IOS_CLIENT_ID` | iOS | Its reversed form is the redirect scheme, and must also appear under `CFBundleURLTypes` in `Info.plist`. |
 
 With none of them set, the sign-in screen shows email and password only.
+
+`VITE_APPLE_SIGN_IN` is a flag, not a credential — `true`, `1`, `yes`, or
+`on`; anything else, including absent, is off. It says whether the Apple
+sign-in Cloud Functions (`appleAuthBegin`, `appleAuthCallback`,
+`appleAuthClaim`) are deployed for this project, which is the one thing
+the client cannot work out for itself and has to answer before drawing a
+button. It therefore has to be set to match the deployment: on where the
+functions are absent gives a button that opens a browser to nothing; off
+where they are present just hides a feature. iOS ignores it — its Apple
+sign-in is the native sheet and needs no server at all. The server side
+takes `APPLE_SERVICE_ID` and `APPLE_OAUTH_CALLBACK_BASE_URL`; see
+[DEPLOYMENT.md](DEPLOYMENT.md).
 
 Where each platform looks for them:
 
@@ -268,6 +281,15 @@ fails if it is lost:
   getting one wrong yields a challenge that fails only for some digests,
   which looks like an intermittent sign-in bug rather than an encoder
   one.
+- Apple's web flow is usually described as needing a client secret that
+  is a JWT signed with a .p8 private key. That is true of the *token
+  exchange*, and the exchange is skipped: asking for
+  `response_type=code id_token` returns the identity token in the
+  callback itself, and the identity token is the only thing Firebase
+  wants. What the flow does still need is a public HTTPS redirect, since
+  Apple will not redirect to a custom scheme or to loopback — which is
+  why it goes through Cloud Functions rather than finishing on the
+  device the way Google's does.
 
 ## Status
 
@@ -309,6 +331,9 @@ Working end to end:
   bottle's photo on the request row it is attached to
 - Google sign-in on Android (Credential Manager) and desktop (a loopback
   redirect with PKCE), alongside email and password
+- Apple sign-in: the native sheet on iOS, and on Android and desktop a
+  browser round trip through three Cloud Functions, shown only where
+  those are deployed
 - The ntfy deep link: the notification screen mints an account topic on
   first open and hands it straight to the ntfy app
 
@@ -337,13 +362,6 @@ Not built yet — the PWA remains the complete client:
 - **Desktop push.** There is no FCM transport for a JVM app. The
   provider reports this explicitly rather than registering nothing and
   looking broken; the in-app alert loop is what pages a desktop user.
-- **Apple sign-in away from iOS.** Apple's web flow needs a client
-  secret that is a JWT signed with a private key — a real confidential
-  credential, which an app shipped to devices has nowhere safe to keep.
-  Doing it properly needs a Cloud Function to run the exchange, and that
-  does not exist. The button is hidden on Android and desktop rather than
-  offered and broken.
-
 Deliberately absent, because the PWA has no such feature either:
 inventory *removal*. Wells, brands, and types are added from the grid's
 "+ ADD …" tiles in both clients, and a brand is taken off the floor by

--- a/docs/CMP.md
+++ b/docs/CMP.md
@@ -22,7 +22,7 @@ scratch, so nothing durable can live there.
 |---|---|---|
 | Android | Builds in CI | `minSdk` 24, `compileSdk` 36 |
 | Desktop (JVM) | Builds in CI | Windows, macOS, Linux via Compose Desktop |
-| iOS | Configured, not built in CI | Needs a macOS runner with Xcode |
+| iOS | Configured, not built in CI | Project generated from `iosApp/project.yml`; needs a macOS runner with Xcode |
 | Web | Not a target | Served by the existing PWA |
 
 Web is deliberately absent. Compose Multiplatform's web target is
@@ -44,7 +44,7 @@ cmp/
   gradle/libs.versions.toml   Version catalog
   shared/                     Domain model, pure logic, Firebase data layer
   composeApp/                 Compose UI plus the per-platform entry points
-  iosApp/                     Swift shim for hosting the Compose view
+  iosApp/                     Swift shim, plus the XcodeGen project spec
 ```
 
 `shared` carries no Compose dependency, so the domain model and the
@@ -151,7 +151,9 @@ Running desktop against a real project:
   # ...and the rest
 ```
 
-iOS needs macOS with Xcode; see `cmp/iosApp/README.md`.
+iOS needs macOS with Xcode, plus XcodeGen to turn `cmp/iosApp/project.yml`
+into the project — the `.xcodeproj` is a generated build output and is
+not committed. See `cmp/iosApp/README.md`.
 
 An `ANDROID_HOME` pointing at an SDK with platform 36 is required for the
 Android target. Create `cmp/local.properties` with `sdk.dir=<path>` if the
@@ -312,8 +314,12 @@ Working end to end:
   the 86'd list, and ownership claims
 - Premium bar theming, with the tile label derived from the accent colour
   it sits on
-- Push registration on Android and iOS, plus the in-app alert loop that
-  sounds and vibrates every minute while un-muted pages are waiting
+- Push registration on Android and iOS — iOS asks for notification
+  permission and registers with APNs from the shared code rather than
+  from an app delegate, since FCM cannot mint a token before Firebase is
+  configured and Firebase is configured in the first composition — plus
+  the in-app alert loop that sounds and vibrates every minute while
+  un-muted pages are waiting
 - Bar management for Manager+: hiding grid buttons, restoring hidden ones
   on premium, and inviting staff or managers by email
 - The theme editor: brand colours, font, and a logo uploaded to Storage
@@ -339,20 +345,20 @@ Working end to end:
 
 Not built yet — the PWA remains the complete client:
 
-- **iOS push delivery.** The token code is shared with Android, but iOS
-  needs an APNs capability and entitlement configured in an Xcode
-  project that does not exist yet (see `cmp/iosApp/README.md`). Until
-  then iOS falls back to the in-app alert loop.
-- **The iOS UIKit interop is unverified.** `ImagePicker.ios.kt`,
-  `PhotoCapture.ios.kt`, and `BottleRecognizer.ios.kt` are written
-  against `UIDocumentPickerViewController`, `UIImagePickerController`,
-  and Vision respectively, but with no macOS runner and no Xcode project
-  none has ever been compiled. `SocialSignIn.ios.kt` joins them —
-  `ASWebAuthenticationSession` for Google, `ASAuthorizationController` for
-  Apple. Treat them all as first drafts. The camera one also needs an
-  `NSCameraUsageDescription` in `Info.plist`, or iOS terminates the app
-  the moment the picker opens, and Apple sign-in needs the "Sign in with
-  Apple" capability on the target. Android and desktop are built in CI.
+- **Everything iOS is unverified.** There is no macOS runner and no Mac
+  in the loop, so nothing here — not the project spec, not the Swift,
+  not the Kotlin — has ever been compiled. `ImagePicker.ios.kt`,
+  `PhotoCapture.ios.kt`, `BottleRecognizer.ios.kt`, and
+  `SocialSignIn.ios.kt` are drafts against
+  `UIDocumentPickerViewController`, `UIImagePickerController`, Vision,
+  and AuthenticationServices; `cmp/iosApp/project.yml` is a draft of the
+  Xcode project. The pieces that would otherwise be invisible failures
+  are all declared there — the APNs entitlement and background mode,
+  Sign in with Apple, `NSCameraUsageDescription` (without which iOS
+  terminates the app the moment the picker opens rather than denying
+  anything), the Gradle framework phase, and the script-sandboxing
+  setting that phase needs — but declaring them is not the same as
+  having watched them work. Android and desktop are built in CI.
 - **The bottle scanner needs a camera and OCR, so desktop has neither
   half.** ML Kit is Android-only and Vision is Apple-only; the
   alternatives were bundling a Tesseract native library per desktop

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -89,6 +89,18 @@ of them is read via `process.env.*` with no fallback.
 | `POS_OAUTH_CALLBACK_BASE_URL` | `functions/src/pos/oauth.ts` | Public base URL the `oauthCallback` function is reachable at — Square redirects here after consent. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | `functions/src/calendar/google.ts`, `functions/src/calendar/oauth.ts` | Google Cloud OAuth 2.0 client credentials, scoped to the Calendar API. |
 | `CALENDAR_OAUTH_CALLBACK_BASE_URL` | `functions/src/calendar/oauth.ts`, `functions/src/calendar/calendars.ts`, `functions/src/calendar/resubscribe.ts` | Public base URL the `calendarOauthCallback` and `calendarWebhook` functions are reachable at — used both as the OAuth redirect target and as the base for Google's push-notification webhook. |
+| `APPLE_SERVICE_ID` | `functions/src/appleAuth.ts` | The **Services ID** from Apple's developer portal (not a bundle identifier), used as the `client_id` of Apple's web sign-in. Only the Compose Multiplatform client's Android and desktop targets need this; iOS uses the native sheet and the PWA uses Firebase's own handler. |
+| `APPLE_OAUTH_CALLBACK_BASE_URL` | `functions/src/appleAuth.ts` | Public base URL the `appleAuthCallback` function is reachable at. Apple form-posts the result here, so `<base>/appleAuthCallback` must also be registered as a Return URL on the Services ID — and must be HTTPS, since Apple refuses custom schemes and loopback alike. |
+
+Apple sign-in needs no private key here, which is worth stating because
+the opposite is usually assumed. The `.p8` client secret is what Apple's
+*token endpoint* requires, and `appleAuthCallback` never calls it: the
+authorize request asks for `response_type=code id_token`, so the identity
+token arrives in the callback POST, and that token is all Firebase wants.
+What does have to be set up outside these two variables is the Apple
+provider in Firebase Authentication, configured with the same Services
+ID — that is the audience the identity token carries, and Firebase
+rejects a token whose `aud` it does not recognise.
 
 Toast (`functions/src/pos/toast.ts`) doesn't use OAuth-redirect
 credentials — a manager enters partner-issued `clientId`/`clientSecret`/

--- a/firestore.rules
+++ b/firestore.rules
@@ -393,6 +393,17 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // In-flight Apple sign-ins — see functions/src/appleAuth.ts. Denied
+    // harder than the two above, in the sense that it matters more: a
+    // completed session briefly holds Apple's identity token, and there
+    // is no signed-in identity to scope a read to anyway, since the
+    // whole point is that nobody is signed in yet. The client collects
+    // it through appleAuthClaim, which checks a secret it never sent
+    // anywhere but here.
+    match /appleAuthSessions/{sessionId} {
+      allow read, write: if false;
+    }
+
     // Requests — top-level collection, scoped by barId field.
     match /requests/{requestId} {
       allow read: if isAuthed() && hasRole(resource.data.barId);

--- a/functions/src/__tests__/appleAuth.test.ts
+++ b/functions/src/__tests__/appleAuth.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  buildAppleAuthorizeUrl,
+  claimMatches,
+  classifyAppleCallback,
+  isSessionExpired,
+  SESSION_TTL_MS,
+} from "../appleAuth";
+
+const NONCE = "a".repeat(64);
+
+describe("buildAppleAuthorizeUrl", () => {
+  const url = buildAppleAuthorizeUrl({
+    serviceId: "com.hereliesaz.barbacker.signin",
+    redirectUri: "https://us-central1-proj.cloudfunctions.net/appleAuthCallback",
+    state: "b".repeat(32),
+    nonce: NONCE,
+  });
+  const query = new URL(url).searchParams;
+
+  it("points at Apple's authorize endpoint", () => {
+    expect(url.startsWith("https://appleid.apple.com/auth/authorize?")).toBe(true);
+  });
+
+  // The reason this flow needs no .p8 private key at all. Asking for a
+  // bare `code` would mean exchanging it at /auth/token, which requires
+  // a client secret that is a signed JWT — and then this server would
+  // have to hold and rotate that key.
+  it("asks for the identity token directly, not just a code", () => {
+    expect(query.get("response_type")).toBe("code id_token");
+  });
+
+  // Apple rejects an id_token response type without form_post, and the
+  // POST body also keeps the token out of browser history and Referer.
+  it("uses form_post, which an id_token response type requires", () => {
+    expect(query.get("response_mode")).toBe("form_post");
+  });
+
+  it("passes the state and nonce through unaltered", () => {
+    expect(query.get("state")).toBe("b".repeat(32));
+    expect(query.get("nonce")).toBe(NONCE);
+  });
+
+  // A service id contains dots and a redirect URI contains slashes and a
+  // colon; unencoded, the second one truncates every parameter after it.
+  it("percent-encodes the redirect URI", () => {
+    expect(url).toContain(
+      "redirect_uri=https%3A%2F%2Fus-central1-proj.cloudfunctions.net%2FappleAuthCallback",
+    );
+    expect(query.get("redirect_uri")).toBe(
+      "https://us-central1-proj.cloudfunctions.net/appleAuthCallback",
+    );
+  });
+});
+
+describe("classifyAppleCallback", () => {
+  it("reads the identity token out of a successful post", () => {
+    expect(classifyAppleCallback({ id_token: "tok", code: "c" })).toEqual({
+      status: "ready",
+      idToken: "tok",
+    });
+  });
+
+  // Someone backing out is the flow working. Reporting it as a failure
+  // shows an error dialog for having changed their mind.
+  it("treats a user cancel as a cancel, not a failure", () => {
+    expect(classifyAppleCallback({ error: "user_cancelled_authorize" })).toEqual({
+      status: "cancelled",
+    });
+  });
+
+  it("keeps other Apple errors as failures, with the reason", () => {
+    const result = classifyAppleCallback({ error: "invalid_request" });
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("invalid_request");
+  });
+
+  // A post with neither an error nor a token is not a success with an
+  // empty credential — that would sign nobody in and say nothing.
+  it("fails when there is no token and no error", () => {
+    expect(classifyAppleCallback({ code: "c" }).status).toBe("failed");
+  });
+
+  it("ignores a non-string id_token", () => {
+    expect(classifyAppleCallback({ id_token: 42 }).status).toBe("failed");
+  });
+});
+
+describe("isSessionExpired", () => {
+  it("keeps a session inside the window", () => {
+    expect(isSessionExpired(1_000, 1_000 + SESSION_TTL_MS - 1)).toBe(false);
+  });
+
+  it("expires one past the window", () => {
+    expect(isSessionExpired(1_000, 1_000 + SESSION_TTL_MS + 1)).toBe(true);
+  });
+
+  // Clock skew between the Firestore server timestamp and the function
+  // host can put createdAt slightly in the future. That is not expiry.
+  it("does not expire a session stamped in the future", () => {
+    expect(isSessionExpired(10_000, 9_000)).toBe(false);
+  });
+});
+
+describe("claimMatches", () => {
+  const secret = "c".repeat(64);
+  const hash = createHash("sha256").update(secret).digest("hex");
+
+  it("accepts the secret behind the stored hash", () => {
+    expect(claimMatches(secret, hash)).toBe(true);
+  });
+
+  it("rejects a different secret", () => {
+    expect(claimMatches("d".repeat(64), hash)).toBe(false);
+  });
+
+  // The presented value is hashed before comparison, so someone who
+  // learned the stored hash still cannot present it as the secret.
+  it("rejects the stored hash presented as the secret", () => {
+    expect(claimMatches(hash, hash)).toBe(false);
+  });
+
+  // timingSafeEqual throws on a length mismatch instead of returning
+  // false, so a malformed stored hash has to be rejected before it
+  // reaches the comparison rather than crashing the callable.
+  it("rejects a malformed stored hash without throwing", () => {
+    expect(claimMatches(secret, "not-a-hash")).toBe(false);
+    expect(claimMatches(secret, "")).toBe(false);
+  });
+
+  it("rejects an empty presented secret", () => {
+    expect(claimMatches("", hash)).toBe(false);
+  });
+});

--- a/functions/src/appleAuth.ts
+++ b/functions/src/appleAuth.ts
@@ -1,0 +1,269 @@
+import { onCall, onRequest, HttpsError } from "firebase-functions/v2/https";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { getFirestore, FieldValue, Timestamp } from "firebase-admin/firestore";
+import { createHash, timingSafeEqual } from "node:crypto";
+
+// Apple's identity tokens are short-lived anyway; this bounds how long
+// one can sit in Firestore waiting to be collected, and how long a
+// half-finished sign-in stays resumable.
+export const SESSION_TTL_MS = 10 * 60 * 1000;
+
+const AUTHORIZE_ENDPOINT = "https://appleid.apple.com/auth/authorize";
+const SESSIONS = "appleAuthSessions";
+
+// 16 bytes as hex, 32 as hex. Fixed lengths because these are the only
+// two shapes the client ever sends, and anything else is either a bug or
+// someone poking at an unauthenticated endpoint.
+const SESSION_ID_PATTERN = /^[0-9a-f]{32}$/;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+type SessionStatus = "pending" | "ready" | "cancelled" | "failed";
+
+interface SessionDoc {
+  claimSecretHash: string;
+  status: SessionStatus;
+  idToken?: string;
+  message?: string;
+  createdAt: Timestamp;
+}
+
+/**
+ * What the browser came back with, reduced to something storable.
+ *
+ * Exported and pure so the branch that decides "signed in" vs "the user
+ * backed out" vs "Apple said no" can be tested without a live callback:
+ * getting `user_cancelled_authorize` wrong shows the person an error
+ * dialog for having changed their mind, which is the flow working.
+ */
+export function classifyAppleCallback(body: Record<string, unknown>): {
+  status: Exclude<SessionStatus, "pending">;
+  idToken?: string;
+  message?: string;
+} {
+  const error = typeof body.error === "string" ? body.error : undefined;
+  if (error === "user_cancelled_authorize") {
+    return { status: "cancelled" };
+  }
+  if (error) {
+    return { status: "failed", message: `Apple declined the sign-in (${error}).` };
+  }
+  const idToken = typeof body.id_token === "string" ? body.id_token : undefined;
+  if (!idToken) {
+    return { status: "failed", message: "Apple returned no identity token." };
+  }
+  return { status: "ready", idToken };
+}
+
+/** True once a session is too old to be completed or collected. */
+export function isSessionExpired(createdAtMillis: number, nowMillis: number): boolean {
+  return nowMillis - createdAtMillis > SESSION_TTL_MS;
+}
+
+/**
+ * Compares a presented claim secret against the stored hash.
+ *
+ * Constant-time, and the length check happens first because
+ * timingSafeEqual throws on a length mismatch rather than returning
+ * false. The secret is the only thing standing between a session and
+ * whoever else knows its id — and the id, unlike the secret, travels
+ * through the browser's URL bar on the way to Apple.
+ */
+export function claimMatches(presented: string, storedHash: string): boolean {
+  if (!HASH_PATTERN.test(storedHash)) return false;
+  const presentedHash = createHash("sha256").update(presented).digest("hex");
+  if (presentedHash.length !== storedHash.length) return false;
+  return timingSafeEqual(Buffer.from(presentedHash), Buffer.from(storedHash));
+}
+
+/**
+ * The URL that starts Apple's web sign-in.
+ *
+ * `response_type=code id_token` is the whole reason this flow needs no
+ * private key. Apple returns the identity token directly in the callback
+ * POST, and that token is the only thing Firebase wants; exchanging the
+ * code at `/auth/token` is what would require a client secret that is a
+ * JWT signed with a .p8 — the credential a shipped app has nowhere safe
+ * to keep, and which this server would then have to hold and rotate.
+ *
+ * `response_mode=form_post` is not optional: Apple rejects an `id_token`
+ * response type without it, and it also keeps the token out of a redirect
+ * URL, and therefore out of browser history and Referer headers.
+ */
+export function buildAppleAuthorizeUrl(input: {
+  serviceId: string;
+  redirectUri: string;
+  state: string;
+  /** SHA-256 of the client's raw nonce, hex. The raw value never leaves the device. */
+  nonce: string;
+}): string {
+  const parameters: Record<string, string> = {
+    client_id: input.serviceId,
+    redirect_uri: input.redirectUri,
+    response_type: "code id_token",
+    response_mode: "form_post",
+    scope: "name email",
+    state: input.state,
+    nonce: input.nonce,
+  };
+  const query = Object.entries(parameters)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join("&");
+  return `${AUTHORIZE_ENDPOINT}?${query}`;
+}
+
+function callbackUrl(): string | null {
+  const base = process.env.APPLE_OAUTH_CALLBACK_BASE_URL;
+  if (!base) return null;
+  return `${base.replace(/\/+$/, "")}/appleAuthCallback`;
+}
+
+// Step 1 — the client mints a session id and a claim secret, sends us the
+// id and the secret's hash, and gets back the URL to open a browser at.
+// Deliberately unauthenticated: nobody is signed in yet, that being the
+// point. What it can be abused for is creating junk session documents, so
+// the shapes are checked strictly and cleanupAppleAuthSessions sweeps.
+export const appleAuthBegin = onCall(async (request) => {
+  const { sessionId, claimSecretHash, nonce } = (request.data ?? {}) as {
+    sessionId?: string;
+    claimSecretHash?: string;
+    nonce?: string;
+  };
+  if (
+    !sessionId || !SESSION_ID_PATTERN.test(sessionId) ||
+    !claimSecretHash || !HASH_PATTERN.test(claimSecretHash) ||
+    !nonce || !HASH_PATTERN.test(nonce)
+  ) {
+    throw new HttpsError("invalid-argument", "Malformed sign-in request.");
+  }
+
+  const serviceId = process.env.APPLE_SERVICE_ID;
+  const redirectUri = callbackUrl();
+  if (!serviceId || !redirectUri) {
+    throw new HttpsError(
+      "failed-precondition",
+      "Apple sign-in is not configured on the server.",
+    );
+  }
+
+  await getFirestore().doc(`${SESSIONS}/${sessionId}`).set({
+    claimSecretHash,
+    status: "pending",
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  return {
+    authorizeUrl: buildAppleAuthorizeUrl({ serviceId, redirectUri, state: sessionId, nonce }),
+  };
+});
+
+// Step 2 — Apple form-posts the result of the consent screen here. Plain
+// onRequest, not onCall, because this is a browser navigation from
+// appleid.apple.com rather than a call from our own client.
+export const appleAuthCallback = onRequest(async (req, res) => {
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const sessionId = typeof body.state === "string" ? body.state : undefined;
+  if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
+    res.status(400).send(page("That sign-in could not be verified. Close this tab and try again."));
+    return;
+  }
+
+  const ref = getFirestore().doc(`${SESSIONS}/${sessionId}`);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    res.status(400).send(page("That sign-in request is unknown. Close this tab and try again."));
+    return;
+  }
+  const session = snap.data() as SessionDoc;
+  if (isSessionExpired(session.createdAt.toMillis(), Date.now())) {
+    await ref.delete();
+    res.status(400).send(page("That sign-in request expired. Close this tab and try again."));
+    return;
+  }
+
+  const outcome = classifyAppleCallback(body);
+  // Only ever updated, never re-created: a POST for a session that has
+  // already been claimed and deleted must not resurrect a document
+  // holding an identity token nothing will ever collect.
+  await ref.update({
+    status: outcome.status,
+    idToken: outcome.idToken ?? FieldValue.delete(),
+    message: outcome.message ?? FieldValue.delete(),
+  });
+
+  res.status(200).send(
+    page(
+      outcome.status === "ready"
+        ? "Signed in. You can close this tab and go back to BarBacker."
+        : "Sign-in was not completed. Close this tab and go back to BarBacker.",
+    ),
+  );
+});
+
+// Step 3 — the client polls this until the browser half finishes. It
+// polls rather than being pushed because the session document holds an
+// identity token, so firestore.rules denies the client any read of it,
+// and there is no signed-in identity to scope such a read to anyway.
+export const appleAuthClaim = onCall(async (request) => {
+  const { sessionId, claimSecret } = (request.data ?? {}) as {
+    sessionId?: string;
+    claimSecret?: string;
+  };
+  if (!sessionId || !SESSION_ID_PATTERN.test(sessionId) || !claimSecret) {
+    throw new HttpsError("invalid-argument", "Malformed sign-in request.");
+  }
+
+  const ref = getFirestore().doc(`${SESSIONS}/${sessionId}`);
+  const snap = await ref.get();
+  // Same answer for "never existed", "already collected", and "wrong
+  // secret": distinguishing them would turn this into an oracle for
+  // which session ids are live.
+  if (!snap.exists) throw new HttpsError("not-found", "That sign-in has expired.");
+
+  const session = snap.data() as SessionDoc;
+  if (!claimMatches(claimSecret, session.claimSecretHash)) {
+    throw new HttpsError("not-found", "That sign-in has expired.");
+  }
+  if (isSessionExpired(session.createdAt.toMillis(), Date.now())) {
+    await ref.delete();
+    throw new HttpsError("not-found", "That sign-in has expired.");
+  }
+
+  if (session.status === "pending") return { status: "pending" };
+
+  // Single use. Deleted before returning rather than after, so a replayed
+  // claim cannot hand the same identity token to a second caller.
+  await ref.delete();
+  return {
+    status: session.status,
+    idToken: session.idToken ?? null,
+    message: session.message ?? null,
+  };
+});
+
+// Not housekeeping. A sign-in that reached Apple and was then abandoned —
+// the tab closed, the app killed — leaves a document holding an identity
+// token that nothing will ever collect and nothing else would ever
+// delete. This is what bounds how long that sits there.
+export const cleanupAppleAuthSessions = onSchedule("every 60 minutes", async () => {
+  const db = getFirestore();
+  const cutoff = Timestamp.fromMillis(Date.now() - SESSION_TTL_MS);
+  const snap = await db
+    .collection(SESSIONS)
+    .where("createdAt", "<", cutoff)
+    .limit(400)
+    .get();
+
+  if (snap.empty) return;
+  const batch = db.batch();
+  snap.docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+  console.log(`Cleared ${snap.size} expired Apple sign-in session(s).`);
+});
+
+/** The tab the person is left looking at. Plain, because nobody reads it twice. */
+function page(message: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width,initial-scale=1">` +
+    `<title>BarBacker</title></head>` +
+    `<body style="font-family:system-ui,sans-serif;padding:2rem">${message}</body></html>`;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,6 +17,12 @@ export { onRequestCreated } from "./onRequestCreated";
 export { onRequestDeleted } from "./onRequestDeleted";
 export { cleanupStaleRequests } from "./cleanupStaleRequests";
 export { onInviteConsumed } from "./onInviteConsumed";
+export {
+  appleAuthBegin,
+  appleAuthCallback,
+  appleAuthClaim,
+  cleanupAppleAuthSessions,
+} from "./appleAuth";
 export { fileOwnershipClaim, reviewOwnershipClaim } from "./ownershipClaims";
 export { migrateNoticesToChat } from "./migrateNoticesToChat";
 export { onChatPinned } from "./onChatPinned";


### PR DESCRIPTION
Closes the remaining PWA-parity gaps in the Compose Multiplatform client. Follows #308, which merged; this branch was rebased onto the resulting `main`.

Three commits, each self-contained.

## 1. Social sign-in and the ntfy deep link

The notification screen mints an account topic on first open and hands it to the ntfy app via a deep link. The topic is shown as text as well as linked — the deep link only works where ntfy is installed, and it has to be readable so it can be typed on a device that does not have it. A link nothing handles says so rather than appearing to do nothing.

The topic is 16 bytes from a per-platform CSPRNG (`SecureRandom` on the JVM, `SecRandomCopyBytes` on Apple), not `kotlin.random`. An ntfy topic is a bearer secret — anyone who knows the string can subscribe to that person's pages — and a seeded PRNG's output is predictable from any other sample of it. Existing accounts keep the topic they have; regenerating would orphan a subscription someone set up months ago and silently stop their pages. Minting happens when the screen opens rather than at sign-in: most accounts never touch ntfy.

Google sign-in uses Credential Manager on Android (`GetSignInWithGoogleOption`, not `GetGoogleIdOption` — the latter silently returns nothing when no eligible account exists, which reads as a dead button; and it takes the project's **web** client id, since that is the audience Firebase expects), a loopback redirect with PKCE on desktop, and `ASWebAuthenticationSession` on iOS. Only token acquisition is per-platform: GitLive exposes `GoogleAuthProvider.credential` and `OAuthProvider.credential` in common code, so one shared `signInWithCredential` serves all three.

## 2. Apple sign-in on Android and desktop

This rests on a premise worth checking. The received wisdom — that Apple's web flow needs a client secret which is a JWT signed with a `.p8` private key, and therefore cannot be done by an app shipped to devices — is true only of the *token exchange*. Asking for `response_type=code id_token` returns the identity token in the callback itself, and the identity token is the only thing Firebase wants. No private key, no key rotation, nothing confidential on the server.

What the flow does still need is a public HTTPS redirect: Apple refuses custom schemes and loopback alike, so unlike Google's desktop flow it cannot finish on the device. Hence three Cloud Functions — `appleAuthBegin` mints a session and returns the authorize URL, `appleAuthCallback` receives Apple's form post, `appleAuthClaim` hands the token over once.

Three separate secrets, defending against three different things:

- **Session id** — public. It goes to Apple as `state` and therefore into browser history.
- **Claim secret** — never leaves the device except as a hash; what stops anyone else collecting the token. Compared in constant time, and a wrong secret gets the same answer as an unknown session so the endpoint is not an oracle for which sessions are live.
- **Nonce** — hashed to Apple, raw to Firebase; what stops a token issued for another request being replayed here.

The client polls rather than being pushed: the session document briefly holds an identity token, so the rules deny the client every read of it, and there is no signed-in identity to scope such a read to — that being the point of sign-in. `cleanupAppleAuthSessions` is not housekeeping; an abandoned sign-in leaves a document holding a token nothing will ever collect, and the sweep bounds how long it sits there.

On the client it is all common code, which is the payoff of going through the browser instead of a platform SDK. `CombinedSocialSignIn` layers the web flow over whatever the platform already does, so no `actual` had to change and iOS keeps its native sheet.

## 3. An iOS project spec, and APNs registration

The reason there was no Xcode project was sound: a `.pbxproj` is generated XML full of opaque UUIDs, unreviewable in a diff and unbuildable on Linux CI. What that argument does not require is leaving the project *undescribed*. `cmp/iosApp/project.yml` says the same thing in a form a person can read, and XcodeGen turns it back into the real project deterministically — so the `.xcodeproj` becomes a build output and is gitignored as one.

It carries the pieces whose absence fails silently: the APNs entitlement and remote-notification background mode, Sign in with Apple, `NSCameraUsageDescription` (without which iOS kills the app the moment the picker opens rather than denying anything), the Gradle framework phase and the script-sandboxing setting that phase needs, and the Firebase SPM products. Two entitlements files rather than one, because `aps-environment` cannot be a build-setting placeholder and a development token sent to the production gateway fails as `BadDeviceToken` — a bug that looks like a broken device.

APNs registration is driven from Kotlin, not an app delegate. FCM cannot mint a token until the APNs token reaches Messaging, and Messaging only exists once Firebase is configured — which happens in the first composition, not at launch. Registering in `didFinishLaunching` races with that: it usually wins, and when it loses the device simply never receives pages, with nothing in the logs saying why.

## Verification

- 135 shared tests, 0 failures
- 58 functions tests, 0 failures
- 129 firestore/storage rules tests, 0 failures
- Android APK and desktop JAR build; no warnings in project code

## Not verified

Nothing iOS has ever been compiled — no macOS runner in CI, no Mac in the loop. That covers `project.yml`, the entitlements, the Swift, and the iOS halves of the shared code (`ImagePicker.ios.kt`, `PhotoCapture.ios.kt`, `BottleRecognizer.ios.kt`, `SocialSignIn.ios.kt`, `PushTokens.ios.kt`). `docs/CMP.md` and `cmp/iosApp/README.md` say so plainly rather than implying iOS is supported.

Two new server env vars, `APPLE_SERVICE_ID` and `APPLE_OAUTH_CALLBACK_BASE_URL`, are documented in `docs/DEPLOYMENT.md`; the client-side `VITE_APPLE_SIGN_IN` flag is documented in `docs/CMP.md`. Until they are set, the Apple button stays hidden on Android and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRDfcoAinHQEhC18r6umDx